### PR TITLE
Do not sanitize exercises or feedback from the exercises

### DIFF
--- a/templates/exercise/inspect_submission.html
+++ b/templates/exercise/inspect_submission.html
@@ -100,7 +100,7 @@
     <div class="span6" id="generated-feedback">
         <h2>{% trans "Feedback" %}</h2>
         <div class="well">
-            {{ submission.feedback|sanitize }}
+            {{ submission.feedback }}
             &nbsp;{# This prevents the div being completely empty and being not rendered #}
         </div>
     </div>

--- a/templates/exercise/view_exercise.html
+++ b/templates/exercise/view_exercise.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block exercisecontent %}
-    {{ page.content|sanitize }}
+    {{ page.content }}
     {% if form %}
     <div>
         {% include "exercise/_submission_form.html" with form=form %}

--- a/templates/exercise/view_submission.html
+++ b/templates/exercise/view_submission.html
@@ -16,7 +16,7 @@
     {% endif %}
     
     {% if submission.feedback %}
-        {{ submission.feedback|sanitize }}
+        {{ submission.feedback }}
     {% else %}
         <div class="alert alert-info">
             {% trans "No verbal feedback available for this submission." %}


### PR DESCRIPTION
Escaping style and script tags limits the way how exercises and feedback can be presented. 
