### PR TITLE
Removed url verification from exercise models

### DIFF
--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -104,7 +104,7 @@ class LearningObject(ModelWithInheritance):
     # verify_exists is deprecated in Django 1.4 and removed in Django 1.5 because of security issues
     # However, in Django 1.3.0, it defaults to True, which is undesired, so we must have verify_exists=False with
     # this version of Django
-    service_url             = models.URLField(veify_exists=False, blank=True)
+    service_url             = models.URLField(verify_exists=False, blank=True)
     
     # Relations
     course_module          = models.ForeignKey(CourseModule, related_name="learning_objects")


### PR DESCRIPTION
It was very annoying when creating new exercises when the service url is not up and running yet.
