### PR TITLE
Fixed the bug where late async submission caused an error in the is_subm...

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -157,6 +157,11 @@ class Submission(models.Model):
 
 
     def is_submitted_late(self):
+        if not self.id and not self.submission_time:
+            # The submission is not saved and the submission_time field is not
+            # set yet so this method takes the liberty to set it.
+            self.submission_time = datetime.now()
+            
         return self.submission_time > self.exercise.course_module.closing_time
 
     def set_grading_data(self, grading_dict):


### PR DESCRIPTION
...itted_late method of Submission because the submission_time field was not set. I think that if is_submitted_late is called on a Submission object that is not yet saved to the database, we can safely set the submission_time in that method.
