### PR TITLE
Bug fix - Trying to view someone else's submission page caused HTTP 500

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -90,22 +90,23 @@ class Submission(models.Model):
 
     def check_user_permission(self, profile):
         """ 
-        Checks if the given user is allowed to access this submission. 
-        Super users are allowed to access all submissions, course personnel is allowed to 
-        access submissions for that course and students are allowed to access their own submissions.
+        Checks if the given user is allowed to access this submission.
+        Superusers and staff are allowed to access all submissions, course
+        personnel is allowed to access submissions for that course and students
+        are allowed to access their own submissions.
 
         @param profile: UserProfile model 
         """
 
-        # Super users are allowed to view all submissions
-        if profile.user.is_superuser:
+        # Superusers and staff are allowed to view all submissions
+        if profile.user.is_superuser or profile.user.is_staff:
             return True
 
-        # Check if the user has submitted him/herself
+        # Check if the user has submitted this submission him/herself
         if profile in self.submitters.all():
             return True
 
-        # Check if the user belongs to course staff
+        # Check if the user belongs to the course staff
         if self.get_course_instance().is_staff(profile):
             return True
 


### PR DESCRIPTION
- Edited Submission.check_user_permission to also allow users with User.is_staff to access the submission.
- Edited some comments in Submission.check_user_permission
- Denied access to view_submission from everyone else but the submitters of the submission because the view would make no sense to staff-like users.
  - This also fixes the bug where the assignment of the index caused error in case anyone but the submitters of the submission tried to access this view.
  - Added a comment about that to the code because check_user_permission might seem the right way to go
