### PR TITLE
Calling add_submitters before submission.save() is called, caused an exc...

### DIFF
--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -214,8 +214,8 @@ def _post_async_submission(request, exercise, submission, students):
                       "</p>\n"
                       "</div>"))
         submission.set_error()
-        submission.add_submitters(students)
         submission.save()
+        submission.add_submitters(students)
 
     return {"success": False, 
             "errors": errors}


### PR DESCRIPTION
...eption because ManyToMany fields do not allow adding before the model that has the field is saved.
