### PR TITLE
Added link to toggle closed rounds, made them hidden by default

### DIFF
--- a/assets/js/aaltoplus.js
+++ b/assets/js/aaltoplus.js
@@ -9,6 +9,17 @@ $(function() {
    });
    
    $("ul.exercise_rounds li.collapsed .table-container").hide();
+   // hide closed rounds by default
+   if ($("ul.exercise_rounds li.closed").addClass("hide").size() > 0) {
+      // show the toggle link and register a click handler
+      $("#toggleOldModules").removeClass("hide").click(function(e) { 
+         e.preventDefault();
+         // toggle visibility of closed rounds
+         var invisible = $("ul.exercise_rounds li.closed").toggleClass("hide").hasClass("hide");
+         // toggle the text of the element, text from the data attributes
+         $(this).text($(this).data(invisible?"show-text":"hide-text"));
+      });
+   }
    
    $("a.group_change_link").click(function() {
        $("#change_to_group").val($(this).attr("data-group-id"));

--- a/templates/course/view_instance.html
+++ b/templates/course/view_instance.html
@@ -24,7 +24,8 @@
                 </form>
             </div>
         </div>
-
+        <a href="#" id="toggleOldModules" data-show-text="{% trans "Show old assignments" %}"
+                    data-hide-text="{% trans "Hide old assignments" %}" class="hide">{% trans "Show old assignments" %}</a>
         <ul class="exercise_rounds">
         {% for round_summary in course_summary.visible_round_summaries %}
             <li class="exercise_round {{ round_summary.get_classes }}">


### PR DESCRIPTION
Course instance view now shows a "Show/Hide old assignments" link that toggles visibility of closed modules. Closed modules are hidden by default.
