### PR TITLE
Removed encode_id and decode_id methods

### DIFF
--- a/apps/app_renderers.py
+++ b/apps/app_renderers.py
@@ -105,7 +105,7 @@ class ExternalIFramePluginRenderer(object):
         }
 
         for k, v in self.context.items():
-            params[k + "_id"] = v.encode_id()
+            params[k + "_id"] = v.id
 
         return update_url_params(self.plugin.service_url, params)
 
@@ -135,8 +135,8 @@ class ExternalIFrameTabRenderer(object):
 
     def _build_src(self):
         params = {
-            "course_instance_id": self.course_instance.encode_id(),
-            "user_profile_id": self.user_profile.encode_id()
+            "course_instance_id": self.course_instance.id,
+            "user_profile_id": self.user_profile.id
         }
 
         return update_url_params(self.tab.content_url, params)
@@ -158,8 +158,8 @@ class TabRenderer(object):
 
     def _build_src(self):
         params = {
-            "course_instance_id": self.course_instance.encode_id(),
-            "user_profile_id": self.user_profile.encode_id()
+            "course_instance_id": self.course_instance.id,
+            "user_profile_id": self.user_profile.id
         }
 
         return update_url_params(self.tab.content_url, params)

--- a/course/models.py
+++ b/course/models.py
@@ -116,10 +116,6 @@ class CourseInstance(models.Model):
     plugins                 = generic.GenericRelation(BasePlugin, object_id_field="container_pk", content_type_field="container_type")
     tabs                    = generic.GenericRelation(BaseTab, object_id_field="container_pk", content_type_field="container_type")
 
-    def encode_id(self):
-        # TODO: Encode using settings.SECRET_KEY
-        return self.id
-
     def is_assistant(self, profile):
         """
         Returns True if the given profile belongs to an assistant on this course instance.

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -171,14 +171,6 @@ class BaseExercise(LearningObject):
     max_submissions         = models.PositiveIntegerField(default=10)
     max_points              = models.PositiveIntegerField(default=100)
     points_to_pass          = models.PositiveIntegerField(default=40)
-
-
-    def decode_id(self, enc_id):
-        return enc_id
-
-    def encode_id(self):
-        # TODO: encode with settings.SECRET_KEY
-        return self.id
     
     def get_page(self, submission_url):
         """ 

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -112,13 +112,6 @@ class Submission(models.Model):
 
         return False
 
-    def decode_id(self, enc_id):
-        return enc_id
-
-    def encode_id(self):
-        # TODO: encode with settings.SECRET_KEY
-        return self.id
-
     def get_course(self):
         return self.get_course_instance().course
 

--- a/userprofile/models.py
+++ b/userprofile/models.py
@@ -19,13 +19,6 @@ class UserProfile(models.Model):
         return "http://www.gravatar.com/avatar/" + hash +"?d=identicon"
     avatar_url = property(_generate_gravatar_url)
 
-    def decode_id(self, enc_id):
-        return enc_id
-
-    def encode_id(self):
-        # TODO: encode with settings.SECRET_KEY
-        return self.id
-
     def get_shortname(self):
         """
         Returns a short version of the user's name, with the first name and the first letter 


### PR DESCRIPTION
It was decided to not to encode the ids for the api. Also, the encode_id/decode_id as methods were bad idea.
