### PR TITLE
Enrollment questions are open after module's closing time

### DIFF
--- a/course/permissions.py
+++ b/course/permissions.py
@@ -109,7 +109,7 @@ class EnrollInfoVisiblePermission(ObjectVisibleBasePermission):
 
 
 class CourseModulePermission(MessageMixin, Permission):
-    message = _("The module is not currently visible")
+    message = _("The module is not currently visible.")
 
     def has_permission(self, request, view):
         if not view.is_course_staff:

--- a/course/views.py
+++ b/course/views.py
@@ -99,7 +99,6 @@ class Enroll(EnrollableViewMixin, BaseRedirectMixin, BaseTemplateView):
             raise PermissionDenied()
 
         # Support enrollment questionnaires.
-        from exercise.models import LearningObject
         exercise = LearningObject.objects.find_enrollment_exercise(
             self.instance, self.profile)
         if exercise:
@@ -199,4 +198,3 @@ class GroupSelect(CourseInstanceMixin, BaseFormView):
             return self.render_to_response(self.get_context_data(
                 **group_info_context(enrollment.selected_group, self.profile)))
         return super().form_valid(form)
-

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -623,8 +623,10 @@ class BaseExercise(LearningObject):
             warnings.append(
                 _("This exercise must be submitted in groups of {size} students.")
                 .format(size=size))
-
-        access_ok,access_warnings = self.one_has_access(students)
+        if self.status in (self.STATUS.ENROLLMENT, self.STATUS.ENROLLMENT_EXTERNAL):
+            access_ok, access_warnings = True, []
+        else:
+            access_ok, access_warnings = self.one_has_access(students)
         is_staff = all(self.course_instance.is_course_staff(p.user) for p in students)
         ok = (access_ok and len(warnings) == 0) or is_staff
         all_warnings = warnings + access_warnings

--- a/exercise/tests.py
+++ b/exercise/tests.py
@@ -59,6 +59,7 @@ class ExerciseTest(TestCase):
 
         self.course_instance = CourseInstance.objects.create(
             instance_name="Fall 2011 day 1",
+            enrollment_starting_time=self.yesterday,
             starting_time=self.today,
             ending_time=self.tomorrow,
             course=self.course,
@@ -194,6 +195,15 @@ class ExerciseTest(TestCase):
             url="b3",
         )
 
+        self.enrollment_exercise = BaseExercise.objects.create(
+            name="test exercise",
+            course_module=self.old_course_module,
+            category=self.learning_object_category,
+            url="b2",
+            max_submissions=1,
+            status="enrollment"
+        )
+
         self.submission = Submission.objects.create(
             exercise=self.base_exercise,
             grader=self.grader.userprofile
@@ -319,6 +329,9 @@ class ExerciseTest(TestCase):
         self.assertFalse(self.old_base_exercise.is_open(self.tomorrow))
         self.assertFalse(self.exercise_in_reading_time.is_open())
         self.assertTrue(self.exercise_in_reading_time.is_open(self.tomorrow))
+
+    def test_enrollment_exercise_access(self):
+        self.assertTrue(self.enrollment_exercise.check_submission_allowed(self.user.userprofile)[0])
 
     def test_base_exercise_one_has_access(self):
         self.assertTrue(self.base_exercise.one_has_access([self.user.userprofile])[0])

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -339,7 +339,7 @@ msgid "This course is only for external students."
 msgstr "Tämä kurssi on vain oppilaitoksen ulkopuolisille opiskelijoille."
 
 #: course/permissions.py:112
-msgid "The module is not currently visible"
+msgid "The module is not currently visible."
 msgstr "Tämä osio ei ole tällä hetkellä nähtävissä."
 
 #: course/permissions.py:131


### PR DESCRIPTION
If course has a enrollment exercise, the exercise can be answered even
if the module containing the exercise was closed.

Additionally add a dot in the end of sentence.

# Description


# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
