### PR TITLE
Confirm the level exercises need to be submitted.

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -45,6 +45,8 @@ class CachedPoints(ContentMixin, CachedAbstract):
                         'graded': False,
                         'unofficial': False, # TODO: this should be True, but we need to ensure nothing breaks when it's changed
                     })
+                if entry.get('confirm_the_level'):
+                    entry['passed'] = False
                 r_augment(entry.get('children'))
         for module in modules:
             module.update({


### PR DESCRIPTION
# Description
Previously, all exercises that had `points_to_pass` as 0 had the `passed`
value `True` as a default, even without any submissions. If the chapter
had an exercise with `confirm_the_level` as `True`, it was often considered
passed and it didn't have to be submitted. By changing the default `passed`
value for the level confirming exercises, those exercises really have to be
submitted to get any points for the chapter.

This PR is related to the issue #432 and even though some visual updates were suggested,
this change already fixes the issue where points were given when they shouldn't.
# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually
- [x] I have tested with my own test data generated by a python script

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
