### PR TITLE
Show initialized and waiting submissions in the submission count.

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -87,7 +87,7 @@ class CachedPoints(ContentMixin, CachedAbstract):
                 entry = tree[-1]
                 ready = submission.status == Submission.STATUS.READY
                 unofficial = submission.status == Submission.STATUS.UNOFFICIAL
-                if ready:
+                if ready or submission.status in (Submission.STATUS.WAITING, Submission.STATUS.INITIALIZED):
                     entry['submission_count'] += 1
                 entry['submissions'].append({
                     'id': submission.id,


### PR DESCRIPTION
Even though the submission with statuses `initialized` or `waiting`
can be rejected, it is better to have them counted in the submission
count. It is more clear for the students so they can see how many
submissions they've made. If the submission gets rejected, it will be
removed from the total submission count.

Adding these statuses to the total count benefits especially exercises
that are graded manually, such as Rubyric exercises. Also not counting
those statuses could give false information of the submissions left, if the
waiting submission should pass.

Fixes #407 
# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
