### PR TITLE
Show modules open in the results page, if they are open for reading

### DIFF
--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -24,14 +24,21 @@
 {% module_accessible module as accessible %}
 {% exercise_accessible module as exercise_accessible %}
 <div class="panel panel-primary module-panel{% if not open and after_open %} module-expired{% endif %}">
-  <a class="panel-heading{% if not open or not accessible %} collapsed{% endif %}"
+  <a class="panel-heading{% if not accessible or not open and after_open %} collapsed{% endif %}"
     role="button" href="#module{{ module.id }}" data-toggle="collapse"
-    aria-expanded="{% if open and accessible %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
+    aria-expanded="{% if accessible and not after_open or open %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
     <h3 class="panel-title">
       {% points_badge module "pull-right" %}
-      {% if not open and not after_open %}
+      {% if not accessible %}
       <span class="badge pull-right">
-        {% trans "Opens" %} {{ module.opening_time }}
+        {% trans "Opens on" %} {{ module.opening_time }}
+      </span>
+      {% elif not after_open %}
+      <span class="badge pull-right">
+        {% trans "Exercises open on" %} {{ module.opening_time }}
+      </span>
+      <span class="badge badge-info pull-right">
+        {% trans "Open for reading" %}
       </span>
       {% endif %}
       {% if module.requirements|length > 0 %}
@@ -44,7 +51,7 @@
       {{ module.name|parse_localization }}
     </h3>
   </a>
-  <div class="collapse{% if open and accessible %} in{% endif %}" id="module{{ module.id }}">
+  <div class="collapse{% if accessible and not after_open or open %} in{% endif %}" id="module{{ module.id }}">
   <div class="panel-body">
     <p>
       {{ module.opening_time }} &ndash; {{ module.closing_time }}

--- a/exercise/templatetags/exercise.py
+++ b/exercise/templatetags/exercise.py
@@ -223,8 +223,11 @@ def min_group_size(context):
 
 @register.simple_tag(takes_context=True)
 def module_accessible(context, entry):
-    t = entry.get('reading_opening_time', entry.get('opening_time'))
-    return _is_accessible(context, entry, t)
+    t = entry.get('reading_opening_time')
+    if t:
+        return _is_accessible(context, entry, t)
+    else:
+        return exercise_accessible(context, entry)
 
 
 @register.simple_tag(takes_context=True)
@@ -293,4 +296,3 @@ def get_format_info(format):
 @register.simple_tag
 def get_format_info_list(formats):
     return [get_format_info(format) for format in formats.split()]
-

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-05 13:47+0200\n"
+"POT-Creation-Date: 2020-02-07 12:41+0200\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jaakko Kantojärvi <jaakko.kantojarvi@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -401,7 +401,7 @@ msgid "Apps"
 msgstr "Sovellukset"
 
 #: course/templates/course/_course_menu.html:108
-#: exercise/templates/exercise/_user_results.html:91
+#: exercise/templates/exercise/_user_results.html:98
 #: exercise/templates/exercise/submission_plain.html:41
 msgid "Course staff"
 msgstr "Kurssihenkilökunta"
@@ -556,8 +556,8 @@ msgstr ""
 #: course/templates/course/_siblings.html:22
 #: course/templates/course/_siblings.html:45
 #: exercise/templates/exercise/_children.html:28
-#: exercise/templates/exercise/_user_results.html:144
-#: exercise/templates/exercise/_user_results.html:171
+#: exercise/templates/exercise/_user_results.html:151
+#: exercise/templates/exercise/_user_results.html:178
 #: exercise/templates/exercise/_user_toc.html:30
 msgid "Early access"
 msgstr "Aikainen pääsy"
@@ -905,7 +905,7 @@ msgstr "Palauttaja"
 
 #: deviations/templates/deviations/list_dl.html:28
 #: edit_course/templates/edit_course/edit_content.html:149
-#: exercise/templates/exercise/_user_results.html:86
+#: exercise/templates/exercise/_user_results.html:93
 msgid "Exercise"
 msgstr "Tehtävä"
 
@@ -962,7 +962,7 @@ msgid "Grade"
 msgstr "Arvostelu"
 
 #: edit_course/course_forms.py:30
-#: exercise/templates/exercise/_user_results.html:87
+#: exercise/templates/exercise/_user_results.html:94
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1333,7 +1333,7 @@ msgid "Open exercise"
 msgstr "Avaa tehtävä"
 
 #: edit_course/templates/edit_course/edit_content.html:119
-#: exercise/templates/exercise/_user_results.html:151
+#: exercise/templates/exercise/_user_results.html:158
 msgid "View submissions"
 msgstr "Näytä palautukset"
 
@@ -2188,7 +2188,7 @@ msgid "Required exercises are not passed"
 msgstr "Kaikkia pakollisia tehtäviä ei ole suoritettu"
 
 #: exercise/templates/exercise/_points_progress.html:3
-#: exercise/templates/exercise/_user_results.html:89
+#: exercise/templates/exercise/_user_results.html:96
 #: exercise/templates/exercise/exercise_plain.html:56
 #: exercise/templates/exercise/submission_plain.html:39
 msgid "Points"
@@ -2268,17 +2268,24 @@ msgid "Show older assignments."
 msgstr "Näytä vanhemmat tehtävät"
 
 #: exercise/templates/exercise/_user_results.html:34
-#: exercise/templates/exercise/_user_toc.html:41
-msgid "Opens"
+msgid "Opens on"
 msgstr "Avautuu"
 
-#: exercise/templates/exercise/_user_results.html:39
+#: exercise/templates/exercise/_user_results.html:38
+msgid "Exercises open on"
+msgstr "Tehtävät avautuvat"
+
+#: exercise/templates/exercise/_user_results.html:41
+msgid "Open for reading"
+msgstr "Lukumateriaali auki"
+
+#: exercise/templates/exercise/_user_results.html:46
 #: exercise/templates/exercise/_user_toc.html:18
 #: exercise/templates/exercise/_user_toc.html:37
 msgid "Requires"
 msgstr "Vaaditaan"
 
-#: exercise/templates/exercise/_user_results.html:55
+#: exercise/templates/exercise/_user_results.html:62
 #, python-format
 msgid ""
 "\n"
@@ -2288,7 +2295,7 @@ msgstr ""
 "\n"
 "Myöhästyneitä palautuksia vastaanotetaan %(deadline)s asti."
 
-#: exercise/templates/exercise/_user_results.html:59
+#: exercise/templates/exercise/_user_results.html:66
 #, python-format
 msgid ""
 "\n"
@@ -2298,7 +2305,7 @@ msgstr ""
 "\n"
 "Pisteiden arvo on %(percent)s%% ajoissa palautetusta."
 
-#: exercise/templates/exercise/_user_results.html:68
+#: exercise/templates/exercise/_user_results.html:75
 #, python-format
 msgid ""
 "\n"
@@ -2308,20 +2315,24 @@ msgstr ""
 "\n"
 "Osion suorittamiseen vaaditaan %(points)s pistettä."
 
-#: exercise/templates/exercise/_user_results.html:79
+#: exercise/templates/exercise/_user_results.html:86
 msgid "There may be changes in the exercises before the module opens!"
 msgstr "Tehtäviin saattaa tulla muutoksia ennen kierroksen avautumista!"
 
-#: exercise/templates/exercise/_user_results.html:88
+#: exercise/templates/exercise/_user_results.html:95
 #: exercise/templates/exercise/staff/_assess_info.html:38
 msgid "Submissions"
 msgstr "Palautukset"
 
-#: exercise/templates/exercise/_user_results.html:131
+#: exercise/templates/exercise/_user_results.html:138
 #: exercise/templates/exercise/exercise_base.html:61
 #: exercise/templates/exercise/exercise_plain.html:83
 msgid "No submissions yet"
 msgstr "Ei vielä palautuksia"
+
+#: exercise/templates/exercise/_user_toc.html:41
+msgid "Opens"
+msgstr "Avautuu"
 
 #: exercise/templates/exercise/_warnings_overlay.html:6
 msgid "You cannot submit this exercise"
@@ -2816,7 +2827,7 @@ msgstr "Viimeisimmät palautukset"
 msgid "No submissions for this course."
 msgstr "Ei vielä palautuksia tälle kurssille."
 
-#: exercise/templatetags/exercise.py:284
+#: exercise/templatetags/exercise.py:287
 msgid "Excel compatible CSV"
 msgstr "Excel-yhteensopiva CSV"
 


### PR DESCRIPTION
# Description
If module is open for reading, it is now opened by default in the
exercise results page. Add a badge to inform that this module is for
reading only. Add correct prepositions with dates (Opens on saturday).
Template tag `module_accessible` fixed to work properly, even when
opening time is not set.
Related issue #473 

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
