### PR TITLE
Show the time of the late deadlines

### DIFF
--- a/course/templates/course/module.html
+++ b/course/templates/course/module.html
@@ -24,7 +24,7 @@
         <br />
         <span class="dates">
             <em>
-                {% blocktrans with deadline=current.late_time %}
+                {% blocktrans with deadline=current.late_time|date:"DATETIME_FORMAT" %}
                 Late submissions are allowed until {{ deadline }}.
                 {% endblocktrans %}
                 {% if current.late_percent != 100 %}
@@ -43,7 +43,7 @@
 	</p>
 	{% endif %}
 
-  {% include "exercise/_children.html" with children=children accessible=True exercise_accessible=current|exercises_open:now %}
+  {% include "exercise/_children.html" with children=children accessible=True exercise_accessible=current|exercises_submittable:now %}
 {% endblock %}
 
 {% block sidecontent %}

--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -82,6 +82,13 @@ def exercises_open(entry, now):
 
 
 @register.filter
+def exercises_submittable(entry, now):
+    if entry['late_allowed']:
+        return entry['opening_time'] <= now <= entry['late_time']
+    return entry['opening_time'] <= now <= entry['closing_time']
+
+
+@register.filter
 def has_opened(entry, now):
     return entry['opening_time'] <= now
 

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -443,29 +443,31 @@ class BaseExercise(LearningObject):
         in consideration.
         """
         timing,d = self.get_timing(students, when or timezone.now())
+
+        formatted_time = date_format(timezone.localtime(d), "DATETIME_FORMAT")
         if timing == self.TIMING.OPEN:
             return True,[]
         if timing == self.TIMING.LATE:
             # xgettext:no-python-format
             return True,[_("Deadline for the exercise has passed. Late submissions are allowed until {date} but points are only worth {percent:d}% of normal.").format(
-                date=date_format(d),
+                date=formatted_time,
                 percent=self.course_module.get_late_submission_point_worth(),
             )]
         if timing == self.TIMING.UNOFFICIAL:
             return True,[_("Deadline for the exercise has passed ({date}). You may still submit to receive feedback, but your current grade will not change.").format(
-                date=date_format(d)
+                date=formatted_time,
             )]
         if timing == self.TIMING.CLOSED_BEFORE:
             return False,[_("The exercise opens {date} for submissions.").format(
-                date=date_format(d)
+                date=formatted_time,
             )]
         if timing == self.TIMING.CLOSED_AFTER:
             return False,[_("Deadline for the exercise has passed ({date}).").format(
-                date=date_format(d)
+                date=formatted_time,
             )]
         if timing == self.TIMING.ARCHIVED:
             return False,[_("This course has been archived ({date}).").format(
-                date=date_format(d)
+                date=formatted_time,
             )]
         return False,["ERROR"]
 

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -59,8 +59,8 @@
       {% if module.late_allowed and module.late_percent > 0 %}
       <br />
       <em>
-        {% blocktrans with deadline=module.late_time %}
-        Late submission are allowed until {{ deadline }}
+        {% blocktrans with deadline=module.late_time|date:"DATETIME_FORMAT" %}
+        Late submissions are allowed until {{ deadline }}
         {% endblocktrans %}
         {% if module.late_percent != 100 %}
         {% blocktrans with percent=module.late_percent %}

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-07 12:41+0200\n"
+"POT-Creation-Date: 2020-02-14 10:27+0200\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jaakko Kantojärvi <jaakko.kantojarvi@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -847,7 +847,7 @@ msgstr "Merkinnät"
 msgid "You cannot enroll, or have already enrolled, in this course."
 msgstr "Et voi ilmoittautua tai olet jo ilmoittautunut tälle kurssille."
 
-#: course/views.py:98 exercise/exercise_models.py:559
+#: course/views.py:98 exercise/exercise_models.py:561
 msgid "The enrollment is not open."
 msgstr "Ilmoittautuminen ei ole avoinna."
 
@@ -1764,7 +1764,7 @@ msgstr "'Points to pass' ei voi olla suurempi kuin 'max_points'."
 msgid "Minimum group size cannot exceed maximum size."
 msgstr "Ryhmän koon alaraja ei voi olla suurempi kuin yläraja."
 
-#: exercise/exercise_models.py:450
+#: exercise/exercise_models.py:452
 #, no-python-format, python-brace-format
 msgid ""
 "Deadline for the exercise has passed. Late submissions are allowed until "
@@ -1773,7 +1773,7 @@ msgstr ""
 "Tehtävän määräaika on mennyt. Myöhäisiä palautuksia vastaanotetaan {date} "
 "asti, mutta pisteiden arvo on ainoastaan {percent:d}% normaalista."
 
-#: exercise/exercise_models.py:455
+#: exercise/exercise_models.py:457
 #, python-brace-format
 msgid ""
 "Deadline for the exercise has passed ({date}). You may still submit to "
@@ -1782,22 +1782,22 @@ msgstr ""
 "Tehtävän määräaika on mennyt ({date}). Voit edelleen palauttaa saadaksesi "
 "palautetta, mutta nykyinen arvosanasi ei muutu."
 
-#: exercise/exercise_models.py:459
+#: exercise/exercise_models.py:461
 #, python-brace-format
 msgid "The exercise opens {date} for submissions."
 msgstr "Tämän tehtävän voi palauttaa {date} alkaen."
 
-#: exercise/exercise_models.py:463
+#: exercise/exercise_models.py:465
 #, python-brace-format
 msgid "Deadline for the exercise has passed ({date})."
 msgstr "Tehtävän määräaika on mennyt ({date})."
 
-#: exercise/exercise_models.py:467
+#: exercise/exercise_models.py:469
 #, python-brace-format
 msgid "This course has been archived ({date})."
 msgstr "Tämä kurssi on arkistoitu ({date})."
 
-#: exercise/exercise_models.py:520
+#: exercise/exercise_models.py:522
 msgid ""
 "You have used the allowed amount of submissions for this exercise. You may "
 "still submit to receive feedback, but your current grade will not change."
@@ -1805,51 +1805,51 @@ msgstr ""
 "Olet käyttänyt kaikki tehtävän palautuskerrat. Voit edelleen palauttaa "
 "saadaksesi palautetta, mutta nykyinen arvosanasi ei muutu."
 
-#: exercise/exercise_models.py:521
+#: exercise/exercise_models.py:523
 msgid "You have used the allowed amount of submissions for this exercise."
 msgstr "Olet käyttänyt kaikki tehtävän palautuskerrat."
 
-#: exercise/exercise_models.py:563
+#: exercise/exercise_models.py:565
 msgid "You cannot enroll in the course."
 msgstr "Et voi ilmoittautua kurssille."
 
-#: exercise/exercise_models.py:568
+#: exercise/exercise_models.py:570
 msgid "Staff can submit exercises without enrolling."
 msgstr "Henkilökunta voi palauttaa tehtäviä ilmoittautumatta."
 
-#: exercise/exercise_models.py:571
+#: exercise/exercise_models.py:573
 msgid "You must enroll in the course to submit exercises."
 msgstr "Palauttaaksesi tehtäviä sinun pitää ilmoittautua kurssille."
 
-#: exercise/exercise_models.py:593
+#: exercise/exercise_models.py:595
 msgid "Group can only change between different exercises."
 msgstr "Ryhmää voi vaihtaa vain eri tehtävien välissä."
 
-#: exercise/exercise_models.py:594
+#: exercise/exercise_models.py:596
 #, python-brace-format
 msgid "You have previously submitted this exercise {with_group}. {msg}"
 msgstr "Olet palauttanut tämän tehtävän aiemmin {with_group}. {msg}"
 
-#: exercise/exercise_models.py:597
+#: exercise/exercise_models.py:599
 msgid "alone"
 msgstr "yksin"
 
-#: exercise/exercise_models.py:601
+#: exercise/exercise_models.py:603
 msgid "with {}"
 msgstr "ryhmässä {}"
 
-#: exercise/exercise_models.py:607
+#: exercise/exercise_models.py:609
 #, python-brace-format
 msgid ""
 "{collaborators} already submitted to this exercise in a different group."
 msgstr "{collaborators} palautti jo tämän tehtävän eri ryhmässä."
 
-#: exercise/exercise_models.py:622
+#: exercise/exercise_models.py:624
 #, python-brace-format
 msgid "This exercise must be submitted in groups of {size} students."
 msgstr "Tämä tehtävä täytyy palauttaa {size} opiskelijan ryhmässä."
 
-#: exercise/exercise_models.py:632
+#: exercise/exercise_models.py:634
 msgid ""
 "Cannot submit exercise due to unknown reason. If you think this is an error, "
 "please contact course staff."
@@ -1857,30 +1857,30 @@ msgstr ""
 "Tehtävää ei voitu palauttaa tuntemattomasta syystä. Jos uskot tämän olevan "
 "virhe, ota ystävällisesti yhteyttä kurssihenkilökuntaan."
 
-#: exercise/exercise_models.py:775
+#: exercise/exercise_models.py:777
 msgid "Default: [hostname]/[course:url]/[instance:url]/"
 msgstr "Oletus: [hostname]/[course:url]/[instance:url]/"
 
-#: exercise/exercise_models.py:777
+#: exercise/exercise_models.py:779
 msgid "Default: [aplusexercise:id]"
 msgstr "Oletus: [aplusexercise:id]"
 
-#: exercise/exercise_models.py:779
+#: exercise/exercise_models.py:781
 msgid "Default: the menu label of the LTI service"
 msgstr "Oletus: LTI-palvelun nimi"
 
-#: exercise/exercise_models.py:781
+#: exercise/exercise_models.py:783
 msgid ""
 "Perform GET and POST from A+ to custom service URL with LTI data appended."
 msgstr ""
 "A+ suorittaa ulkoisen palvelun GET ja POST pyynnöt lisätyillä LTI-tiedoilla."
 
-#: exercise/exercise_models.py:783
+#: exercise/exercise_models.py:785
 msgid ""
 "Open the exercise in an iframe inside the A+ page instead of a new window."
 msgstr "Avaa tehtävä iframe-kehyksessä A+-sivun sisällä uuden ikkunan sijasta."
 
-#: exercise/exercise_models.py:800
+#: exercise/exercise_models.py:802
 msgid ""
 "Domain of Service URL must match the domain of LTI Service or it should only "
 "be the path."
@@ -1888,14 +1888,14 @@ msgstr ""
 "Palveluosoitteen domainin täytyy vastata LTI-palvelun domainia tai osoitteen "
 "tulee olla vain polku."
 
-#: exercise/exercise_models.py:807
+#: exercise/exercise_models.py:809
 msgid ""
 "The exercise can not be loaded because the external LTI service has been "
 "disabled."
 msgstr ""
 "Tehtävää ei voi ladata, koska ulkoinen LTI-palvelu on poistettu käytöstä."
 
-#: exercise/exercise_models.py:939
+#: exercise/exercise_models.py:941
 msgid ""
 "File names that user should submit, use pipe character to separate files"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr "Vaaditaan"
 #, python-format
 msgid ""
 "\n"
-"        Late submission are allowed until %(deadline)s\n"
+"        Late submissions are allowed until %(deadline)s\n"
 "        "
 msgstr ""
 "\n"


### PR DESCRIPTION
# Description
Previous version showed only the date of the deadline.
Additionally, activate the links to the exercises between the closing time and the late deadline.
Fix #382 
# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [x] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [x] Not relevant
