### PR TITLE
Group and submission API endpoints

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -50,6 +50,12 @@ with api.register(r'courses',
     courses.register(r'aggregatedata',
                      exercise.api.csv.views.CourseAggregateDataViewSet,
                      basename='course-aggregatedata')
+    courses.register(r'mygroups',
+                     course.api.views.CourseOwnStudentGroupsViewSet,
+                     basename='course-mygroups')
+    courses.register(r'groups',
+                     course.api.views.CourseStudentGroupsViewSet,
+                     basename='course-groups')
 
 with api.register(r'exercises',
                   exercise.api.views.ExerciseViewSet,

--- a/course/api/full_serializers.py
+++ b/course/api/full_serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers, exceptions
 from lib.api.fields import NestedHyperlinkedIdentityField
 from lib.api.serializers import AplusModelSerializer, NestedHyperlinkedIdentityFieldWithQuery
 from exercise.api.serializers import ExerciseBriefSerializer
-from userprofile.api.serializers import UserBriefSerializer
+from userprofile.api.serializers import UserBriefSerializer, UserListField
 from ..models import (
     CourseInstance,
     CourseModule,
@@ -18,6 +18,7 @@ from .serializers import *
 __all__ = [
     'CourseModuleSerializer',
     'CourseSerializer',
+    'CourseStudentGroupSerializer',
     'CourseUsertagSerializer',
     'CourseUsertaggingsSerializer',
 ]
@@ -71,6 +72,8 @@ class CourseSerializer(CourseBriefSerializer):
     )
     data = NestedHyperlinkedIdentityField(view_name='api:course-submissiondata-list')
     aggregate_data = NestedHyperlinkedIdentityField(view_name='api:course-aggregatedata-list')
+    groups = NestedHyperlinkedIdentityField(view_name='api:course-groups-list')
+    my_groups = NestedHyperlinkedIdentityField(view_name='api:course-mygroups-list')
 
     class Meta(CourseBriefSerializer.Meta):
         fields = (
@@ -88,6 +91,8 @@ class CourseSerializer(CourseBriefSerializer):
             'my_data',
             'data',
             'aggregate_data',
+            'groups',
+            'my_groups',
         )
 
 
@@ -202,3 +207,15 @@ class CourseUsertaggingsSerializer(AplusModelSerializer):
                 )
             )
         return obj
+
+
+class CourseStudentGroupSerializer(CourseStudentGroupBriefSerializer):
+    members = UserListField()
+
+    class Meta(CourseStudentGroupBriefSerializer.Meta):
+        extra_kwargs = {
+            'url': {
+                'view_name': 'api:course-groups-detail',
+            }
+        }
+

--- a/course/api/serializers.py
+++ b/course/api/serializers.py
@@ -3,12 +3,13 @@ from rest_framework.reverse import reverse
 
 from lib.api.fields import NestedHyperlinkedIdentityField
 from lib.api.serializers import AplusModelSerializer, AlwaysListSerializer
-from userprofile.api.serializers import UserBriefSerializer
+from userprofile.api.serializers import UserBriefSerializer, UserMinimalListField
 
 from ..models import (
     CourseInstance,
     CourseModule,
     UserTag,
+    StudentGroup,
 )
 from ..cache.students import CachedStudent
 
@@ -18,6 +19,7 @@ __all__ = [
     'CourseListField',
     'StudentBriefSerializer',
     'CourseUsertagBriefSerializer',
+    'CourseStudentGroupBriefSerializer',
 ]
 
 
@@ -101,3 +103,20 @@ class CourseUsertagBriefSerializer(AplusModelSerializer):
                 'lookup_map': 'course.api.views.CourseUsertagsViewSet',
             }
         }
+
+
+class CourseStudentGroupBriefSerializer(AplusModelSerializer):
+    members = UserMinimalListField()
+
+    class Meta(AplusModelSerializer.Meta):
+        model = StudentGroup
+        fields = (
+            'members',
+            'timestamp',
+        )
+        extra_kwargs = {
+            'url': {
+                'view_name': 'api:course-mygroups-detail',
+            }
+        }
+

--- a/course/permissions.py
+++ b/course/permissions.py
@@ -193,3 +193,17 @@ class IsCourseAdminOrUserObjIsSelf(OnlyCourseStaffPermission, FilterBackend):
         ):
             queryset = queryset.filter(user_id=user.id)
         return queryset
+
+
+class OnlyEnrolledStudentOrCourseStaffPermission(Permission):
+    message = _("Only enrolled students or course staff are allowed")
+
+    def has_permission(self, request, view):
+        return self.has_object_permission(request, view, None)
+
+    def has_object_permission(self, request, view, obj):
+        try:
+            return view.is_student or view.is_course_staff or request.user.is_superuser
+        except AttributeError:
+            return False
+

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -710,9 +710,11 @@ class BaseExercise(LearningObject):
                 request, url, self, submission, no_penalties=no_penalties
             )
         except OSError as error:
-            messages.error(request, "Unable to grade the submission. %s: %s" % (
-                error.__class__.__name__, error))
-            return None
+            page = ExercisePage(self)
+            msg = "Unable to grade the submission. %s: %s" % (
+                error.__class__.__name__, error)
+            page.errors.append(msg)
+            return page
 
     def modify_post_parameters(self, data, files, user, students, request, url):
         """

--- a/exercise/protocol/aplus.py
+++ b/exercise/protocol/aplus.py
@@ -39,7 +39,6 @@ def load_exercise_page(request, url, last_modified, exercise):
 def load_feedback_page(request, url, exercise, submission, no_penalties=False):
     """
     Loads the feedback or accept page from the remote URL.
-
     """
     page = ExercisePage(exercise)
     try:
@@ -48,8 +47,7 @@ def load_feedback_page(request, url, exercise, submission, no_penalties=False):
         submission.clean_post_parameters()
         parse_page_content(page, remote_page, exercise)
     except RemotePageException:
-        messages.error(request,
-            _("Connecting to the assessment service failed!"))
+        page.errors.append(_("Connecting to the assessment service failed!"))
         if exercise.course_instance.visible_to_students:
             msg = "Failed to request {}".format(url)
             logger.exception(msg)
@@ -76,7 +74,7 @@ def load_feedback_page(request, url, exercise, submission, no_penalties=False):
                     #     messages.success(request, msg)
                 else:
                     submission.set_error()
-                    messages.error(request,
+                    page.errors.append(
                         _("Assessment service responded with invalid points. "
                           "Points: {points:d}/{max:d} "
                           "(exercise max {exercise_max:d})").format(
@@ -105,8 +103,7 @@ def load_feedback_page(request, url, exercise, submission, no_penalties=False):
             submission.set_error()
             logger.info("No accept or points received: %s",
                 exercise.service_url)
-            messages.error(request,
-                _("Assessment service responded with error."))
+            page.errors.append(_("Assessment service responded with error."))
         submission.save()
 
     return page

--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -76,7 +76,9 @@ class ResubmitSubmissionView(SubmissionMixin, BaseRedirectView):
     access_mode = ACCESS.ASSISTANT
 
     def post(self, request, *args, **kwargs):
-        _ = self.exercise.grade(request, self.submission)
+        page = self.exercise.grade(request, self.submission)
+        for error in page.errors:
+            messages.error(request, error)
         return self.redirect(self.submission.get_inspect_url())
 
 

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -149,6 +149,8 @@ class ExerciseView(BaseRedirectMixin, ExerciseBaseView, EnrollableViewMixin):
             if new_submission:
                 page = self.exercise.grade(request, new_submission,
                     url_name=self.post_url_name)
+                for error in page.errors:
+                    messages.error(request, error)
 
                 # Enroll after succesfull enrollment exercise.
                 if self.exercise.status in (

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -322,42 +322,46 @@ msgstr ""
 "palautuskertojen raja on ylitetty. Pisteet tallennetaan, mutta ne eivät "
 "sisälly virallisiin tuloksiin."
 
-#: course/permissions.py:20 course/permissions.py:88
+#: course/permissions.py:20 course/permissions.py:100
 msgid "Permission denied by course visibility"
 msgstr "Pääsy kielletty kurssin näkyvyyden perusteella"
 
-#: course/permissions.py:46 course/permissions.py:99
+#: course/permissions.py:46 course/permissions.py:111
 msgid "The resource is not currently visible."
 msgstr "Materiaali ei ole tällä hetkellä nähtävissä."
 
-#: course/permissions.py:57 course/permissions.py:105
+#: course/permissions.py:57 course/permissions.py:117
 msgid "This course is not open for public."
 msgstr "Tälle kurssille ei ole vapaata pääsyä."
 
-#: course/permissions.py:79
+#: course/permissions.py:91
 msgid "This course is only for internal students."
 msgstr "Tämä kurssi on vain oppilaitoksen koulutusohjelmien opiskelijoille."
 
-#: course/permissions.py:82
+#: course/permissions.py:94
 msgid "This course is only for external students."
 msgstr "Tämä kurssi on vain oppilaitoksen ulkopuolisille opiskelijoille."
 
-#: course/permissions.py:112
+#: course/permissions.py:124
 msgid "The module is not currently visible."
 msgstr "Tämä osio ei ole tällä hetkellä nähtävissä."
 
-#: course/permissions.py:131
+#: course/permissions.py:143
 #, python-brace-format
 msgid "The module will open for submissions at {date}."
 msgstr "Tämä osio avautuu {date}."
 
-#: course/permissions.py:144
+#: course/permissions.py:156
 msgid "Only course teacher is allowed"
 msgstr "Vain opettajalle."
 
-#: course/permissions.py:154
+#: course/permissions.py:166
 msgid "Only course staff is allowed"
 msgstr "Vain kurssihenkilökunnalle."
+
+#: course/permissions.py:199
+msgid "Only enrolled students or course staff are allowed"
+msgstr "Vain ilmoittautuneille opiskelijoille tai kurssihenkilökunnalle"
 
 #: course/staff_views.py:102 edit_course/views.py:49
 #: exercise/staff_views.py:289

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-05 23:24+0300\n"
+"POT-Creation-Date: 2020-06-03 12:25+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
-"Last-Translator: Jaakko Kantojärvi <jaakko.kantojarvi@aalto.fi>\n"
+"Last-Translator: Markku Riekkinen <markku.riekkinen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
 "Language: fi_FI\n"
 "MIME-Version: 1.0\n"
@@ -77,7 +77,7 @@ msgstr "Vain opettajille."
 msgid "Only course staff shall pass."
 msgstr "Vain kurssihenkilökunnalle."
 
-#: authorization/permissions.py:141 course/permissions.py:66
+#: authorization/permissions.py:141 course/permissions.py:78
 msgid "Only enrolled students shall pass."
 msgstr "Vain ilmoittautuneille."
 
@@ -364,12 +364,12 @@ msgid "Only enrolled students or course staff are allowed"
 msgstr "Vain ilmoittautuneille opiskelijoille tai kurssihenkilökunnalle"
 
 #: course/staff_views.py:102 edit_course/views.py:49
-#: exercise/staff_views.py:289
+#: exercise/staff_views.py:291
 msgid "Changes were saved succesfully."
 msgstr "Muutokset tallennettiin onnistuneesti."
 
 #: course/staff_views.py:106 edit_course/views.py:53
-#: exercise/staff_views.py:293
+#: exercise/staff_views.py:295
 msgid "Failed to save changes."
 msgstr "Muutosten tallentaminen epäonnistui."
 
@@ -1726,6 +1726,12 @@ msgstr "Kurssikerta"
 msgid "Submitters"
 msgstr "Opiskelijat"
 
+#: exercise/api/views.py:275 exercise/views.py:168
+msgid ""
+"The submission could not be saved for some reason. The submission was not "
+"registered."
+msgstr "Palautuksen tallentaminen epäonnistui. Palautusta ei ole huomioitu."
+
 #: exercise/async_views.py:29
 msgid ""
 "<div class=\"alert alert-error\">\n"
@@ -1901,30 +1907,30 @@ msgstr ""
 "Tehtävää ei voitu palauttaa tuntemattomasta syystä. Jos uskot tämän olevan "
 "virhe, ota ystävällisesti yhteyttä kurssihenkilökuntaan."
 
-#: exercise/exercise_models.py:779
+#: exercise/exercise_models.py:781
 msgid "Default: [hostname]/[course:url]/[instance:url]/"
 msgstr "Oletus: [hostname]/[course:url]/[instance:url]/"
 
-#: exercise/exercise_models.py:781
+#: exercise/exercise_models.py:783
 msgid "Default: [aplusexercise:id]"
 msgstr "Oletus: [aplusexercise:id]"
 
-#: exercise/exercise_models.py:783
+#: exercise/exercise_models.py:785
 msgid "Default: the menu label of the LTI service"
 msgstr "Oletus: LTI-palvelun nimi"
 
-#: exercise/exercise_models.py:785
+#: exercise/exercise_models.py:787
 msgid ""
 "Perform GET and POST from A+ to custom service URL with LTI data appended."
 msgstr ""
 "A+ suorittaa ulkoisen palvelun GET ja POST pyynnöt lisätyillä LTI-tiedoilla."
 
-#: exercise/exercise_models.py:787
+#: exercise/exercise_models.py:789
 msgid ""
 "Open the exercise in an iframe inside the A+ page instead of a new window."
 msgstr "Avaa tehtävä iframe-kehyksessä A+-sivun sisällä uuden ikkunan sijasta."
 
-#: exercise/exercise_models.py:804
+#: exercise/exercise_models.py:806
 msgid ""
 "Domain of Service URL must match the domain of LTI Service or it should only "
 "be the path."
@@ -1932,14 +1938,14 @@ msgstr ""
 "Palveluosoitteen domainin täytyy vastata LTI-palvelun domainia tai osoitteen "
 "tulee olla vain polku."
 
-#: exercise/exercise_models.py:811
+#: exercise/exercise_models.py:813
 msgid ""
 "The exercise can not be loaded because the external LTI service has been "
 "disabled."
 msgstr ""
 "Tehtävää ei voi ladata, koska ulkoinen LTI-palvelu on poistettu käytöstä."
 
-#: exercise/exercise_models.py:943
+#: exercise/exercise_models.py:945
 msgid ""
 "File names that user should submit, use pipe character to separate files"
 msgstr ""
@@ -2041,11 +2047,11 @@ msgstr "Sinulla ei ole lupaa katsoa tämän tehtävän esimerkkiratkaisua."
 msgid "Connecting to the exercise service failed!"
 msgstr "Tehtäväpalveluun ei saatu yhteyttä!"
 
-#: exercise/protocol/aplus.py:52
+#: exercise/protocol/aplus.py:50
 msgid "Connecting to the assessment service failed!"
 msgstr "Tehtäväpalveluun ei saatu yhteyttä!"
 
-#: exercise/protocol/aplus.py:80
+#: exercise/protocol/aplus.py:78
 #, python-brace-format
 msgid ""
 "Assessment service responded with invalid points. Points: {points:d}/{max:d} "
@@ -2054,19 +2060,19 @@ msgstr ""
 "Tehtävän pisteytyksessä on vikaa. Pisteet: {points:d}/{max:d} (exercise max "
 "{exercise_max:d})"
 
-#: exercise/protocol/aplus.py:109
+#: exercise/protocol/aplus.py:106
 msgid "Assessment service responded with error."
 msgstr "Tehtäväpalvelussa tapahtui virhe."
 
-#: exercise/staff_views.py:151
+#: exercise/staff_views.py:153
 msgid "The review was saved successfully and the submitters were notified."
 msgstr "Palaute on tallennettu, ja opiskelijoille on lähetetty ilmoitus."
 
-#: exercise/staff_views.py:172
+#: exercise/staff_views.py:174
 msgid "Failed to load the resource."
 msgstr "Lataus epäonnistui."
 
-#: exercise/staff_views.py:251
+#: exercise/staff_views.py:253
 #, python-brace-format
 msgid ""
 "Invalid POST data:\n"
@@ -2075,7 +2081,7 @@ msgstr ""
 "Epäkelvollinen POST sisältö:\n"
 "{error}"
 
-#: exercise/staff_views.py:266
+#: exercise/staff_views.py:268
 msgid "New submission stored."
 msgstr "Uusi palautus on lisätty."
 
@@ -2883,13 +2889,7 @@ msgstr "Tehtävässä on huoltokatko, ja sisältö on piilotettu opiskelijoilta.
 msgid "Unfortunately this exercise is currently under maintenance."
 msgstr "Valitettavasti tässä tehtävässä on juuri nyt huoltokatko."
 
-#: exercise/views.py:166
-msgid ""
-"The submission could not be saved for some reason. The submission was not "
-"registered."
-msgstr "Palautuksen tallentaminen epäonnistui. Palautusta ei ole huomioitu."
-
-#: exercise/views.py:179
+#: exercise/views.py:181
 msgid "You need to sign in and enroll to submit exercises."
 msgstr ""
 "Palauttaaksesi tehtäviä sinun pitää rekisteröityä ja ilmoittautua kurssin "

--- a/userprofile/api/serializers.py
+++ b/userprofile/api/serializers.py
@@ -43,3 +43,26 @@ class UserBriefSerializer(AplusModelSerializer):
 
 class UserListField(AlwaysListSerializer, UserBriefSerializer):
     pass
+
+
+class UserMinimalSerializer(AplusModelSerializer):
+    """User serializer that includes only the data that students are allowed
+    to see from each other.
+    """
+    full_name = serializers.CharField(source='user.get_full_name', required=False)
+
+    class Meta(AplusModelSerializer.Meta):
+        model = UserProfile
+        fields = (
+            'full_name',
+        )
+        extra_kwargs = {
+            'url': {
+                'view_name': 'api:user-detail',
+                'lookup_map': 'userprofile.api.views.UserViewSet',
+            }
+        }
+
+
+class UserMinimalListField(AlwaysListSerializer, UserMinimalSerializer):
+    pass


### PR DESCRIPTION
# Description

Add API endpoints for retrieving StudentGroups and for submitting new solutions to grading. Both endpoints can be accessed by students. These are needed by the new IntelliJ IDEA plugin.

# Testing

No unit tests have been added. I tested the API endpoints manually with curl or in the web browser. My testing covered different error cases and access control for users (teachers and students).

Manual testing needs to check that normal submissions still work (in the normal course web page). The old grade function was slightly changed so that the API requests are not dependent on the session-based Django messages framework.

# Have you updated the README or other relevant documentation?

No, the API has not previously been documented like that and won't be now either.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
