### PR TITLE
LTI: enable branding for instance name Fixes #423

### DIFF
--- a/aplus/local_settings.example.py
+++ b/aplus/local_settings.example.py
@@ -5,6 +5,9 @@
 #ADMINS = (
 #    ('Your Name', 'your_email@domain.com'),
 #)
+## Branding
+#BRAND_NAME = 'Your brand name (default is A+)'
+#BRAND_DESCRIPTION = 'Description of your service (default is Virtual Learning Environment)'
 # Show red alert on top of all pages
 #SITEWIDE_ALERT_TEXT = "Maintenance on Monday"
 #SITEWIDE_ALERT_TEXT = {'en': "Maintenance on Monday", 'fi': "Maanantaina on palvelukatko"}

--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -29,6 +29,7 @@ ALLOWED_HOSTS = ["*"]
 SITEWIDE_ALERT_TEXT = None
 SITEWIDE_ADVERT = None
 BRAND_NAME = 'A+'
+BRAND_DESCRIPTION = 'Virtual Learning Environment'
 
 WELCOME_TEXT = 'Welcome to A+ <small>modern learning environment</small>'
 SHIBBOLETH_TITLE_TEXT = 'Aalto University users'

--- a/external_services/lti.py
+++ b/external_services/lti.py
@@ -66,7 +66,9 @@ class LTIRequest(object):
             "launch_presentation_return_url": urljoin(settings.BASE_URL, instance.get_absolute_url()),
 
             "tool_consumer_instance_guid": base_url_parts.netloc + "/aplus",
-            "tool_consumer_instance_name": "A+ LMS",
+            "tool_consumer_instance_name": settings.BRAND_NAME,
+            "tool_consumer_instance_description": settings.BRAND_DESCRIPTION,
+            "tool_consumer_instance_url": settings.BASE_URL,
         })
 
         if service.api_access:


### PR DESCRIPTION
# Description

This PR changes how  `tool_consumer_instance_name` is set and adds two new parameters: 
 `tool_consumer_instance_description` and  `tool_consumer_instance_url`. Setting the the instance name using BRAND_NAME enables easier branding.

# Testing

Testing has been done manually with the help of https://github.com/Aalto-LeTech/django-lti-login
# Have you updated the README or other relevant documentation?
Not relevant.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
