### PR TITLE
Improve extra login options on login page

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -32,13 +32,10 @@ BRAND_NAME = 'A+'
 
 WELCOME_TEXT = 'Welcome to A+ <small>modern learning environment</small>'
 SHIBBOLETH_TITLE_TEXT = 'Aalto University users'
-SHIBBOLETH_BODY_TEXT = 'Log in with Aalto University user account by clicking the button below. Programme students and faculty must login here.'
-SHIBBOLETH_BUTTON_TEXT = 'Aalto Login'
+SHIBBOLETH_BODY_TEXT = 'Log in with Aalto University user account by clicking the button below. Programme students and faculty must log in here.'
+SHIBBOLETH_BUTTON_TEXT = 'Aalto login'
 MOOC_TITLE_TEXT = 'Users external to Aalto'
-MOOC_BODY_TEXT = 'Some of our courses are open for everyone. Login with your user account from one of the following services.'
-LOGIN_TITLE_TEXT = ''
-LOGIN_BODY_TEXT = ''
-LOGIN_BUTTON_TEXT = 'Maintenance login'
+MOOC_BODY_TEXT = 'Some of our courses are open for everyone. Log in with your user account from one of the following services.'
 INTERNAL_USER_LABEL = 'Aalto'
 EXTERNAL_USER_LABEL = 'MOOC'
 
@@ -48,9 +45,6 @@ SHIBBOLETH_BODY_TEXT_FI = 'Kirjaudu palveluun Aalto-yliopiston käyttäjätunnuk
 SHIBBOLETH_BUTTON_TEXT_FI = 'Aalto-kirjautuminen'
 MOOC_TITLE_TEXT_FI = 'Käyttäjät Aallon ulkopuolelta'
 MOOC_BODY_TEXT_FI = 'Osa kursseistamme on avoinna kaikille. Kirjaudu sisään jonkin seuraavan palvelun käyttäjätunnuksellasi.'
-LOGIN_TITLE_TEXT_FI = ''
-LOGIN_BODY_TEXT_FI = ''
-LOGIN_BUTTON_TEXT_FI = 'Ylläpidon kirjautuminen'
 
 TRACKING_HTML = ''
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3586,13 +3586,8 @@ msgid "Password"
 msgstr "Salasana"
 
 #: userprofile/templates/userprofile/login.html:94
-#, python-format
-msgid ""
-"\n"
-"  You may want to read our <a href=\"%(url)s\">privacy notice</a>.\n"
-"  "
+msgid "You may want to read our <a href=\"%(url)s\">privacy notice</a>."
 msgstr ""
-"\n"
 "Voit olla kiinnostunut <a href=\"%(url)s\">tietosuojailmoituksestamme</a>."
 
 #: userprofile/templates/userprofile/logout.html:4

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -985,7 +985,7 @@ msgstr "Avaa 0 arvosanan diplomi"
 
 #: diploma/templates/diploma/list.html:26
 #: edit_course/templates/edit_course/signin_as_user.html:14
-#: userprofile/templates/userprofile/login.html:78
+#: userprofile/templates/userprofile/login.html:84
 #: userprofile/templates/userprofile/profile.html:35
 msgid "Username"
 msgstr "Käyttäjätunnus"
@@ -3524,6 +3524,7 @@ msgid "Log out"
 msgstr "Kirjaudu ulos"
 
 #: templates/base.html:138 templates/base.html:174
+#: userprofile/templates/userprofile/login.html:90
 msgid "Log in"
 msgstr "Kirjaudu sisään"
 
@@ -3572,25 +3573,38 @@ msgstr "Vaativammat pisteet käytetään helpompien vaatimuksien täyttöön."
 msgid "{:d} points"
 msgstr "{:d} pisteet"
 
-#: userprofile/templates/userprofile/login.html:5
-#: userprofile/templates/userprofile/login.html:10
+#: userprofile/templates/userprofile/login.html:6
+#: userprofile/templates/userprofile/login.html:17
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
-#: userprofile/templates/userprofile/login.html:54
-msgid "Login Using Google"
+#: userprofile/templates/userprofile/login.html:61
+msgid "Log in using Google"
 msgstr "Kirjaudu Google-tunnuksella"
 
-#: userprofile/templates/userprofile/login.html:81
+#: userprofile/templates/userprofile/login.html:72
+msgid "Local users"
+msgstr "Paikalliset käyttäjät"
+
+#: userprofile/templates/userprofile/login.html:75
+#, python-format
+msgid ""
+"If you have been provided with credentials specifically for %(brand_name)s, "
+"use this login."
+msgstr ""
+"Mikäli sinulla on tunnukset yksinomaan %(brand_name)s-palvelua varten, "
+"kirjaudu sisään tästä."
+
+#: userprofile/templates/userprofile/login.html:87
 msgid "Password"
 msgstr "Salasana"
 
+#: userprofile/templates/userprofile/login.html:98
 #: userprofile/templates/userprofile/login.html:99
-#: userprofile/templates/userprofile/login.html:100
 msgid "Show more login options"
 msgstr "Näytä lisää kirjautumisvaihtoehtoja"
 
-#: userprofile/templates/userprofile/login.html:108
+#: userprofile/templates/userprofile/login.html:107
 #, python-format
 msgid "You may want to read our <a href=\"%(url)s\">privacy notice</a>."
 msgstr ""
@@ -3686,6 +3700,6 @@ msgstr ""
 msgid "Forget automatic redirection"
 msgstr "Unohda automaattinen uudelleenohjaus."
 
-#: userprofile/views.py:80
+#: userprofile/views.py:78
 msgid "No privacy notice. Please notify administration!"
 msgstr "Ei tietosuojailmoitusta. Ota yhteys ylläpitäjään!"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3585,7 +3585,13 @@ msgstr "Kirjaudu Google-tunnuksella"
 msgid "Password"
 msgstr "Salasana"
 
-#: userprofile/templates/userprofile/login.html:94
+#: userprofile/templates/userprofile/login.html:99
+#: userprofile/templates/userprofile/login.html:100
+msgid "Show more login options"
+msgstr "Näytä lisää kirjautumisvaihtoehtoja"
+
+#: userprofile/templates/userprofile/login.html:108
+#, python-format
 msgid "You may want to read our <a href=\"%(url)s\">privacy notice</a>."
 msgstr ""
 "Voit olla kiinnostunut <a href=\"%(url)s\">tietosuojailmoituksestamme</a>."

--- a/userprofile/static/userprofile/extra_logins.js
+++ b/userprofile/static/userprofile/extra_logins.js
@@ -1,0 +1,24 @@
+(function ($) {
+
+  function showExtras(event) {
+    event.preventDefault();
+    const extras = $("#login-box-row").find(".extra-login")
+    extras.show();
+    $(".show-extra-login-btn").hide();
+    extras.find(":input:visible").first().focus() // focus for keyboard navigation
+  }
+
+  $(function () {
+    const row = $("#login-box-row")
+    const normal = row.find(".login-box").not(".extra-login")
+    if (normal.length > 0) {
+      row.find(".extra-login").hide();
+      $(".show-extra-login-btn").on("click", showExtras).show();
+
+      if (normal.length % 2 == 0) {
+        normal.last().after('<div class="clearfix visible-sm-block"></div>');
+      }
+    }
+  });
+
+}(jQuery));

--- a/userprofile/static/userprofile/login.css
+++ b/userprofile/static/userprofile/login.css
@@ -1,0 +1,13 @@
+#login-box-row {
+    margin-bottom: 2em;
+}
+
+button.show-extra-login-btn {
+    border: 0px;
+    display: none;
+}
+
+button.show-extra-login-btn > i {
+    font-size: 1.4em;
+    color: #aaa;
+}

--- a/userprofile/templates/userprofile/login.html
+++ b/userprofile/templates/userprofile/login.html
@@ -58,7 +58,7 @@
 							</p>
 						{% endif %}
 						<p>
-							<a class="btn btn-danger btn-block" role="button" href="{% url 'social:begin' 'google-oauth2' %}?next={{ next|iriencode }}">{% trans 'Login Using Google' %}</a>
+							<a class="btn btn-danger btn-block" role="button" href="{% url 'social:begin' 'google-oauth2' %}?next={{ next|iriencode }}">{% trans 'Log in using Google' %}</a>
 						</p>
 					</div>
 				</div>
@@ -68,16 +68,15 @@
 		<div class="col-sm-6 col-md-3 login-box extra-login">
 			<div class="thumbnail">
 				<div class="caption">
-					{% if login_title_text %}
-						<h3>
-							{{ login_title_text|safe }}
-						</h3>
-					{% endif %}
-					{% if login_body_text %}
-						<p>
-							{{ login_body_text|safe }}
-						</p>
-					{% endif %}
+					<h3>
+						{% trans "Local users" %}
+					</h3>
+					<p>
+						{% blocktrans trimmed %}
+							If you have been provided with credentials specifically
+							for {{ brand_name }}, use this login.
+						{% endblocktrans %}
+					</p>
 					<form method="post" role="form">
 						{% csrf_token %}
 						{#{ form|bootstrap }#}
@@ -88,7 +87,7 @@
 							<input class="form-control" type="password" id="id_password" name="password" placeholder="{% trans 'Password' %}">
 						</div>
 						<div class="form-group">
-							<button type="submit" class="btn btn-default btn-block">{{ login_button_text|safe }}</button>
+							<button type="submit" class="btn btn-default btn-block">{% trans "Log in" %}</button>
 						</div>
 					</form>
 				</div>

--- a/userprofile/templates/userprofile/login.html
+++ b/userprofile/templates/userprofile/login.html
@@ -1,8 +1,15 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load static %}
 {% load bootstrap %}
 
 {% block title %}{% trans "Login" %} | {{ block.super }}{% endblock %}
+
+{% block scripts %}
+	{{ block.super }}
+	<link rel="stylesheet" href="{% static 'userprofile/login.css' %}" />
+	<script src="{% static 'userprofile/extra_logins.js' %}"></script>
+{% endblock %}
 
 {% block content %}
 
@@ -10,10 +17,10 @@
 		<h1>{% trans "Login" %}</h1>
 	</div>
 
-	<div class="row">
+	<div id="login-box-row" class="row">
 
 		{% if shibboleth_login %}
-			<div class="col-sm-6 col-md-3">
+			<div class="col-sm-6 col-md-3 login-box">
 				<div class="thumbnail">
 					<div class="caption">
 						{% if shibboleth_title_text %}
@@ -37,7 +44,7 @@
 		{% endif %}
 
 		{% if mooc_login %}
-			<div class="col-sm-6 col-md-3">
+			<div class="col-sm-6 col-md-3 login-box">
 				<div class="thumbnail">
 					<div class="caption">
 						{% if mooc_title_text %}
@@ -58,7 +65,7 @@
 			</div>
 		{% endif %}
 
-		<div class="col-sm-6 col-md-3">
+		<div class="col-sm-6 col-md-3 login-box extra-login">
 			<div class="thumbnail">
 				<div class="caption">
 					{% if login_title_text %}
@@ -86,6 +93,16 @@
 					</form>
 				</div>
 			</div>
+		</div>
+
+		<div class="col-sm-1">
+			<button class="btn btn-default show-extra-login-btn"
+				aria-label="{% trans 'Show more login options' %}"
+				title="{% trans 'Show more login options' %}"
+			>
+				<i class="glyphicon glyphicon-chevron-right hidden-xs" focusable="false"></i>
+				<i class="glyphicon glyphicon-chevron-down visible-xs-inline" focusable="false"></i>
+			</button>
 		</div>
 	</div>
 

--- a/userprofile/templates/userprofile/login.html
+++ b/userprofile/templates/userprofile/login.html
@@ -6,94 +6,94 @@
 
 {% block content %}
 
-<div class="page-header">
-    <h1>{% trans "Login" %}</h1>
-</div>
+	<div class="page-header">
+		<h1>{% trans "Login" %}</h1>
+	</div>
 
-<div class="row">
+	<div class="row">
 
-    {% if shibboleth_login %}
-    <div class="col-sm-6 col-md-3">
-        <div class="thumbnail">
-            <div class="caption">
-                {% if shibboleth_title_text %}
-                <h3>
-                	{{ shibboleth_title_text|safe }}
-                </h3>
-                {% endif %}
-                {% if shibboleth_body_text %}
-                <p>
-                	{{ shibboleth_body_text|safe }}
-                </p>
-                {% endif %}
-                <p>
-                	<a class="btn btn-primary btn-block" role="button" href="{% url 'shibboleth-login' %}?next={{ next|iriencode }}">
-                		{{ shibboleth_button_text|safe }}
-                	</a>
-                </p>
-            </div>
-        </div>
-    </div>
-    {% endif %}
+		{% if shibboleth_login %}
+			<div class="col-sm-6 col-md-3">
+				<div class="thumbnail">
+					<div class="caption">
+						{% if shibboleth_title_text %}
+							<h3>
+								{{ shibboleth_title_text|safe }}
+							</h3>
+						{% endif %}
+						{% if shibboleth_body_text %}
+							<p>
+								{{ shibboleth_body_text|safe }}
+							</p>
+						{% endif %}
+						<p>
+							<a class="btn btn-primary btn-block" role="button" href="{% url 'shibboleth-login' %}?next={{ next|iriencode }}">
+								{{ shibboleth_button_text|safe }}
+							</a>
+						</p>
+					</div>
+				</div>
+			</div>
+		{% endif %}
 
-    {% if mooc_login %}
-    <div class="col-sm-6 col-md-3">
-        <div class="thumbnail">
-            <div class="caption">
-                {% if mooc_title_text %}
-                <h3>
-                  {{ mooc_title_text|safe }}
-                </h3>
-                {% endif %}
-                {% if mooc_body_text %}
-                <p>
-                    {{ mooc_body_text|safe }}
-                </p>
-                {% endif %}
-                <p>
-                    <a class="btn btn-danger btn-block" role="button" href="{% url 'social:begin' 'google-oauth2' %}?next={{ next|iriencode }}">{% trans 'Login Using Google' %}</a>
-                </p>
-            </div>
-        </div>
-    </div>
-    {% endif %}
+		{% if mooc_login %}
+			<div class="col-sm-6 col-md-3">
+				<div class="thumbnail">
+					<div class="caption">
+						{% if mooc_title_text %}
+							<h3>
+								{{ mooc_title_text|safe }}
+							</h3>
+						{% endif %}
+						{% if mooc_body_text %}
+							<p>
+								{{ mooc_body_text|safe }}
+							</p>
+						{% endif %}
+						<p>
+							<a class="btn btn-danger btn-block" role="button" href="{% url 'social:begin' 'google-oauth2' %}?next={{ next|iriencode }}">{% trans 'Login Using Google' %}</a>
+						</p>
+					</div>
+				</div>
+			</div>
+		{% endif %}
 
-    <div class="col-sm-6 col-md-3">
-        <div class="thumbnail">
-            <div class="caption">
-                {% if login_title_text %}
-                <h3>
-                	{{ login_title_text|safe }}
-                </h3>
-                {% endif %}
-                {% if login_body_text %}
-                <p>
-                    {{ login_body_text|safe }}
-                </p>
-                {% endif %}
-                <form method="post" role="form">
-                    {% csrf_token %}
-                    {#{ form|bootstrap }#}
-                    <div class="form-group">
-                        <input class="form-control" type="text" id="id_username" name="username" maxlength="254" placeholder="{% trans 'Username' %}">
-                    </div>
-                    <div class="form-group">
-                        <input class="form-control" type="password" id="id_password" name="password" placeholder="{% trans 'Password' %}">
-                    </div>
-                    <div class="form-group">
-                        <button type="submit" class="btn btn-default btn-block">{{ login_button_text|safe }}</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
+		<div class="col-sm-6 col-md-3">
+			<div class="thumbnail">
+				<div class="caption">
+					{% if login_title_text %}
+						<h3>
+							{{ login_title_text|safe }}
+						</h3>
+					{% endif %}
+					{% if login_body_text %}
+						<p>
+							{{ login_body_text|safe }}
+						</p>
+					{% endif %}
+					<form method="post" role="form">
+						{% csrf_token %}
+						{#{ form|bootstrap }#}
+						<div class="form-group">
+							<input class="form-control" type="text" id="id_username" name="username" maxlength="254" placeholder="{% trans 'Username' %}">
+						</div>
+						<div class="form-group">
+							<input class="form-control" type="password" id="id_password" name="password" placeholder="{% trans 'Password' %}">
+						</div>
+						<div class="form-group">
+							<button type="submit" class="btn btn-default btn-block">{{ login_button_text|safe }}</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
 
-{% url 'privacy_notice' as privacy_url %}
-<p>
-  {% blocktrans with url=privacy_url %}
-  You may want to read our <a href="{{ url }}">privacy notice</a>.
-  {% endblocktrans %}
-</p>
+	{% url 'privacy_notice' as privacy_url %}
+	<p>
+		{% blocktrans trimmed with url=privacy_url %}
+			You may want to read our <a href="{{ url }}">privacy notice</a>.
+		{% endblocktrans %}
+	</p>
 
 {% endblock %}

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -26,6 +26,7 @@ class CustomLoginView(LoginView):
     extra_context = {
         'shibboleth_login': 'shibboleth_login' in settings.INSTALLED_APPS,
         'mooc_login': 'social_django' in settings.INSTALLED_APPS,
+        'brand_name': settings_text('BRAND_NAME'),
     }
 
     def get_context_data(self, **kwargs):
@@ -37,9 +38,6 @@ class CustomLoginView(LoginView):
         # in the class level, but there is a request when this method is called
         # (self.request).
         context.update({
-            'login_title_text': settings_text('LOGIN_TITLE_TEXT'),
-            'login_body_text': settings_text('LOGIN_BODY_TEXT'),
-            'login_button_text': settings_text('LOGIN_BUTTON_TEXT'),
             'shibboleth_title_text': settings_text('SHIBBOLETH_TITLE_TEXT'),
             'shibboleth_body_text': settings_text('SHIBBOLETH_BODY_TEXT'),
             'shibboleth_button_text': settings_text('SHIBBOLETH_BUTTON_TEXT'),


### PR DESCRIPTION
# Description

- The local user login (previously "maintenance login") is rarely used, yet was visible on the login page. This pull request hides that login option by default if there are normal login options and provides support for hiding other additional login options similarly. These hidden login options can be made visible by pressing a button.
- The "Maintenance login" was quite unclear and misleadingly named, the title is changed to a more fitting "Local users" and an instructive and descriptive text is added to explain who should use the login in question.
- The texts for the local user login used to be fetched from aplus/settings.py, this changes the implementation to hard coding by defining the login texts directly in the template.
- The texts in the login box headings and login buttons were updated to sentence case (from title case) to be consistent with the rest of the service.

Fixes #541 

# Testing

- All old basic tests except seemingly broken `test_uploading_and_viewing_file (exercise.tests.ExerciseTest)` work

Should be tested manually:
- When there are other login options, the local user login is hidden, there is an button with an chevron icon ("Show more login options"), and pressing that button displays the local user login (and possible other extra logins) and the button itself is hidden
- When there are no normal login options, the local user login (and other possible login options) are visible, and the "Show more login options" button is not.
- Navigating with keyboard works and the focus is changed to a visible input element after pressing the "Show more login options"
- The page and "Show more login options" is usable using a screen reader
- Logging in through the local user login is possible when JavaScript is disabled (both when there are other login options and when there aren't), and the "Show more login options" button should not be visible
- Everything is in Finnish when the browser's preferred language is set in Finnish (and likewise in English)
- Everything works fine even if using an older version of aplus/settings.py as well as when with a different brand name

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] ~I (developer) have created unit tests and the tests pass~
- [ ] ~I (developer) have created functional tests (Selenium tests) if applicable~
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
