### PR TITLE
Create "skip links" for keyboard users

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -228,6 +228,33 @@ html, body {
   padding-top: 70px;
 }*/
 
+/* Skip links */
+
+.skip-link { /* This one is equally applicable to all skip links */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    display: block;
+}
+
+.skip-link:focus {
+    position: static;
+    width: 100%;
+    min-height: 50px;
+    height: auto;
+    margin: inherit;
+    overflow: visible;
+    clip: auto;
+    padding: 15px;
+}
+
+.page-skip-link:focus {
+    min-height: 24px;
+}
+
 /* menus */
 .course-menu .nav>li>a {
     padding: 2px 2px 2px 5px;

--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -7,6 +7,12 @@
 
 {% prepare_course_menu %}
 
+<li>
+	<a href="#course-content" class="skip-link page-skip-link">
+		{% trans "Skip course navigation" %}
+	</a>
+</li>
+
 {% if instance.language|first == "|" %}
 <li role="presentation" class="header">
 	<div class="row">

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -18,7 +18,7 @@
 {% block content %}
 <div data-taggings="{{ get_taggings|join:' ' }}"  class="row">
     <div class="col-sm-2 hidden-xs">
-        <nav class="course-menu" id="main-course-menu">
+        <nav class="course-menu" id="main-course-menu" aria-label="{% trans "Course navigation" %}">
             <ul class="nav nav-pills nav-stacked">
                 {% include "course/_course_menu.html" %}
             </ul>
@@ -51,7 +51,7 @@
         </div>
         {% endcomment %}
     </div>
-    <div class="col-sm-10">
+    <div class="col-sm-10" id="course-content">
         {% block siblings %}{% endblock %}
         {% block breadcrumb %}
         <ol class="breadcrumb">

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-03 12:25+0300\n"
+"POT-Creation-Date: 2020-06-23 11:11+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Markku Riekkinen <markku.riekkinen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -260,7 +260,7 @@ msgstr "Valmis"
 msgid "Unlisted in table of contents"
 msgstr "Näkymätön sisällysluettelossa"
 
-#: course/models.py:680 course/models.py:806 templates/base.html:102
+#: course/models.py:680 course/models.py:806 templates/base.html:104
 msgid "Hidden"
 msgstr "Piilotettu"
 
@@ -382,44 +382,52 @@ msgstr "Seuraavat käyttäjät olivat jo ilmoittautuneet: {users}"
 msgid "Begin by enrolling in a course."
 msgstr "Aloita ilmoittautumalla jollekin kurssille."
 
-#: course/templates/course/_course_menu.html:14
-#: course/templates/course/_course_menu.html:38
+#: course/templates/course/_course_menu.html:11
+msgid "Course navigation"
+msgstr "Kurssivalikko"
+
+#: course/templates/course/_course_menu.html:12
+msgid "Skip course navigation"
+msgstr "Ohita kurssivalikko"
+
+#: course/templates/course/_course_menu.html:20
+#: course/templates/course/_course_menu.html:44
 #: edit_course/templates/edit_course/edit_course_base.html:26
 msgid "Course"
 msgstr "Kurssi"
 
-#: course/templates/course/_course_menu.html:18
+#: course/templates/course/_course_menu.html:24
 #: userprofile/templates/userprofile/profile.html:39
 msgid "Language"
 msgstr "Kieli"
 
-#: course/templates/course/_course_menu.html:51
+#: course/templates/course/_course_menu.html:57
 #: course/templates/course/_siblings.html:54
 #: exercise/templates/exercise/toc.html:7
 #: exercise/templates/exercise/toc.html:12
 msgid "Course materials"
 msgstr "Kurssimateriaali"
 
-#: course/templates/course/_course_menu.html:57
+#: course/templates/course/_course_menu.html:63
 #: exercise/templates/exercise/results.html:13
 msgid "Exercise results"
 msgstr "Pistetilanne"
 
-#: course/templates/course/_course_menu.html:66
+#: course/templates/course/_course_menu.html:72
 msgid "Form a group"
 msgstr "Luo uusi ryhmä"
 
-#: course/templates/course/_course_menu.html:94
+#: course/templates/course/_course_menu.html:100
 msgid "Apps"
 msgstr "Sovellukset"
 
-#: course/templates/course/_course_menu.html:108
+#: course/templates/course/_course_menu.html:114
 #: exercise/templates/exercise/_user_results.html:98
 #: exercise/templates/exercise/submission_plain.html:41
 msgid "Course staff"
 msgstr "Kurssihenkilökunta"
 
-#: course/templates/course/_course_menu.html:114
+#: course/templates/course/_course_menu.html:120
 #: course/templates/course/staff/enroll_students.html:16
 #: course/templates/course/staff/participants.html:6
 #: course/templates/course/staff/participants.html:11
@@ -427,7 +435,7 @@ msgstr "Kurssihenkilökunta"
 msgid "Participants"
 msgstr "Opiskelijat"
 
-#: course/templates/course/_course_menu.html:121
+#: course/templates/course/_course_menu.html:127
 #: course/templates/course/staff/group_delete.html:6
 #: course/templates/course/staff/group_delete.html:11
 #: course/templates/course/staff/group_edit.html:11
@@ -438,29 +446,29 @@ msgstr "Opiskelijat"
 msgid "Groups"
 msgstr "Ryhmät"
 
-#: course/templates/course/_course_menu.html:129
+#: course/templates/course/_course_menu.html:135
 #: diploma/templates/diploma/list.html:4 diploma/templates/diploma/list.html:8
 msgid "Grades"
 msgstr "Arvosanat"
 
-#: course/templates/course/_course_menu.html:137
+#: course/templates/course/_course_menu.html:143
 #: exercise/templates/exercise/staff/results.html:6
 #: exercise/templates/exercise/staff/results.html:11
 msgid "All results"
 msgstr "Kaikki pisteet"
 
-#: course/templates/course/_course_menu.html:144
+#: course/templates/course/_course_menu.html:150
 #: exercise/templates/exercise/staff/analytics.html:6
 #: exercise/templates/exercise/staff/analytics.html:11
 msgid "Visualizations"
 msgstr "Visualisoinnit"
 
-#: course/templates/course/_course_menu.html:152
+#: course/templates/course/_course_menu.html:158
 #: news/templates/news/edit.html:11 news/templates/news/list.html:11
 msgid "Edit news"
 msgstr "Muokkaa kurssiuutisia"
 
-#: course/templates/course/_course_menu.html:158
+#: course/templates/course/_course_menu.html:164
 #: edit_course/templates/edit_course/edit_content.html:8
 #: edit_course/templates/edit_course/edit_course_base.html:5
 #: edit_course/templates/edit_course/edit_course_base.html:11
@@ -774,7 +782,7 @@ msgstr "Ilmoita opiskelijoita kurssille"
 #: edit_course/templates/edit_course/usertag_delete.html:29
 #: edit_course/templates/edit_course/usertag_list.html:48
 #: external_services/templates/external_services/list_menu.html:68
-#: news/templates/news/list.html:53 templates/base.html:245
+#: news/templates/news/list.html:53 templates/base.html:247
 msgid "Remove"
 msgstr "Poista"
 
@@ -3507,61 +3515,69 @@ msgstr ""
 "Olet päätynyt tuntemattomasta syystä osoitteeseen, jota ei ole olemassa.Ole "
 "ystävällinen, ja yritä uudelleen."
 
-#: templates/base.html:81
+#: templates/base.html:77
+msgid "Main navigation"
+msgstr "Päävalikko"
+
+#: templates/base.html:77
+msgid "Skip main navigation"
+msgstr "Ohita päävalikko"
+
+#: templates/base.html:83
 msgid "Toggle navigation"
 msgstr "Näytä valikko"
 
-#: templates/base.html:105
+#: templates/base.html:107
 msgid "Select course"
 msgstr "Valitse kurssi"
 
-#: templates/base.html:123 userprofile/templates/userprofile/profile.html:6
+#: templates/base.html:125 userprofile/templates/userprofile/profile.html:6
 msgid "Profile"
 msgstr "Käyttäjätili"
 
-#: templates/base.html:129 templates/base.html:167
+#: templates/base.html:131 templates/base.html:169
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
-#: templates/base.html:138 templates/base.html:174
+#: templates/base.html:140 templates/base.html:176
 #: userprofile/templates/userprofile/login.html:90
 msgid "Log in"
 msgstr "Kirjaudu sisään"
 
-#: templates/base.html:149
+#: templates/base.html:151
 msgid "Site"
 msgstr "Sivusto"
 
-#: templates/base.html:153
+#: templates/base.html:155
 msgid "Home"
 msgstr "Etusivu"
 
-#: templates/base.html:198 userprofile/templates/userprofile/privacy.html:4
+#: templates/base.html:200 userprofile/templates/userprofile/privacy.html:4
 #: userprofile/templates/userprofile/privacy.html:9
 msgid "Privacy Notice"
 msgstr "Tietosuojailmoitus"
 
-#: templates/base.html:209 templates/base.html:228
+#: templates/base.html:211 templates/base.html:230
 msgid "Loading failed!"
 msgstr "Lataus epäonnistui!"
 
-#: templates/base.html:210 templates/base.html:229
+#: templates/base.html:212 templates/base.html:231
 msgid "Loading..."
 msgstr "Ladataan..."
 
-#: templates/base.html:217 templates/base.html:234
+#: templates/base.html:219 templates/base.html:236
 msgid "Close"
 msgstr "Sulje"
 
-#: templates/base.html:249
+#: templates/base.html:251
 msgid "Search"
 msgstr "Hae"
 
-#: templates/base.html:253
+#: templates/base.html:255
 msgid "No matches"
 msgstr "Ei osumia"
 
-#: templates/base.html:256
+#: templates/base.html:258
 msgid "Search for..."
 msgstr "Etsi..."
 
@@ -3599,12 +3615,12 @@ msgstr ""
 msgid "Password"
 msgstr "Salasana"
 
-#: userprofile/templates/userprofile/login.html:98
 #: userprofile/templates/userprofile/login.html:99
+#: userprofile/templates/userprofile/login.html:100
 msgid "Show more login options"
 msgstr "Näytä lisää kirjautumisvaihtoehtoja"
 
-#: userprofile/templates/userprofile/login.html:107
+#: userprofile/templates/userprofile/login.html:110
 #, python-format
 msgid "You may want to read our <a href=\"%(url)s\">privacy notice</a>."
 msgstr ""

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,8 +74,9 @@
         <meta name="msapplication-TileImage" content="{{ STATIC_URL }}mstile-144x144.png">
     </head>
     <body class="{% if profile %}{% if is_external_student %}external-student{% else %}internal-student{% endif %}{% endif %} lang-{{ request.LANGUAGE_CODE }}" data-view-tag="{% block view_tag %}{% endblock %}">
+        <a href="#content" class="skip-link">{% trans "Skip main navigation" %}</a>
         <div class="page-wrap">
-            <nav class="topbar navbar navbar-inverse navbar-static-top">
+            <nav class="topbar navbar navbar-inverse navbar-static-top" aria-label="{% trans "Main navigation" %}">
                 <div class="container-fluid">
                     <div class="navbar-header">
                         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar-collapse" aria-expanded="false">
@@ -181,7 +182,7 @@
                 </div>
             </nav>
 
-            <div class="site-content container-fluid">
+            <div class="site-content container-fluid" id="content">
                 {% site_alert %}
                 {% include "_messages.html" %}
                 {% block content %}


### PR DESCRIPTION
# Description

Adds two skip links - one at the top of the page which jumps
to the page contents, and another at the top of the "course menu"
which jumps to the course content.

As described in https://github.com/apluslms/a-plus/issues/559 this is really useful for keyboard users.

It would be sensible to merge this after #547 , as it doesn't have it's own focus state.

Here are a couple of screenshots of how it looks on top of the focus state from #547:

![Skip to content page link](https://user-images.githubusercontent.com/6674046/84254998-b0af4f80-ab1a-11ea-8049-d179ac6cca6a.png)

![Skip course menu link](https://user-images.githubusercontent.com/6674046/84255006-b3aa4000-ab1a-11ea-8a08-80bc85604c1c.png)

Fixes https://github.com/apluslms/a-plus/issues/559

# Testing

I've not tried any changes to the automatic tests for keyboard-only stuff here.

It can be tested manually by tabbing through the pages, and especially pages where the course menu is visible. 

# Have you updated the README or other relevant documentation?

I don't think it's necessary to add any specific documentation here. 

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
