### PR TITLE
Add missing html end tag to a template

### DIFF
--- a/course/templates/course/groups.html
+++ b/course/templates/course/groups.html
@@ -65,6 +65,7 @@
       </tr>
       {% endfor %}
     </table>
+  </div>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
# Description

The groups.html -template had a div-tag that was missing its end tag. This commit adds that missing end tag.

# Testing
All unit tests of the project except the broken test pass.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] ~I (developer) have created unit tests and the tests pass~
- [ ] ~I (developer) have created functional tests (Selenium tests) if applicable~
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] ~Customer/Teacher has accepted the implementation of the feature~
