### PR TITLE
Compress HTML pages in cache

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -43,7 +43,7 @@ Common system configuration
           postgresql memcached \
           uwsgi-core uwsgi-plugin-python3 \
           python3-virtualenv \
-          python3-psycopg2 python3-certifi python3-reportlab python3-reportlab-accel
+          python3-certifi python3-lz4 python3-psycopg2 python3-reportlab python3-reportlab-accel
 
  1. Create a new user for a-plus
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ git+https://github.com/Aalto-LeTech/django-colortag.git@2.1.1#egg=django-colorta
 feedparser~=5.2.1
 html5lib
 lxml ~= 4.3.2
+#lz4==3.1.0
 cachetools~=3.1.0
 icalendar~=4.0.3
 mimeparse~=0.1.3


### PR DESCRIPTION
# Description

- Exercise and chapter pages are stored in the cache and only update if the backend reports that there is a change. Some pages might be too large to fit in the cache (e.g. 1M), but do compress relatively well. Memcached API supports compression on the fly, but that is not usable over django API. This pull request adds lz4 compressor (https://pypi.org/project/lz4/) and zlib as backup (https://docs.python.org/3/library/zlib.html) to compress HTML exercise and chapter pages so that they can be stored in the cache, and decompress them before viewing.
- Compress and decompress functions can be changed easily by modifying the corresponding global variables in exercise.py.

Fixes #510 

# Testing

- The existing unit tests pass, I have not added new unit tests.
- Testing can be done manually by checking that the exercise and chapter pages load correctly, and by making these changes to settings.py file:
  - Move CACHES block into end of the file
  - Add into LOGGING/logger: 
```
  'aplus.cached': {
        'level': 'DEBUG',
    },
```
   Log shows now cache events, and it shouldn't say anywhere "Failed to store a value to the cache. It might be too big!".

# Have you updated the README or other relevant documentation?

- I don't think that documentation needs to be updated.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
