### PR TITLE
Add labels for local user login form

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -999,7 +999,6 @@ msgstr "Avaa 0 arvosanan diplomi"
 
 #: diploma/templates/diploma/list.html:26
 #: edit_course/templates/edit_course/signin_as_user.html:14
-#: userprofile/templates/userprofile/login.html:84
 #: userprofile/templates/userprofile/profile.html:35
 msgid "Username"
 msgstr "Käyttäjätunnus"
@@ -3617,12 +3616,8 @@ msgstr ""
 "Mikäli sinulla on tunnukset yksinomaan %(brand_name)s-palvelua varten, "
 "kirjaudu sisään tästä."
 
-#: userprofile/templates/userprofile/login.html:87
-msgid "Password"
-msgstr "Salasana"
-
-#: userprofile/templates/userprofile/login.html:99
-#: userprofile/templates/userprofile/login.html:100
+#: userprofile/templates/userprofile/login.html:93
+#: userprofile/templates/userprofile/login.html:94
 msgid "Show more login options"
 msgstr "Näytä lisää kirjautumisvaihtoehtoja"
 

--- a/userprofile/static/userprofile/extra_logins.js
+++ b/userprofile/static/userprofile/extra_logins.js
@@ -2,16 +2,18 @@
 
   function showExtras(event) {
     event.preventDefault();
-    const extras = $("#login-box-row").find(".extra-login")
+    const extras = $("#login-box-row").find(".extra-login");
     extras.show();
     $(".show-extra-login-btn").hide();
-    extras.find(":input:visible").first().focus() // focus for keyboard navigation
+    extras.find(":input:visible").first().focus(); // focus for keyboard navigation
   }
 
   $(function () {
-    const row = $("#login-box-row")
-    const normal = row.find(".login-box").not(".extra-login")
-    if (normal.length > 0) {
+    const row = $("#login-box-row");
+    const normal = row.find(".login-box").not(".extra-login");
+    const errors = row.find(".extra-login").find(".alert");
+    // if any of the extra logins have errors, none of them are hidden
+    if (normal.length > 0 && errors.length == 0) {
       row.find(".extra-login").hide();
       $(".show-extra-login-btn").on("click", showExtras).show();
 

--- a/userprofile/templates/userprofile/login.html
+++ b/userprofile/templates/userprofile/login.html
@@ -79,15 +79,9 @@
 					</p>
 					<form method="post" role="form">
 						{% csrf_token %}
-						{#{ form|bootstrap }#}
+						{{ form|bootstrap }}
 						<div class="form-group">
-							<input class="form-control" type="text" id="id_username" name="username" maxlength="254" placeholder="{% trans 'Username' %}">
-						</div>
-						<div class="form-group">
-							<input class="form-control" type="password" id="id_password" name="password" placeholder="{% trans 'Password' %}">
-						</div>
-						<div class="form-group">
-							<button type="submit" class="btn btn-default btn-block">{% trans "Log in" %}</button>
+							<button type="submit" class="btn btn-info btn-block">{% trans "Log in" %}</button>
 						</div>
 					</form>
 				</div>


### PR DESCRIPTION
# Description
Add labels to local user login form to support accessibility and fulfill accessibility standards. By switching the login form to use the Django form, also error messages and error handling are provided automatically.
Also change color of the login button to make it look more like a button.

Fixes #582 

# Testing

All existing unit tests pass (except the one broken one)

Manual tests:
- Works with keyboard navigation
- Works both in English and Finnish
- Works with a screen reader

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] ~I (developer) have created unit tests and the tests pass~
- [ ] ~I (developer) have created functional tests (Selenium tests) if applicable~
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
