### PR TITLE
Show all modules to course teachers and assistants in API endpoint

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -305,13 +305,10 @@ class UserTagging(models.Model):
         ordering = ['tag']
 
 
-def get_course_visibility_filter(user, prefix=None):
+def get_course_staff_visibility_filter(user, prefix=None):
     class OR(Q):
         default = Q.OR
-
-    filters = (
-        ('visible_to_students', True),
-    )
+    filters = ()
     if isinstance(user, User):
         user = user.userprofile
         filters += (
@@ -341,7 +338,10 @@ class CourseInstanceManager(models.Manager):
         if not user or not user.is_authenticated:
             return self.filter(visible_to_students=True)
         if not user.is_superuser:
-            return self.filter(get_course_visibility_filter(user)).distinct()
+            return self.filter(
+                get_course_staff_visibility_filter(user)
+                | Q(visible_to_students=True),
+            ).distinct()
         return self.all()
 
 
@@ -662,8 +662,8 @@ class CourseModuleManager(models.Manager):
             )
         if not user.is_superuser:
             return self.filter(
-                get_course_visibility_filter(user, 'course_instance__'),
-                opening_time__lte=timezone.now(),
+                get_course_staff_visibility_filter(user, 'course_instance__')
+                | Q(course_instance__visible_to_students=True, opening_time__lte=timezone.now()),
             ).distinct()
         return self.all()
 


### PR DESCRIPTION

# Show unopened modules to teachers

Show all modules to course teachers and assistants in API endpoint
`/api/v2/courses/ID/exercises/`even if not open yet.

Previously unopened modules were hidden from everyone instead of only
students.

Fixes #549 

# Testing
API endpoint has been tested for all user types.
# Have you updated the README or other relevant documentation?

Not relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
