### PR TITLE
Front page flex-box

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -311,12 +311,21 @@ html, body {
     font-size: 18px;
 }
 
+.frontpage-section {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+    width: 100%;
+}
+
 .frontpage .card {
-    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    width: 400px;
     border: solid 1px #ccc;
-    position: relative;
-    height: 355px;
     border-radius: 4px;
+    margin: 8px;
+    margin-bottom: 20px;
     padding: 4px;
 }
 
@@ -325,8 +334,36 @@ html, body {
     border-color: #bce8f1;
 }
 
+@media (min-width: 1200px) and (max-width: 1800px) {
+    .frontpage .card {
+        width: 23%;
+    }
+}
+
+@media (min-width: 960px) and (max-width: 1199px) {
+    .frontpage .card {
+        width: 30%;
+    }
+}
+
+@media (min-width: 670px) and (max-width: 959px) {
+    .frontpage .card {
+        width: 47%;
+    }
+}
+
+@media (max-width: 669px) {
+    .frontpage .card {
+        width: 100%;
+    }
+}
+
 .frontpage a:hover {
     text-decoration: none;
+}
+
+.frontpage .card-clickable {
+    flex-grow: 1;
 }
 
 .frontpage .card-clickable:hover {
@@ -347,8 +384,12 @@ html, body {
     background-color:#eeeeee;
 }
 
+.frontpage .advert-image,
 .frontpage .course-image {
     position: relative;
+}
+
+.frontpage .course-image {
     color: #fff;
 }
 
@@ -375,11 +416,9 @@ html, body {
 }
 
 .frontpage .card-footer {
-    position: absolute;
-    bottom: 0px;
-    left: 0px;
+    padding: 10px 10px 14px 14px;
     width: 100%;
-    padding: 14px;
+    flex-shrink: 0;
 }
 
 .archive-link {

--- a/course/templates/course/_course_cards.html
+++ b/course/templates/course/_course_cards.html
@@ -3,8 +3,7 @@
 
 {% for instance in instances %}
 {% with instance_url=instance|url %}
-<div class="col-sm-6 col-md-4 col-lg-3">
-	<div class="frontpage-course card">
+	<div class="frontpage card">
 		<div class="card-clickable">
 			<a href="{{ instance_url }}">
 				<div class="course-image" aria-hidden="true">
@@ -45,6 +44,5 @@
 			{% endif %}
 		</div>
 	</div>
-</div>
 {% endwith %}
 {% endfor %}

--- a/course/templates/course/index.html
+++ b/course/templates/course/index.html
@@ -36,19 +36,19 @@
 		{% if advert %}
 			<div class="frontpage advert-card card">
 				<a href="{{ advert.href }}" target="_blank">
-						<div class="advert-image" aria-hidden="true">
-							{% if advert.image %}
-								<img class="card-img-top" src="{{ advert.image }}" alt="" />
-							{% else %}
-								<div class="card-img-top">
-									<i class="glyphicon glyphicon-comment"></i>
-								</div>
-							{% endif %}
-						</div>
-						<div class="card-body">
-							<h3 class="card-title">{{ advert.title }}</h3>
-							<p class="card-text">{{ advert.text|safe }}</p>
-						</div>
+					<div class="advert-image" aria-hidden="true">
+						{% if advert.image %}
+							<img class="card-img-top" src="{{ advert.image }}" alt="" />
+						{% else %}
+							<div class="card-img-top">
+								<i class="glyphicon glyphicon-comment"></i>
+							</div>
+						{% endif %}
+					</div>
+					<div class="card-body">
+						<h3 class="card-title">{{ advert.title }}</h3>
+						<p class="card-text">{{ advert.text|safe }}</p>
+					</div>
 				</a>
 			</div>
 		{% endif %}

--- a/course/templates/course/index.html
+++ b/course/templates/course/index.html
@@ -16,9 +16,9 @@
 	<div class="frontpage-panel">
 		<h2 class="panel-heading">{% trans "My courses" %}</h2>
 		{% if my_instances %}
-			<div class="row frontpage">
+			<section class="frontpage frontpage-section">
 				{% include "course/_course_cards.html" with instances=my_instances %}
-			</div>
+			</section>
 		{% else %}
 			<div class="panel-body">
 				<p class="panel-default-text">
@@ -31,12 +31,11 @@
 
 <div class="frontpage-panel">
 	<h2 class="panel-heading">{% trans "All ongoing courses" %}</h2>
-	<div class="row frontpage">
+	<section class="frontpage frontpage-section">
 		{% site_advert as advert %}
 		{% if advert %}
-			<div class="col-sm-6 col-md-4 col-lg-3">
+			<div class="frontpage advert-card card">
 				<a href="{{ advert.href }}" target="_blank">
-					<div class="card advert-card">
 						<div class="advert-image" aria-hidden="true">
 							{% if advert.image %}
 								<img class="card-img-top" src="{{ advert.image }}" alt="" />
@@ -50,14 +49,13 @@
 							<h3 class="card-title">{{ advert.title }}</h3>
 							<p class="card-text">{{ advert.text|safe }}</p>
 						</div>
-					</div>
 				</a>
 			</div>
 		{% endif %}
 		{% if all_instances %}
 			{% include "course/_course_cards.html" with instances=all_instances %}
 		{% endif %}
-	</div>
+	</section>
 	{% if not all_instances and not siteadvert %}
 		<div class="panel-body">
 			<p class="panel-default-text">

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-30 09:07+0300\n"
+"POT-Creation-Date: 2020-07-03 10:03+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Saara Satokangas <saara.satokangas@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -378,7 +378,7 @@ msgstr "Muutosten tallentaminen epäonnistui."
 msgid "The following users were already enrolled: {users}"
 msgstr "Seuraavat käyttäjät olivat jo ilmoittautuneet: {users}"
 
-#: course/templates/course/_course_cards.html:29
+#: course/templates/course/_course_cards.html:28
 #: course/templates/course/archive.html:23
 msgid "Hidden from students"
 msgstr "Piilotettu opiskelijoilta"
@@ -685,11 +685,11 @@ msgstr "Sinulla ei ole käynnissä olevia kursseja."
 msgid "All ongoing courses"
 msgstr "Kaikki kurssit"
 
-#: course/templates/course/index.html:64
+#: course/templates/course/index.html:62
 msgid "There are currently no active courses."
 msgstr "Tällä hetkellä ei ole käynnissä olevia kursseja."
 
-#: course/templates/course/index.html:72
+#: course/templates/course/index.html:70
 #, python-format
 msgid "Old courses can be found at the <a href=\"%(url)s\">course archive</a>."
 msgstr "Vanhat kurssit ovat nähtävissä <a href=\"%(url)s\">kurssiarkistossa</a>."


### PR DESCRIPTION
# Description

In order to better accommodate longer course and course instance -names, the bootstrap3 row-column-grid is removed from front page sections and flex-box is applied instead. This enables the course cards to grow vertically.

Four media-breakpoints have been applied, so that the width of the cards would look good with different screens.

The second commit 57e54963a is only to fix the indendation of the adverts, so that the changes made in the first commit can be more easily spotted.

Fixes #583

**Desktop width**

![Screenshot from 2020-07-03 10-17-35](https://user-images.githubusercontent.com/43036333/86444133-faa1e480-bd18-11ea-8735-e502dab9dc3c.png)

**Tablet width**

![Screenshot from 2020-07-03 10-18-48](https://user-images.githubusercontent.com/43036333/86444142-fe356b80-bd18-11ea-9bff-cab109ec7351.png)

**Mobile width**

![Screenshot from 2020-07-03 10-19-14](https://user-images.githubusercontent.com/43036333/86444148-01305c00-bd19-11ea-828b-25590f1eb18d.png)




# Testing

- The appearance after changes has been tested on Chrome and Firefox and different screen widths.
- The appearance has also been tested with Lambdatest on Edge and IE. 
- It has also been tested for very long and very short course and course instance names
- Appearance has been tested when there are very few course instances and very many instances.
- The appearance has been tested also in case there is a site-wide advert present

# Have you updated the README or other relevant documentation?

Not relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
