### PR TITLE
Add landmark roles to the template

### DIFF
--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -17,7 +17,7 @@
 <li role="presentation" class="header">
 	<div class="row">
     <div class="col-sm-10">
-			<h4>{% trans "Course" %}</h4>
+			<h4 id="course-menu-heading">{% trans "Course" %}</h4>
     </div>
     <div class="col-sm">
 			<div class="dropdown h4">
@@ -41,7 +41,7 @@
 </li>
 {% else %}
 <li role="presentation" class="header">
-	<h4>{% trans "Course" %}</h4>
+	<h4 id="course-menu-heading">{% trans "Course" %}</h4>
 </li>
 {% endif %}
 

--- a/course/templates/course/_siblings.html
+++ b/course/templates/course/_siblings.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load course %}
 {% load exercise %}
-<nav class="row siblings">
+<nav class="row siblings" aria-label="{% trans "Pagination" %}">
 
     {% if next %}
     {% if next.submittable %}

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -13,12 +13,20 @@
 {% endfor %}
 {% endblock %}
 
+{% block container_opening_tag %}
+<div class="site-content container-fluid" id="content">                
+{% endblock %}
+
+{% block container_closing_tag %}
+</div>                
+{% endblock %}
+
 {% block title %}{{ course.name|parse_localization }} | {{ block.super }} {% endblock %}
 
 {% block content %}
 <div data-taggings="{{ get_taggings|join:' ' }}"  class="row">
     <div class="col-sm-2 hidden-xs">
-        <nav class="course-menu" id="main-course-menu" aria-label="{% trans "Course navigation" %}">
+        <nav class="course-menu" id="main-course-menu" aria-labelledby="course-menu-heading">
             <ul class="nav nav-pills nav-stacked">
                 {% include "course/_course_menu.html" %}
             </ul>
@@ -60,7 +68,7 @@
             {% endblock %}
         </ol>
         {% endblock %}
-        <div class="row">
+        <main class="row">
             {% block columns %}
             <div class="col-lg-9">
                 {% block coursecontent %}
@@ -71,7 +79,7 @@
                 {% endblock %}
             </div>
             {% endblock %}
-        </div>
+        </main>
         {% block siblings_bottom %}{% endblock %}
     </div>
 </div>

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-03 10:03+0300\n"
+"POT-Creation-Date: 2020-07-14 12:07+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Saara Satokangas <saara.satokangas@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -576,6 +576,10 @@ msgstr ""
 "          Palauta ryhmässä: %(collaborators)s\n"
 "          "
 
+#: course/templates/course/_siblings.html:4
+msgid "Pagination"
+msgstr "Sivuilla siirtyminen"
+
 #: course/templates/course/_siblings.html:22
 #: course/templates/course/_siblings.html:45
 #: exercise/templates/exercise/_children.html:28
@@ -590,11 +594,7 @@ msgstr "Aikainen pääsy"
 msgid "Course archive"
 msgstr "Kurssiarkisto"
 
-#: course/templates/course/course_base.html:21
-msgid "Course navigation"
-msgstr "Kurssivalikko"
-
-#: course/templates/course/course_base.html:34
+#: course/templates/course/course_base.html:42
 msgid "Read more"
 msgstr "Lue lisää"
 
@@ -3504,8 +3504,8 @@ msgstr ""
 msgid "Skip main navigation"
 msgstr "Ohita päävalikko"
 
-#: templates/base.html:79
-msgid "Main navigation"
+#: templates/base.html:80
+msgid "Main"
 msgstr "Päävalikko"
 
 #: templates/base.html:83

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,131 +76,139 @@
     <body class="{% if profile %}{% if is_external_student %}external-student{% else %}internal-student{% endif %}{% endif %} lang-{{ request.LANGUAGE_CODE }}" data-view-tag="{% block view_tag %}{% endblock %}">
         <a href="#content" class="skip-link">{% trans "Skip main navigation" %}</a>
         <div class="page-wrap">
-            <nav class="topbar navbar navbar-inverse navbar-static-top" aria-label="{% trans "Main navigation" %}">
-                <div class="container-fluid">
-                    <div class="navbar-header">
-                        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar-collapse" aria-expanded="false">
-                            <span class="sr-only">{% trans "Toggle navigation" %}</span>
-                            {% notification_count as n_count %}
-                            {% if n_count > 0 %}
-                            <span class="badge badge-danger pull-right">{{ n_count }}</span>
-                            {% endif %}
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                        </button>
-                        <a class="navbar-brand hidden-xs" href="{% url 'home' %}">{% brand_name %}</a>
-                        <span class="navbar-brand visible-xs">
-                        {% brand_name %}{% if instance %} &nbsp; {{ course.name|parse_localization }}{% endif %}
-                        </span>
-                    </div>
-                    <div class="collapse navbar-collapse" id="bs-navbar-collapse">
-                        <ul class="nav navbar-nav hidden-xs">
-                            <li role="presentation" class="dropdown">
-                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                    {% if instance %}
-                                    {{ course|parse_localization }}
-                                    {% if not instance.visible_to_students %}
-                                    <span class="label label-danger">{% trans "Hidden" %}</span>
-                                    {% endif %}
-                                    {% else %}
-                                    {% trans "Select course" %}
-                                    {% endif %}
-                                    <span class="caret"></span>
-                                </a>
-                                {% course_menu %}
-                            </li>
-                        </ul>
-                        <ul class="user-menu nav navbar-nav navbar-right hidden-xs">
-                            {% if user.is_authenticated %}
-                            {% group_select %}
-                            {% notification_menu %}
-                            <li role="presentation" class="profile-menu dropdown">
-                              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-                                {{ user.first_name }} {{ user.last_name }} <span class="caret"></span>
-                              </a>
-                              <ul class="dropdown-menu">
-                                <li role="presentation">
-                                    <a href="{% url 'profile' %}">{% trans "Profile" %}</a>
+            <header>
+                <nav class="topbar navbar navbar-inverse navbar-static-top" aria-label="{% trans "Main" %}">
+                    <div class="container-fluid">
+                        <div class="navbar-header">
+                            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar-collapse" aria-expanded="false">
+                                <span class="sr-only">{% trans "Toggle navigation" %}</span>
+                                {% notification_count as n_count %}
+                                {% if n_count > 0 %}
+                                <span class="badge badge-danger pull-right">{{ n_count }}</span>
+                                {% endif %}
+                                <span class="icon-bar"></span>
+                                <span class="icon-bar"></span>
+                                <span class="icon-bar"></span>
+                            </button>
+                            <a class="navbar-brand hidden-xs" href="{% url 'home' %}">{% brand_name %}</a>
+                            <span class="navbar-brand visible-xs">
+                            {% brand_name %}{% if instance %} &nbsp; {{ course.name|parse_localization }}{% endif %}
+                            </span>
+                        </div>
+                        <div class="collapse navbar-collapse" id="bs-navbar-collapse">
+                            <ul class="nav navbar-nav hidden-xs">
+                                <li role="presentation" class="dropdown">
+                                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                                        {% if instance %}
+                                        {{ course|parse_localization }}
+                                        {% if not instance.visible_to_students %}
+                                        <span class="label label-danger">{% trans "Hidden" %}</span>
+                                        {% endif %}
+                                        {% else %}
+                                        {% trans "Select course" %}
+                                        {% endif %}
+                                        <span class="caret"></span>
+                                    </a>
+                                    {% course_menu %}
                                 </li>
-                                <li role="separator" class="divider"></li>
-                                <li role="presentation">
-                                  <a href="{% url 'logout' %}">
-                                    <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
-                                    {% trans "Log out"%}
-                                  </a>
-                                </li>
-                              </ul>
-                            </li>
-                            {% else %}
-                            <li role="presentation">
-                                <a href="{% url 'login' %}">
-                                    <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-                                    {% trans "Log in"%}
-                                </a>
-                            </li>
-                            {% endif %}
-                        </ul>
-
-                        {# Separate menu optimized for mobile users #}
-                        <ul class="nav navbar-nav visible-xs">
-                            {% notification_menu %}
-                            {% group_select %}
-                            {% block mobilemenu %}{% endblock %}
-                            <li role="presentation" class="header"><h4>{% trans "Site" %}</h4></li>
-                            <li role="presentation">
-                                <a href="{% url 'home' %}">
-                                    <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
-                                    {% trans "Home" %}
-                                </a>
-                            </li>
-                            {% course_menu %}
-                            {% if user.is_authenticated %}
-                            <li role="presentation">
-                                <a href="{% url 'profile' %}">
+                            </ul>
+                            <ul class="user-menu nav navbar-nav navbar-right hidden-xs">
+                                {% if user.is_authenticated %}
+                                {% group_select %}
+                                {% notification_menu %}
+                                <li role="presentation" class="profile-menu dropdown">
+                                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                     <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-                            	    {{ user.first_name }} {{ user.last_name }}
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a href="{% url 'logout' %}">
-                                    <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
-                            	    {% trans "Log out"%}
-                                </a>
-                            </li>
-                            {% else %}
-                            <li role="presentation">
-                                <a href="{% url 'login' %}">
-                                    <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-                                    {% trans "Log in" %}
-                                </a>
-                            </li>
-                            {% endif %}
-                        </ul>
+                                    {{ user.first_name }} {{ user.last_name }} <span class="caret"></span>
+                                  </a>
+                                  <ul class="dropdown-menu">
+                                    <li role="presentation">
+                                        <a href="{% url 'profile' %}">{% trans "Profile" %}</a>
+                                    </li>
+                                    <li role="separator" class="divider"></li>
+                                    <li role="presentation">
+                                      <a href="{% url 'logout' %}">
+                                        <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
+                                        {% trans "Log out"%}
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </li>
+                                {% else %}
+                                <li role="presentation">
+                                    <a href="{% url 'login' %}">
+                                        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+                                        {% trans "Log in"%}
+                                    </a>
+                                </li>
+                                {% endif %}
+                            </ul>
+    
+                            {# Separate menu optimized for mobile users #}
+                            <ul class="nav navbar-nav visible-xs">
+                                {% notification_menu %}
+                                {% group_select %}
+                                {% block mobilemenu %}{% endblock %}
+                                <li role="presentation" class="header"><h4>{% trans "Site" %}</h4></li>
+                                <li role="presentation">
+                                    <a href="{% url 'home' %}">
+                                        <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+                                        {% trans "Home" %}
+                                    </a>
+                                </li>
+                                {% course_menu %}
+                                {% if user.is_authenticated %}
+                                <li role="presentation">
+                                    <a href="{% url 'profile' %}">
+                                        <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+                                        {{ user.first_name }} {{ user.last_name }}
+                                    </a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="{% url 'logout' %}">
+                                        <span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
+                                        {% trans "Log out"%}
+                                    </a>
+                                </li>
+                                {% else %}
+                                <li role="presentation">
+                                    <a href="{% url 'login' %}">
+                                        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+                                        {% trans "Log in" %}
+                                    </a>
+                                </li>
+                                {% endif %}
+                            </ul>
+                        </div>
                     </div>
-                </div>
-            </nav>
+                </nav>
+            </header>
 
-            <div class="site-content container-fluid" id="content">
-                {% site_alert %}
+            {% block container_opening_tag %}
+            <main class="site-content container-fluid" id="content">                
+            {% endblock %}
+            {% site_alert %}
                 {% include "_messages.html" %}
                 {% block content %}
                     <div class="error">
                         No content
                     </div>
                 {% endblock %}
-            </div>
+            {% block container_closing_tag %}
+            </main>                
+            {% endblock %}
 
             {% block footer %}
-            <nav class="site-footer navbar navbar-default navbar-fixed-bottom">
-                <div class="container-fluid">
-                    <ul class="nav navbar-nav">
-                        {% block footercontent %}{% endblock %}
-                        <li role="presentation"><a href="{% url 'privacy_notice' %}">{% trans "Privacy Notice" %}</a></li>
-                    </ul>
+            <footer role="contentinfo">
+                <div class="site-footer navbar navbar-default navbar-fixed-bottom" role="presentation">
+                    <div class="container-fluid">
+                        <ul class="nav navbar-nav">
+                            {% block footercontent %}{% endblock %}
+                            <li><a href="{% url 'privacy_notice' %}">{% trans "Privacy Notice" %}</a></li>
+                        </ul>
+                    </div>
                 </div>
-            </nav>
+            </footer>
             {% endblock %}
         </div>
         <div id="page-modal" class="modal" role="dialog">


### PR DESCRIPTION
# Description

The previous audit highlighted that we have very few landmark roles in use. These are useful for giving semantic strucutre to the page and some assistive technology users will use them to "jump" from element to element around the page (similar to the skip links). 

One particular challenge here was that we need `main` to include the content. On all non-course pages, that's everything after the main navigation, but on course pages it starts after the course navigation. For this reason, there's an optional block which can be defined to override the usual `<main>` tag, for example, with a semantic-free `<div>` or any other element as needed. This is currently only defined for the course template. 

Fixes #595 

# Testing

If you're not familiar with landmarks, I suggest starting with [W3Cs example pages](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/index.html), which can highlight them and also explains how they should be used, then WAVE can show you where they are, and shows them in the "Structure" tab. 

I also suggest reviewers test this manually with a screen reader. 

# Have you updated the README or other relevant documentation?

It might be useful to make a note of how to override the `<main>` somewhere, but we don't yet have a good place for that. 

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
