### PR TITLE
Move max submissions to BriefExerciseSerializer

### DIFF
--- a/exercise/api/custom_serializers.py
+++ b/exercise/api/custom_serializers.py
@@ -62,6 +62,7 @@ class ExercisePointsSerializer(serializers.Serializer):
             'max_points',
             'points_to_pass',
             'submission_count',
+            'max_submissions',
             # best submission
             'points',
             'passed',

--- a/exercise/api/custom_serializers.py
+++ b/exercise/api/custom_serializers.py
@@ -62,7 +62,6 @@ class ExercisePointsSerializer(serializers.Serializer):
             'max_points',
             'points_to_pass',
             'submission_count',
-            'max_submissions',
             # best submission
             'points',
             'passed',

--- a/exercise/api/full_serializers.py
+++ b/exercise/api/full_serializers.py
@@ -63,8 +63,6 @@ class ExerciseSerializer(ExerciseBriefSerializer):
             'course',
             'is_submittable',
             'post_url',
-            'max_points',
-            'max_submissions',
             'exercise_info',
             'templates',
             'submissions',

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -21,10 +21,6 @@ class ExerciseBriefSerializer(AplusModelSerializer):
         lookup_map='exercise.api.views.ExerciseViewSet',
     )
     display_name = serializers.CharField(source='__str__')
-    max_submissions_for_student = serializers.SerializerMethodField()
-
-    def get_max_submissions_for_student(self, obj):
-        return obj.max_submissions_for_student(self.context['request'].user.userprofile)
 
     class Meta(AplusModelSerializer.Meta):
         model = BaseExercise
@@ -32,7 +28,8 @@ class ExerciseBriefSerializer(AplusModelSerializer):
             'url',
             'html_url',
             'display_name',
-            'max_submissions_for_student',
+            'max_points',
+            'max_submissions',
         )
 
 

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -21,6 +21,10 @@ class ExerciseBriefSerializer(AplusModelSerializer):
         lookup_map='exercise.api.views.ExerciseViewSet',
     )
     display_name = serializers.CharField(source='__str__')
+    max_submissions_for_student = serializers.SerializerMethodField()
+
+    def get_max_submissions_for_student(self, obj):
+        return obj.max_submissions_for_student(self.context['request'].user.userprofile)
 
     class Meta(AplusModelSerializer.Meta):
         model = BaseExercise
@@ -28,6 +32,7 @@ class ExerciseBriefSerializer(AplusModelSerializer):
             'url',
             'html_url',
             'display_name',
+            'max_submissions_for_student',
         )
 
 


### PR DESCRIPTION
# Description

Move `max_submissions` and `max_points` from `ExerciseSerializer` to `BriefExerciseSerializer`. 

Fixes #605 

# Testing
API endpoints have been manually tested
# Have you updated the README or other relevant documentation?

Not relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
