### PR TITLE
Handle invalid JSON in check_submission_allowed

### DIFF
--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -581,7 +581,8 @@ class BaseExercise(LearningObject):
             try:
                 group_id = json.loads(request.POST.get('__aplus__', '{}')).get('group')
             except json.JSONDecodeError:
-                pass
+                warnings.append(_("Cannot submit exercise because of invalid JSON in POST data"))
+                return self.SUBMIT_STATUS.INVALID, warnings, students
             if not group_id:
                 group_id = request.POST.get("_aplus_group")
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1871,7 +1871,11 @@ msgstr "Henkilökunta voi palauttaa tehtäviä ilmoittautumatta."
 msgid "You must enroll in the course to submit exercises."
 msgstr "Palauttaaksesi tehtäviä sinun pitää ilmoittautua kurssille."
 
-#: exercise/exercise_models.py:595
+#: exercise/exercise_models.py:584
+msgid "Cannot submit exercise because of invalid JSON in POST data"
+msgstr "Tehtävää ei voitu palauttaa, POST pyyntö sisälsi virheellistä JSON:nia"
+
+#: exercise/exercise_models.py:605
 msgid "Group can only change between different exercises."
 msgstr "Ryhmää voi vaihtaa vain eri tehtävien välissä."
 


### PR DESCRIPTION
# Description

Return an error message if POST data contains invalid JSON, when
getting group id in `_check_submission_allowed`.

Earlier this error was silently ignored, meaning that a user would
have gotten an error about how something is wrong with their group,
when it's really caused by a syntax error in the data.


Fixes #613

# Testing

Changes have been manually tested.

# Have you updated the README or other relevant documentation?

Not relevant

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
