### PR TITLE
Save language in submission even if not provided

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -474,6 +474,14 @@ class CourseInstance(UrlMixin, models.Model):
     def is_valid_language(self, lang):
         return lang == "" or lang in [key for key,name in settings.LANGUAGES]
 
+    @property
+    def default_language(self):
+        language = self.language
+        language_code = language.lstrip('|').split('|', 1)[0]
+        if language_code:
+            return language_code
+        return settings.LANGUAGE_CODE.split('-', 1)[0]
+
     def save(self, *args, **kwargs):
         """
         Saves the model.

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -705,7 +705,7 @@ class BaseExercise(LearningObject):
         Loads the exercise feedback page.
         """
         # Get the language from the submission
-        language = submission.lang or get_language()
+        language = submission.lang or self.course_module.course_instance.default_language
 
         submission_url = update_url_params(
             api_reverse("submission-grader", kwargs={

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -8,7 +8,7 @@ from django.core.files.storage import default_storage
 from django.db import models, DatabaseError
 from django.db.models.signals import post_delete
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language, ugettext_lazy as _
 from mimetypes import guess_type
 
 from lib.fields import JSONField, PercentField
@@ -38,6 +38,9 @@ class SubmissionManager(models.Manager):
             meta_data_dict = json.loads(request.POST.get('__aplus__', '{}'))
         except json.JSONDecodeError:
             raise ValueError("The content of the field __aplus__ is not valid json")
+        if 'lang' not in meta_data_dict:
+            meta_data_dict['lang'] = get_language()
+
         try:
             new_submission = Submission.objects.create(
                 exercise=exercise,


### PR DESCRIPTION
# Description

Save language to submission `meta_data` even if not provided. This way the language 
is consistent when regrading a submission where language data isn't given.

Fixes #611

# Testing

Changes have been tested manually.

# Have you updated the README or other relevant documentation?

Not relevant.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
