### PR TITLE
Fix the broken selenium-test-locator

### DIFF
--- a/selenium_test/test/locators.py
+++ b/selenium_test/test/locators.py
@@ -13,7 +13,7 @@ class FirstPageLocators(object):
 
 class BasePageLocators(object):
     COURSE_BANNER = (By.XPATH, "//*[@id='bs-navbar-collapse']/ul[1]/li[1]/a")
-    FOOTER = (By.XPATH, "//nav[contains(@class, 'site-footer')]")
+    FOOTER = (By.XPATH, "//div[contains(@class, 'site-footer')]")
     HOME_LINK = (By.XPATH, "//*[contains(@class, 'course-menu')]/ul/li[contains(@class, 'menu-home')]/a")
     CALENDAR_FEED_LINK = (By.XPATH, "//*[contains(@class, 'calendar-view')]/p/a[contains(@href, '/export-calendar/')]")
     RESULTS_LINK = (By.XPATH, "//*[contains(@class, 'course-menu')]/ul/li[contains(@class, 'menu-results')]/a")


### PR DESCRIPTION
# Description

One of the items on BasePageLocators referenced to a `<nav>`, which
had been replaced by a `<div>` in https://github.com/apluslms/a-plus/commit/426a0c727c5b718754c0e48d8d4aecdc1028bd45. It broke the selenium-tests. This fixes that.

# Testing

All selenium-tests and unit-tests pass now.

# Have you updated the README or other relevant documentation?

Not relevant 

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?


- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x ] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
