### PR TITLE
Past instance notification

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,6 +75,21 @@ table.src tr td.src {
     outline: 3px solid #ffdd00 !important;
 }
 
+/* alerts */
+.sticky-alert {
+    position: -webkit-sticky; /* Safari */
+    position: sticky;
+    top: 0;
+    overflow: hidden;
+    z-index: 100;
+}
+
+.alert-default {
+    background-color: #fff;
+    color: #333;
+    border: 2px solid #333;
+    font-weight: bold;
+}
 
 /* site footer */
 html, body {

--- a/course/templates/course/_enroll_form.html
+++ b/course/templates/course/_enroll_form.html
@@ -2,42 +2,42 @@
 {% load course %}
 
 {% if not is_student and not instance.is_past and not instance.has_enrollment_closed %}
-<div class="alert alert-info">
-{% if enrollable or is_course_staff %}
-  {% if instance.is_enrollment_open %}
-  <form method="post" action="{{ instance|url:'enroll' }}">
-    {% csrf_token %}
-    {% if instance.view_content_to > 1 %}
-    {% trans "In order to submit exercises you must enroll in the course." %}
-    {% else %}
-    {% trans "In order to submit exercises and see material, you must enroll in the course." %}
-    {% endif %}
-    <input type="submit" value="{% trans 'Enroll' %}" class="btn btn-info">
-    {% if instance.enrollment_ending_time %}
-    <div>
-      <small>
-        {% blocktrans with end=instance.enrollment_ending_time %}
-        The course enrollment is open until {{ end }}.
-        {% endblocktrans %}
-      </small>
-    </div>
-    {% endif %}
-  </form>
-  {% elif instance.has_enrollment_closed %}
-  {% trans "Unfortunately, enrolling in the course has ended." %}
-  {% else %}
-  {% blocktrans with start=instance.enrollment_start end=instance.enrollment_end %}
-  The course opens {{ start }}.
-  {% endblocktrans %}
-  {% endif %}
-{% elif profile %}
-  {% if instance.view_content_to < 3 %}
-  {% trans "Unfortunately, you may not enroll in this course and you may not explore the contents either." %}
-  {% else %}
-  {% trans "Unfortunately, you cannot enroll in this course, but you may explore the course material." %}
-  {% endif %}
-{% else %}
-  {% trans "Login is required to submit exercises, but you may anonymously explore the course material." %}
-{% endif %}
+	<div class="alert alert-info">
+	{% if enrollable or is_course_staff %}
+		{% if instance.is_enrollment_open %}
+			<form method="post" action="{{ instance|url:'enroll' }}">
+				{% csrf_token %}
+				{% if instance.view_content_to > 1 %}
+					{% trans "In order to submit exercises you must enroll in the course." %}
+				{% else %}
+					{% trans "In order to submit exercises and see material, you must enroll in the course." %}
+				{% endif %}
+				<input type="submit" value="{% trans 'Enroll' %}" class="btn btn-info">
+				{% if instance.enrollment_ending_time %}
+					<div>
+						<small>
+							{% blocktrans with end=instance.enrollment_ending_time %}
+							The course enrollment is open until {{ end }}.
+							{% endblocktrans %}
+						</small>
+					</div>
+				{% endif %}
+			</form>
+		{% elif instance.has_enrollment_closed %}
+			{% trans "Unfortunately, enrolling in the course has ended." %}
+		{% else %}
+			{% blocktrans with start=instance.enrollment_start end=instance.enrollment_end %}
+				The course opens {{ start }}.
+			{% endblocktrans %}
+		{% endif %}
+	{% elif profile %}
+		{% if instance.view_content_to < 3 %}
+			{% trans "Unfortunately, you may not enroll in this course and you may not explore the contents either." %}
+		{% else %}
+			{% trans "Unfortunately, you cannot enroll in this course, but you may explore the course material." %}
+		{% endif %}
+	{% else %}
+		{% trans "Login is required to submit exercises, but you may anonymously explore the course material." %}
+	{% endif %}
 </div>
 {% endif %}

--- a/course/templates/course/_enroll_form.html
+++ b/course/templates/course/_enroll_form.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load course %}
 
-{% if not is_student %}
+{% if not is_student and not instance.is_past and not instance.has_enrollment_closed %}
 <div class="alert alert-info">
 {% if enrollable or is_course_staff %}
   {% if instance.is_enrollment_open %}

--- a/course/templates/course/_enroll_form.html
+++ b/course/templates/course/_enroll_form.html
@@ -16,7 +16,7 @@
 				{% if instance.enrollment_ending_time %}
 					<div>
 						<small>
-							{% blocktrans with end=instance.enrollment_ending_time %}
+							{% blocktrans trimmed with end=instance.enrollment_ending_time %}
 							The course enrollment is open until {{ end }}.
 							{% endblocktrans %}
 						</small>
@@ -26,7 +26,7 @@
 		{% elif instance.has_enrollment_closed %}
 			{% trans "Unfortunately, enrolling in the course has ended." %}
 		{% else %}
-			{% blocktrans with start=instance.enrollment_start end=instance.enrollment_end %}
+			{% blocktrans trimmed with start=instance.enrollment_start end=instance.enrollment_end %}
 				The course opens {{ start }}.
 			{% endblocktrans %}
 		{% endif %}

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -60,6 +60,21 @@
         {% endcomment %}
     </div>
     <div class="col-sm-10" id="course-content">
+        {% if instance.is_past and instance.has_enrollment_closed %}
+            <div class="alert sticky-alert alert-default">
+                {% trans "This course has already ended." %}
+                {% if later_instance %}
+                    <p>
+                        {% trans "The latest version of the course can be found at:" %}
+                        <a class="alert-link" href="{{ later_instance|url }}">
+                            <span lang="{{ later_instance.language }}">
+                                {{ later_instance.course.name|parse_localization }}: {{ later_instance.instance_name|parse_localization }}
+                            </span>
+                        </a>
+                    </p>
+                {% endif %}
+            </div>
+        {% endif %}
         {% block siblings %}{% endblock %}
         {% block breadcrumb %}
         <ol class="breadcrumb">

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-14 12:07+0300\n"
+"POT-Creation-Date: 2020-07-21 12:51+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Saara Satokangas <saara.satokangas@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -493,15 +493,8 @@ msgid "Enroll"
 msgstr "Ilmoittaudu"
 
 #: course/templates/course/_enroll_form.html:19
-#, python-format
-msgid ""
-"\n"
-"        The course enrollment is open until %(end)s.\n"
-"        "
-msgstr ""
-"\n"
-"        Kurssille ilmoittautuminen on avoinna %(end)s asti.\n"
-"        "
+msgid "The course enrollment is open until %(end)s."
+msgstr "Kurssille ilmoittautuminen on avoinna %(end)s asti."
 
 #: course/templates/course/_enroll_form.html:27
 msgid "Unfortunately, enrolling in the course has ended."
@@ -509,14 +502,8 @@ msgstr "Valitettavasti kurssille ilmoittautuminen on päättynyt."
 
 #: course/templates/course/_enroll_form.html:29
 #, python-format
-msgid ""
-"\n"
-"  The course opens %(start)s.\n"
-"  "
-msgstr ""
-"\n"
-"  Kurssi  avautuu %(start)s\n"
-"  "
+msgid "The course opens %(start)s."
+msgstr "Kurssi  avautuu %(start)s."
 
 #: course/templates/course/_enroll_form.html:35
 msgid ""
@@ -602,7 +589,7 @@ msgstr "Lue lisää"
 msgid "This course has already ended."
 msgstr "Tämä kurssi on jo päättynyt."
 
-#: course/templates/course/course_base.html:68
+#: course/templates/course/course_base.html:69
 msgid "The latest version of the course can be found at:"
 msgstr "Kurssin viimeisimmän version löydät täältä:"
 
@@ -700,7 +687,8 @@ msgstr "Tällä hetkellä ei ole käynnissä olevia kursseja."
 #: course/templates/course/index.html:70
 #, python-format
 msgid "Old courses can be found at the <a href=\"%(url)s\">course archive</a>."
-msgstr "Vanhat kurssit ovat nähtävissä <a href=\"%(url)s\">kurssiarkistossa</a>."
+msgstr ""
+"Vanhat kurssit ovat nähtävissä <a href=\"%(url)s\">kurssiarkistossa</a>."
 
 #: course/templates/course/module.html:27
 #, python-format
@@ -901,15 +889,15 @@ msgstr "Sähköposti"
 msgid "Tags"
 msgstr "Merkinnät"
 
-#: course/views.py:135
+#: course/views.py:134
 msgid "You cannot enroll, or have already enrolled, in this course."
 msgstr "Et voi ilmoittautua tai olet jo ilmoittautunut tälle kurssille."
 
-#: course/views.py:139 exercise/exercise_models.py:561
+#: course/views.py:138 exercise/exercise_models.py:561
 msgid "The enrollment is not open."
 msgstr "Ilmoittautuminen ei ole avoinna."
 
-#: course/views.py:212
+#: course/views.py:211
 msgid "A new student group was created."
 msgstr "Luotiin uusi opiskelijaryhmä."
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -111,15 +111,15 @@ msgstr "Käyttäjät"
 msgid "Input an URL identifier for this course."
 msgstr "Syötä URL-osoitteessa käytettävä tunnus kurssille."
 
-#: course/models.py:68 course/models.py:729 exercise/exercise_models.py:127
+#: course/models.py:68 course/models.py:732 exercise/exercise_models.py:127
 msgid "Taken words include: {}"
 msgstr "Varatut sanat: {}"
 
-#: course/models.py:236
+#: course/models.py:239
 msgid "internal"
 msgstr "sisäinen"
 
-#: course/models.py:238
+#: course/models.py:241
 msgid ""
 "The user profile contains a student number and has logged in via local "
 "organisation authentication"
@@ -127,11 +127,11 @@ msgstr ""
 "Käyttäjän profiililla on opiskelijanumero ja hän on kirjautunut sisään "
 "organisaation kirjautumisen kautta"
 
-#: course/models.py:244
+#: course/models.py:247
 msgid "external"
 msgstr "ulkoinen"
 
-#: course/models.py:246
+#: course/models.py:249
 msgid ""
 "The user profile doesn't have a student number, thus the user has logged in "
 "from a different organization or via social authentication"
@@ -139,75 +139,75 @@ msgstr ""
 "Käyttäjän profiililla ei ole opiskelijanumeroa, joten hän on kirjautunut "
 "sisään toisesta organisaatiosta tai sosiaalisen palvelun kautta"
 
-#: course/models.py:366
+#: course/models.py:369
 msgid "Internal users"
 msgstr "Paikalliset käyttäjät"
 
-#: course/models.py:367
+#: course/models.py:370
 msgid "External users"
 msgstr "Ulkoiset käyttäjät"
 
-#: course/models.py:368
+#: course/models.py:371
 msgid "Internal and external users"
 msgstr "Paikalliset ja ulkoiset käyttäjät"
 
-#: course/models.py:371
+#: course/models.py:374
 msgid "Enrolled students"
 msgstr "Ilmoittautuneet opiskelijat"
 
-#: course/models.py:372
+#: course/models.py:375
 msgid "Enrollment audience"
 msgstr "Ilmoittautumisen kohdeyleisö"
 
-#: course/models.py:373
+#: course/models.py:376
 msgid "All registered users"
 msgstr "Kaikki rekisteröityneet käyttäjät"
 
-#: course/models.py:374
+#: course/models.py:377
 msgid "Public to internet"
 msgstr "Julkisesti internetissä"
 
-#: course/models.py:377
+#: course/models.py:380
 msgid "User results"
 msgstr "Pistetilanne"
 
-#: course/models.py:378
+#: course/models.py:381
 msgid "Table of contents"
 msgstr "Sisällysluettelo"
 
-#: course/models.py:379
+#: course/models.py:382
 msgid "Link to last visited content"
 msgstr "Linkki viimeksi vierailtuun sisältöön"
 
-#: course/models.py:380
+#: course/models.py:383
 msgid "Experimental setup (hard-coded)"
 msgstr "Koeasetelma (kovakoodattu)"
 
-#: course/models.py:383
+#: course/models.py:386
 msgid "No numbering"
 msgstr "Ei numerointia"
 
-#: course/models.py:384
+#: course/models.py:387
 msgid "Arabic"
 msgstr "arabialainen"
 
-#: course/models.py:385
+#: course/models.py:388
 msgid "Roman"
 msgstr "roomalainen"
 
-#: course/models.py:386
+#: course/models.py:389
 msgid "Hidden arabic"
 msgstr "piilotettu arabialainen"
 
-#: course/models.py:393
+#: course/models.py:396
 msgid "Input an URL identifier for this course instance."
 msgstr "Syötä URL-osoitteessa käytettävä tunnus kurssikerralle."
 
-#: course/models.py:410
+#: course/models.py:413
 msgid "Select content for the course index page."
 msgstr "Valitse sisältö kurssin etusivulle."
 
-#: course/models.py:416
+#: course/models.py:419
 msgid ""
 "External CSS and JS resources that are included on all course pages. "
 "Separate with white space."
@@ -215,7 +215,7 @@ msgstr ""
 "Ulkoiset CSS- ja JS-resurssit, jotka sisällytetään kurssisivuihin. Erottele "
 "osoitteet rivinvaihdoilla."
 
-#: course/models.py:423
+#: course/models.py:426
 msgid ""
 "By default exercise errors are reported to teacher email addresses. Set this "
 "field as comma separated emails to override the recipients."
@@ -224,87 +224,87 @@ msgstr ""
 "sähköposteihin. Syötä pilkuilla erotettuja sähköpostiosoitteita korvaamaan "
 "oletusvastaanottajat."
 
-#: course/models.py:450
+#: course/models.py:453
 msgid "Ending time must be later than starting time."
 msgstr "Päättymisajan tulee olla alkamisajan jälkeen."
 
-#: course/models.py:452
+#: course/models.py:455
 msgid "Lifesupport time must be later than ending time."
 msgstr "Saattohoitoajan tulee alkaa loppumisajan jälkeen."
 
-#: course/models.py:458
+#: course/models.py:461
 msgid ""
 "Lifesupport time and archive time must be either both set or both unset."
 msgstr ""
 "Saattohoitoaika ja arkistointiaika pitää molemmat asettaa tai muutoin "
 "kumpaakaan ei voi asettaa."
 
-#: course/models.py:460
+#: course/models.py:463
 msgid "Archive time must be later than lifesupport time."
 msgstr "Arkistointiajan tulee olla saattohoidon jälkeen."
 
-#: course/models.py:468
+#: course/models.py:471
 msgid "Language code(s) missing from settings: "
 msgstr "Palvelun asetuksista puuttuva(t) kielikoodi(t):"
 
-#: course/models.py:470
+#: course/models.py:473
 msgid "Language code missing from settings."
 msgstr "Kielikoodi puuttuu palvelun asetuksista."
 
-#: course/models.py:678 course/models.py:804 exercise/exercise_models.py:68
+#: course/models.py:681 course/models.py:807 exercise/exercise_models.py:68
 #: exercise/submission_models.py:106
 msgid "Ready"
 msgstr "Valmis"
 
-#: course/models.py:679 exercise/exercise_models.py:69
+#: course/models.py:682 exercise/exercise_models.py:69
 msgid "Unlisted in table of contents"
 msgstr "Näkymätön sisällysluettelossa"
 
-#: course/models.py:680 course/models.py:806 templates/base.html:104
+#: course/models.py:683 course/models.py:809 templates/base.html:105
 msgid "Hidden"
 msgstr "Piilotettu"
 
-#: course/models.py:681 exercise/exercise_models.py:73
+#: course/models.py:684 exercise/exercise_models.py:73
 msgid "Maintenance"
 msgstr "Huolto"
 
-#: course/models.py:689
+#: course/models.py:692
 msgid "Input an URL identifier for this module."
 msgstr "Syötä URL-osoitteessa käytettävä tunnus moduulille."
 
-#: course/models.py:695
+#: course/models.py:698
 msgid "Opening time for the reading material"
 msgstr "Lukumateriaalin avautumisaika"
 
-#: course/models.py:696
+#: course/models.py:699
 msgid ""
 "Leave empty if the reading material should not open before the exercises."
 msgstr "Jätä tyhjäksi, jos lukumateriaalin ei pidä aueta ennen tehtäviä."
 
-#: course/models.py:708
+#: course/models.py:711
 msgid "Multiplier of points to reduce, as decimal. 0.1 = 10%"
 msgstr "Pisteiden vähennyskerroin desimaalilukuna, 0.1 = 10%"
 
-#: course/models.py:731
+#: course/models.py:734
 msgid "Opening time must be earlier than the closing time."
 msgstr "Alkamisajan tulee olla aikaisempi kuin päättymisaika."
 
-#: course/models.py:733
+#: course/models.py:736
 msgid "Late submission deadline must be later than the closing time."
 msgstr ""
 "Myöhäisten palautusten määräajan tulee olla myöhäisempi kuin sulkeutumisajan."
 
-#: course/models.py:735
+#: course/models.py:738
 msgid ""
 "Opening time of reading material must be earlier than the opening time of "
 "the exercises."
 msgstr "Lukumateriaalin tulee aueta ennen tehtäviä."
 
-#: course/models.py:805
+#: course/models.py:808
 msgid "No total points"
 msgstr "Ei kokonaispisteitä"
 
-#: course/models.py:816
+#: course/models.py:819
 msgid ""
 "Once exercise is graded non zero it confirms all the points on the hierarchy "
 "level. Implemented as a mandatory feedback feature."
@@ -312,7 +312,7 @@ msgstr ""
 "Kun tehtävä arvostellaan nollasta paremmaksi, se vahvistaa kaikki pisteet "
 "hierarkiatasolla. Suunniteltu pakollisen palautteen keräämiseksi."
 
-#: course/models.py:818
+#: course/models.py:821
 msgid ""
 "Grade unofficial submissions after deadlines have passed or submission "
 "limits have been exceeded. The points are stored but not included in "
@@ -598,6 +598,14 @@ msgstr "Kurssiarkisto"
 msgid "Read more"
 msgstr "Lue lisää"
 
+#: course/templates/course/course_base.html:66
+msgid "This course has already ended."
+msgstr "Tämä kurssi on jo päättynyt."
+
+#: course/templates/course/course_base.html:68
+msgid "The latest version of the course can be found at:"
+msgstr "Kurssin viimeisimmän version löydät täältä:"
+
 #: course/templates/course/enroll.html:6 course/templates/course/enroll.html:10
 msgid "Enrollment"
 msgstr "Ilmoittautuminen"
@@ -788,7 +796,7 @@ msgstr "Ilmoita opiskelijoita kurssille"
 #: edit_course/templates/edit_course/usertag_delete.html:29
 #: edit_course/templates/edit_course/usertag_list.html:48
 #: external_services/templates/external_services/list_menu.html:68
-#: news/templates/news/list.html:49 templates/base.html:247
+#: news/templates/news/list.html:49 templates/base.html:255
 msgid "Remove"
 msgstr "Poista"
 
@@ -893,15 +901,15 @@ msgstr "Sähköposti"
 msgid "Tags"
 msgstr "Merkinnät"
 
-#: course/views.py:120
+#: course/views.py:135
 msgid "You cannot enroll, or have already enrolled, in this course."
 msgstr "Et voi ilmoittautua tai olet jo ilmoittautunut tälle kurssille."
 
-#: course/views.py:124 exercise/exercise_models.py:561
+#: course/views.py:139 exercise/exercise_models.py:561
 msgid "The enrollment is not open."
 msgstr "Ilmoittautuminen ei ole avoinna."
 
-#: course/views.py:197
+#: course/views.py:212
 msgid "A new student group was created."
 msgstr "Luotiin uusi opiskelijaryhmä."
 
@@ -3462,7 +3470,7 @@ msgstr "Listan kärkeen nostettu viesti"
 msgid "Published on"
 msgstr "Julkaisu"
 
-#: news/templates/news/user_news.html:40
+#: news/templates/news/user_news.html:41
 msgid "Show older"
 msgstr "Näytä aiemmat"
 
@@ -3508,61 +3516,61 @@ msgstr "Ohita päävalikko"
 msgid "Main"
 msgstr "Päävalikko"
 
-#: templates/base.html:83
+#: templates/base.html:84
 msgid "Toggle navigation"
 msgstr "Näytä valikko"
 
-#: templates/base.html:107
+#: templates/base.html:108
 msgid "Select course"
 msgstr "Valitse kurssi"
 
-#: templates/base.html:125 userprofile/templates/userprofile/profile.html:6
+#: templates/base.html:126 userprofile/templates/userprofile/profile.html:6
 msgid "Profile"
 msgstr "Käyttäjätili"
 
-#: templates/base.html:131 templates/base.html:169
+#: templates/base.html:132 templates/base.html:170
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
-#: templates/base.html:140 templates/base.html:176
-#: userprofile/templates/userprofile/login.html:90
+#: templates/base.html:141 templates/base.html:177
+#: userprofile/templates/userprofile/login.html:84
 msgid "Log in"
 msgstr "Kirjaudu sisään"
 
-#: templates/base.html:151
+#: templates/base.html:152
 msgid "Site"
 msgstr "Sivusto"
 
-#: templates/base.html:155
+#: templates/base.html:156
 msgid "Home"
 msgstr "Etusivu"
 
-#: templates/base.html:200 userprofile/templates/userprofile/privacy.html:4
+#: templates/base.html:207 userprofile/templates/userprofile/privacy.html:4
 #: userprofile/templates/userprofile/privacy.html:9
 msgid "Privacy Notice"
 msgstr "Tietosuojailmoitus"
 
-#: templates/base.html:211 templates/base.html:230
+#: templates/base.html:219 templates/base.html:238
 msgid "Loading failed!"
 msgstr "Lataus epäonnistui!"
 
-#: templates/base.html:212 templates/base.html:231
+#: templates/base.html:220 templates/base.html:239
 msgid "Loading..."
 msgstr "Ladataan..."
 
-#: templates/base.html:219 templates/base.html:236
+#: templates/base.html:227 templates/base.html:244
 msgid "Close"
 msgstr "Sulje"
 
-#: templates/base.html:251
+#: templates/base.html:259
 msgid "Search"
 msgstr "Hae"
 
-#: templates/base.html:255
+#: templates/base.html:263
 msgid "No matches"
 msgstr "Ei osumia"
 
-#: templates/base.html:258
+#: templates/base.html:266
 msgid "Search for..."
 msgstr "Etsi..."
 
@@ -3601,7 +3609,7 @@ msgstr ""
 msgid "Show more login options"
 msgstr "Näytä lisää kirjautumisvaihtoehtoja"
 
-#: userprofile/templates/userprofile/login.html:110
+#: userprofile/templates/userprofile/login.html:104
 #, python-format
 msgid "You may want to read our <a href=\"%(url)s\">privacy notice</a>."
 msgstr ""


### PR DESCRIPTION
# Description

- If the course instance has ended and enrolling has already closed, the page visitor will be told that the course has already ended. 
- If there is an instance of the same course, that has a later ending time than now, and that instance is visible for that user, they will be given a link to that instance. 
- If there are several instances that fit this description, the latest is given.
- Even if the course has already ended, but the enrolling would for some reason be open, the enroll_form is shown.  
- Front page and enroll-page of the course show the link to the latest instance of the course. 
- Other course-pages show only the text "This course has already ended" to save some database-queries
(If the link is wanted for other pages as well, most likely the best option would be to move the alert to the course_base.html, that seems to work as well and is easy to move around. That however will cause an extra query for old instances. If this issue is considered more important and worth using extra time, a cache entry could be probably implemented.)

Fixes #554

**Front page of the course**:

![image](https://user-images.githubusercontent.com/43036333/87779880-39b25880-c836-11ea-8fb9-dd20ecdc4e15.png)


**Content-pages of the course**

![image](https://user-images.githubusercontent.com/43036333/87779919-4c2c9200-c836-11ea-9fc8-da44ed0dd1ce.png)


# Testing

Unit-tests and selenium-tests pass once this has been merged: https://github.com/apluslms/a-plus/pull/621

The changes have been tested as a logged in user, a student and a staff member with past courses that have no future instances and with courses that have future instances. Both hidden ones and ones visible to students. Also the case where a future instance exist and where the enrolling has not yet started has been tested. 

The changes do not change the way the content is shown to the user, only limit the showing of the enroll_form to courses where the enrolling is still .  
 
o1 has other implementations of this, which would become unnecessary now: 
https://plus.cs.aalto.fi/o1/2018/

# Have you updated the README or other relevant documentation?

Not relevant here.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
