### PR TITLE
Remove old _aplus_group parameter

### DIFF
--- a/exercise/api/views.py
+++ b/exercise/api/views.py
@@ -236,7 +236,7 @@ class ExerciseSubmissionsViewSet(NestedViewSetMixin,
     def submit(self, request, *args, **kwargs):
         """Submit a new solution to the exercise for grading.
         Students are allowed to submit via this endpoint. In a group submission,
-        the student group ID is defined with the POST parameter _aplus_group.
+        the student group ID is defined with the POST parameter __aplus__={"group": ID}.
         The POST data is used as the submission data and files may be uploaded too.
         """
         # Stop submit trials for e.g. chapters.

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -583,8 +583,6 @@ class BaseExercise(LearningObject):
             except json.JSONDecodeError:
                 warnings.append(_("Cannot submit exercise because of invalid JSON in POST data"))
                 return self.SUBMIT_STATUS.INVALID, warnings, students
-            if not group_id:
-                group_id = request.POST.get("_aplus_group")
 
         if not group_id is None:
             try:

--- a/exercise/static/exercise/group.js
+++ b/exercise/static/exercise/group.js
@@ -52,7 +52,9 @@
         var list = this.ui.find('select');
         for (var i = 0; i < this.groups.length; i++) {
           var group = this.groups[i];
-          list.append($('<option value="{&quot;group&quot;:' + group.id + '}" data-group-size="' + group.size + '">' + group.text + '</option>'));
+          var meta_data = JSON.stringify({group: parseInt(group.id)})
+          /* TODO: add lang to meta_data*/
+          list.append(($('<option value=\''+ meta_data + '\'data-group-size="' + group.size + '">' + group.text + '</option>')));
         }
       }
 		},

--- a/exercise/static/exercise/group.js
+++ b/exercise/static/exercise/group.js
@@ -46,13 +46,13 @@
         });
 
         this.ui = $('<div class="submit-group-selector input-group col-md-6">'
-          + '<select name="_aplus_group" class="form-control"></select>'
+          + '<select name="__aplus__" class="form-control"></select>'
           + '<span class="input-group-btn"></span>'
           + '</div>');
         var list = this.ui.find('select');
         for (var i = 0; i < this.groups.length; i++) {
           var group = this.groups[i];
-          list.append($('<option value="' + group.id + '" data-group-size="' + group.size + '">' + group.text + '</option>'));
+          list.append($('<option value="{&quot;group&quot;:' + group.id + '}" data-group-size="' + group.size + '">' + group.text + '</option>'));
         }
       }
 		},
@@ -71,7 +71,7 @@
 
             var groupFixed = $(this).attr(self.settings.group_fixed_attribute);
             if (groupFixed) {
-              ui.find('option:not([value="' + groupFixed + '"])').remove();
+              ui.find('option:not([value="{\\"group\\":' + groupFixed + '}"])').remove();
             } else {
               var groupSize = $(this).attr(self.settings.group_size_attribute).split("-");
               ui.find("option").each(function() {


### PR DESCRIPTION
# Description

Change web submissions to use the new POST parameter
`__aplus__={"group": ID}` to set submission group.
Remove all uses of the old `_aplus_group` POST parameter.

Fixes #612

# Testing

Changes have been manually changed, to work the same way as before using the old parameter.

*Describe here what needs to be tested MANUALLY due to these changes.*
*Think of what is affected by these changes and could become broken (and can not be easily tested automatically)?*

# Have you updated the README or other relevant documentation?
Wiki still mentions `_aplus_group` as the old way, but I guess that's OK. Might make it cleared for 
someone who has used the old parameter before.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
