### PR TITLE
Change language based on query parameter

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -629,5 +629,25 @@ $(function() {
     });
 })(jQuery, window, document);
 
+/*
+ * Listen to link click events and copy query parameters from current url
+ * to the next
+ * Note! Translation requires that at least 'hl' query parameter is copied
+ */
+(function(window) {
+    window.addEventListener('click', function(event) {
+        if (
+            event.target.nodeName === 'A'
+            && event.target.href
+            && event.target.protocol === window.location.protocol
+            && event.target.host === window.location.host // hostname:port
+            && (event.target.search === '' || event.target.search === '?') // no search
+        ) {
+            event.preventDefault(); // stop default redirect
+            event.target.search = window.location.search; // copy query params
+            window.location.href = event.target.href; // redirect
+        }
+    }, false);
+})(window);
 
 /* vim: set et ts=4 sw=4: */

--- a/authorization/exceptions.py
+++ b/authorization/exceptions.py
@@ -1,4 +1,4 @@
 class ValidationFailed(Exception):
     def __init__(self, response):
-        super(ValidationFailed, self).__init__("HTTP Reqeust validation failed")
+        super(ValidationFailed, self).__init__("HTTP Request validation failed")
         self.response = response

--- a/course/exceptions.py
+++ b/course/exceptions.py
@@ -1,0 +1,2 @@
+class TranslationNotFound(Exception):
+    pass

--- a/course/views.py
+++ b/course/views.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 from authorization.permissions import ACCESS
 from exercise.cache.hierarchy import NoSuchContent
 from exercise.models import LearningObject
-from lib.helpers import settings_text
+from lib.helpers import settings_text, remove_query_param_from_url
 from lib.viewbase import BaseTemplateView, BaseRedirectMixin, BaseFormView, BaseView
 from userprofile.viewbase import UserProfileView
 from .forms import GroupsForm, GroupSelectForm
@@ -251,12 +251,12 @@ class LanguageView(CourseInstanceMixin, BaseView):
     def post(self, request, *args, **kwargs):
         LANGUAGE_PARAMETER = 'language'
         
-        next = request.POST.get('next', request.GET.get('next'))
+        next = remove_query_param_from_url(request.POST.get('next', request.GET.get('next')), 'hl')
         if ((next or not request.is_ajax()) and
                 not is_safe_url(url=next,
                                 allowed_hosts={request.get_host()}, 
                                 require_https=request.is_secure())):
-            next = request.META.get('HTTP_REFERER')
+            next = remove_query_param_from_url(request.META.get('HTTP_REFERER'), 'hl')
             next = next and unquote(next)  # HTTP_REFERER may be encoded.
             if not is_safe_url(url=next,
                                allowed_hosts={request.get_host()},

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -4,7 +4,7 @@ import functools
 import warnings
 from cachetools import cached, TTLCache
 from collections import OrderedDict
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlsplit, urlunsplit
 from PIL import Image
 from django.conf import settings
 from django.utils.crypto import get_random_string as django_get_random_string
@@ -84,6 +84,16 @@ def url_with_query_in_data(url: str, data: dict = {}):
 def update_url_params(url, params):
     delimiter = "&" if "?" in url else "?"
     return url + delimiter + urlencode(params)
+
+
+def remove_query_param_from_url(url, param):
+    """
+    Take an url with (or without) query parameters. Return url without the selected query parameter.
+    """
+    url = urlsplit(url)
+    query = parse_qs(url.query, keep_blank_values=True)
+    query.pop(param, None)
+    return urlunsplit(url._replace(query=urlencode(query, True)))
 
 
 FILENAME_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ._-0123456789"

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -3,6 +3,9 @@ from django.http import HttpResponseRedirect
 from django.utils import translation
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
+from django.shortcuts import render_to_response
+
+from lib.helpers import remove_query_param_from_url
 
 
 class LocaleMiddleware(MiddlewareMixin):
@@ -10,7 +13,14 @@ class LocaleMiddleware(MiddlewareMixin):
     response_redirect_class = HttpResponseRedirect
 
     def process_request(self, request):
-        if hasattr(request, 'user') and request.user.is_authenticated:
+        query_language = request.GET.get('hl')
+        if query_language:
+            language = query_language
+            lang_codes = set(lang[0][:2] for lang in settings.LANGUAGES)
+            if language[:2] not in lang_codes:
+                url = remove_query_param_from_url(request.get_full_path(), 'hl')
+                return render_to_response('404.html', {'url_without_language': url}, status=404) 
+        elif hasattr(request, 'user') and request.user.is_authenticated and not request.user.is_anonymous:
             language = request.user.userprofile.language
         else:
             language = translation.get_language_from_request(request)

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-19 09:22+0300\n"
+"POT-Creation-Date: 2020-08-27 15:56+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Saara Satokangas <saara.satokangas@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -1187,45 +1187,45 @@ msgstr ""
 "Assistentin lisääminen epäonnistui, sillä käyttäjää opiskelijanumerolla {id} "
 "ei ole olemassa."
 
-#: edit_course/operations/configure.py:412
+#: edit_course/operations/configure.py:411
 msgid "Categories required as an object."
 msgstr "Kategoriat vaaditaan objektina."
 
-#: edit_course/operations/configure.py:415
+#: edit_course/operations/configure.py:414
 msgid "Modules required as an array."
 msgstr "Moduulit vaaditaan taulukkona."
 
-#: edit_course/operations/configure.py:423
+#: edit_course/operations/configure.py:422
 msgid "Category requires a name."
 msgstr "Kategoria vaatii nimen."
 
-#: edit_course/operations/configure.py:461
+#: edit_course/operations/configure.py:460
 msgid "Module requires a key."
 msgstr "Moduuli vaatii avaimen."
 
-#: edit_course/operations/configure.py:564
+#: edit_course/operations/configure.py:563
 msgid "ExerciseCollection requires collection_category."
 msgstr "Tehtäväkokoelma tarvitsee collection_category:n."
 
-#: edit_course/operations/configure.py:567
+#: edit_course/operations/configure.py:566
 msgid "ExerciseCollection requires URL to target course instance."
 msgstr "Tehtäväkokoelma tarvitsee kohde kurssin URL:n."
 
-#: edit_course/operations/configure.py:573
+#: edit_course/operations/configure.py:572
 msgid "Course URL '{}' doesn't match service's hostname '{}'"
 msgstr "Kurssin URL '{}' ei vastaa palvelun domain nimeä '{}'"
 
-#: edit_course/operations/configure.py:579
+#: edit_course/operations/configure.py:578
 msgid "Couldn't determine course and/or instance from URL '{}'"
 msgstr "Kurssin ja/tai instanssin selvittäminen ei onnistunut URLsta '{}'"
 
-#: edit_course/operations/configure.py:586
+#: edit_course/operations/configure.py:585
 msgid "No course found with URL '{}'. course_slug: '{}', instance_slug: '{}'"
 msgstr ""
 "Yhtään kurssia ei löytynyt URLlla '{}' (course_slug: '{}', instance_slug: "
 "'{}')"
 
-#: edit_course/operations/configure.py:593
+#: edit_course/operations/configure.py:592
 msgid "Category '{}' not found in target course."
 msgstr "Kategoriaa '{}' ei löytynyt kohde kurssista."
 
@@ -2194,6 +2194,7 @@ msgstr "Pisteet tällä kurssilla"
 
 #: exercise/templates/exercise/_file_link.html:12
 #: exercise/templates/exercise/_model_files.html:14
+#: exercise/templates/exercise/_template_files.html:14
 msgid "File not found"
 msgstr "Tiedostoa ei löytynyt"
 
@@ -3478,7 +3479,23 @@ msgstr ""
 msgid "The user account has been disabled."
 msgstr "Käyttäjätunnus on suljettu."
 
-#: templates/404.html:20
+#: templates/404.html:21
+msgid "The page is not available in this language."
+msgstr "Sivu ei ole saatavilla tällä kielellä."
+
+#: templates/404.html:22
+msgid "Open the page in default language"
+msgstr "Avaa sivu oletuskielellä"
+
+#: templates/404.html:26
+msgid ""
+"The course is not available in this language. You can view the course in "
+"these languages:"
+msgstr ""
+"Kurssi ei ole saatavilla tällä kielellä. Voit katsella kurssia näillä "
+"kielillä:"
+
+#: templates/404.html:36
 msgid ""
 "\n"
 "                        For an unknown reason you arrived somewhere that "
@@ -3693,14 +3710,16 @@ msgstr ""
 msgid "Forget automatic redirection"
 msgstr "Unohda automaattinen uudelleenohjaus."
 
-#: userprofile/views.py:126
+#: userprofile/views.py:127
 msgid "No privacy notice. Please notify administration!"
 msgstr "Ei tietosuojailmoitusta. Ota yhteys ylläpitäjään!"
 
-#: userprofile/views.py:153
+#: userprofile/views.py:154
 msgid "No local accessibility statement. Please notify the site's owner!"
-msgstr "Ei paikallista saavutettavuusselostetta. Ilmoitathan tästä sivuston ylläpitäjälle!"
+msgstr ""
+"Ei paikallista saavutettavuusselostetta. Ilmoitathan tästä sivuston "
+"ylläpitäjälle!"
 
-#: userprofile/views.py:165
+#: userprofile/views.py:166
 msgid "No system-wide accessibility statement found."
 msgstr "Järjestelmätason saavutettavuusselostetta ei löytynyt."

--- a/templates/404.html
+++ b/templates/404.html
@@ -16,12 +16,29 @@
                         <h1>404 Not found</h1>
                     </div>
                     {% include "_messages.html" %}
+                    {% if url_without_language %}
+                    <div class="alert alert-danger">
+                        {% trans "The page is not available in this language." %}
+                        <a href="{{ url_without_language }}">{% trans "Open the page in default language" %}</a>
+                    </div>
+                    {% elif languages %}
+                    <div class="alert alert-danger">
+                        {% blocktrans trimmed %}
+                        The course is not available in this language.
+                        You can view the course in these languages:
+                        {% endblocktrans %}
+                        {% for lang in languages %}
+                            <a href="{{ lang.url }}">{{ lang.name }}</a>
+                        {% endfor %}
+                    </div>
+                    {% else %}
                     <div class="alert alert-danger">
                         {% blocktrans %}
                         For an unknown reason you arrived somewhere that does not exist.
                         Please, try again.
                         {% endblocktrans %}
                     </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -17,7 +17,7 @@ from django.utils.translation import (
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import gettext
 
-from lib.helpers import settings_text
+from lib.helpers import settings_text, remove_query_param_from_url
 from authorization.permissions import ACCESS
 from .viewbase import UserProfileView
 
@@ -61,12 +61,12 @@ def set_user_language(request):
     """"Overrides set_language function from  django.views.i18n."""
     LANGUAGE_PARAMETER = 'language'
 
-    next = request.POST.get('next', request.GET.get('next'))
+    next = remove_query_param_from_url(request.POST.get('next', request.GET.get('next')), 'hl')
     if ((next or not request.is_ajax()) and
             not is_safe_url(url=next,
                             allowed_hosts={request.get_host()},
                             require_https=request.is_secure())):
-        next = request.META.get('HTTP_REFERER')
+        next = remove_query_param_from_url(request.META.get('HTTP_REFERER'), 'hl')
         next = next and unquote(next)  # HTTP_REFERER may be encoded.
         if not is_safe_url(url=next,
                             allowed_hosts={request.get_host()},


### PR DESCRIPTION

# Description

This PR adds a possibility of linking to a specific page in A+ in a specific language or viewing content with different language without having to change and save it in profile or in course page, by using language query parameter at the end of the url. 
For example, adding ?hl=en at the end of the url changes the content to English if it's supported for the page. If not, an error is raised.

* If the language is supported for A+ but not for this course, a 404 html page is shown with a list of available languages and links for each.
![520-error1](https://user-images.githubusercontent.com/36920208/90131520-f388e000-dd74-11ea-86de-5ff51527283a.png)

* If the language is not supported for A+ at all, a 404 page is shown with a link to the material in default language.
![404-default](https://user-images.githubusercontent.com/36920208/91525554-7039c380-e90a-11ea-9187-b0116c7bf6af.png)

Language parameter stays in the url when navigating through page, except when user changes language either on course page
or on profile page.

This is achieved by adding an event listener to `assets/js/aplus.js` that listens to click events and copies query parameters from the current url to the next when a link is clicked. When user changes language either on course page or on profile page, the language query parameter is removed from the url.



1/3 of issue https://github.com/apluslms/a-plus/issues/520

# Testing

* Existing unit tests pass

* Testing has been done manually by navigating through pages and checking that the language parameter changes the content language and also stays in the url, and that the errors are raised properly.

# Have you updated the README or other relevant documentation?

* No, I'm not sure if it's needed.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [x] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
