### PR TITLE
Remove mention of media-folder from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,3 @@ Code Organization
 * [templates/](templates) : General site templates
 * [assets/](assets) : Static web server assets, e.g., JavaScript, styles and images
 * [assets_src/](assets_src) : Asset packages (as npm packages), which should populate `assets/` with compiled files.
-* [media/](media) : User uploaded files


### PR DESCRIPTION
Mention of media-folder is removed from `README.md` as it is not being used for any permanent data storage.

# Testing

All existing unit- and selenium-tests pass

# Have you updated the README or other relevant documentation?

This will make README to be up-to-date

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
