### PR TITLE
Implement aplus-material-v1, aplus-assess-v1, and aplus-hook-v1 inferfaces by adding User-Agent and correct X-Aplus-Event headers

### DIFF
--- a/aplus/__init__.py
+++ b/aplus/__init__.py
@@ -1,0 +1,20 @@
+
+# Version
+try:
+    from .version import __version__
+except ImportError:
+    try:
+        __version__ = (
+            __import__('subprocess')
+                .check_output(('git', 'describe'))
+                .decode('utf-8')
+                .strip()
+                .lstrip('v')
+        )
+    except Exception as error:
+        __import__('warnings').warn(
+            'Unable to determine aplus version. %s: %s' % (
+                error.__class__.__name__,
+                error,
+            ))
+        __version__ = 'unknown'

--- a/exercise/cache/exercise.py
+++ b/exercise/cache/exercise.py
@@ -6,7 +6,6 @@ from django.db.models.signals import post_save, post_delete
 
 from lib.cache import CachedAbstract
 from lib.remote_page import RemotePageNotModified
-from ..protocol.aplus import load_exercise_page
 
 logger = logging.getLogger('aplus.cached')
 

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -35,7 +35,7 @@ from lib.validators import generate_url_key_validator
 from userprofile.models import UserProfile
 
 from .cache.exercise import ExerciseCache
-from .protocol.aplus import load_exercise_page, load_feedback_page
+from .protocol.aplus import load_chapter_page, load_exercise_page, load_feedback_page
 from .protocol.exercise_page import ExercisePage
 
 
@@ -326,6 +326,13 @@ class CourseChapter(LearningObject):
     def _is_empty(self):
         return not self.generate_table_of_contents
 
+    def load_page(self, language, request, students, url_name, last_modified=None):
+        return load_chapter_page(
+            request,
+            self.get_load_url(language, request, students, url_name),
+            last_modified,
+            self,
+        )
 
 class BaseExerciseManager(models.Manager):
 

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -272,7 +272,10 @@ class ExerciseModelView(ExerciseModelBaseView):
         self.models = []
         for url,name in self.exercise.get_models():
             try:
-                response = request_for_response(url)
+                response = request_for_response(
+                    url,
+                    headers={'X-Aplus-Event': 'aplus.assess.v1/retrieve-model'},
+                )
             except RemotePageNotFound:
                 self.models.append({'name': name})
             else:
@@ -295,7 +298,10 @@ class ExerciseTemplateView(ExerciseTemplateBaseView):
         self.templates = []
         for url,name in self.exercise.get_templates():
             try:
-                response = request_for_response(url)
+                response = request_for_response(
+                    url,
+                    headers={'X-Aplus-Event': 'aplus.assess.v1/retrieve-template'},
+                )
             except RemotePageNotFound as error:
                 self.templates.append({'name': name})
             else:

--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -2,6 +2,7 @@ import logging
 import posixpath
 import re
 import requests
+import threading
 import time
 from urllib.parse import urlparse, urljoin
 
@@ -17,6 +18,7 @@ from aplus import __version__ as aplus_version
 logger = logging.getLogger('aplus.remote_page')
 
 
+LOCAL = threading.local()
 USER_AGENT = "a-plus/%s (+%s) %s" % (
     aplus_version,
     settings.BASE_URL,
@@ -54,8 +56,11 @@ def request_for_response(
         headers=None,
         stamp=None,
         ):
-    session = requests.Session()
-    session.headers['User-Agent'] = USER_AGENT
+    if hasattr(LOCAL, 'session'):
+        session = LOCAL.session
+    else:
+        LOCAL.session = session = requests.Session()
+        session.headers['User-Agent'] = USER_AGENT
 
     if post:
         def make_request():


### PR DESCRIPTION
# Description

Every self respecting web client should provide a good User-Agent string to the server. A+ was sending only `python-requests/2.21.0`. Now, it sends `a-plus/1.7.0-63-gab401233 (+http://plus.example.com) python-requests/2.21.0`, where `1.7.0*` is the current A+ version  defined in `aplus.version.__version__` or resolved by `git describe` (first for real deployments and second for git clone installations) and `http://plus.example.com` is the content of `settings.BASE_URL`.

Additionally, send header `X-Aplus-Event` with a interface version and event type info. Following events are known:

* `aplus.assess.v1/assess-submission` - when sending submission for grading
* `aplus.assess.v1/retrieve-exercise` - when retrieving exercises
* `aplus.assess.v1/retrieve-model` - when retrieving the model file (or files)
* `aplus.assess.v1/retrieve-template` - when retrieving the template file (or files)
* `aplus.hook.v1/post-assessment` - send as part of the post hook
* `aplus.material.v1/retrieve-chapter` - when retrieving chapters

To support this. the `load_exercise_page` in `exercise/protocol/aplus.py` is split to two functions, one for exercises and one for chapters. Additionally, new content selectors are added, so content and exercise services may update their outputs. Even though chapters are internally exercises and should be kept as such from the points point of view, that doesn't mean the interface for them should be identical. I think this separation will make the interface less error prone and will also make the code more clear on what is what.

Finally, start using requests session in `lib/remote_page.py`, which allows reusing http connections. This requires a web server with a http/1.1 support. For example, MOOC-Grader has too old Django for that, but MOOC-Jutut is updated to 2.2 already, which supports this.

# Testing

Hook requires testing with a service, which can react to the hook some way. The following container can be used to print requests.

```yaml
services:
  hookservice:
    image: mendhak/http-https-echo
    depends_on:
      - grader
      - plus
```

MOOC-Grader can be used to test  requests send to it. The following middleware can print all the required info:

```python
class LogRequestsMiddleware(MiddlewareMixin):
    def process_request(self, request):
        logger.warning(" -- MIDDLEWARE DEBUG -- ")
        logger.info("Request %s by %s", request.method, request.META.get('HTTP_USER_AGENT', 'unknown'))
        logger.info("Aplus event: %s", request.META.get('HTTP_X_APLUS_EVENT', 'unknown'))
```

To verify connection pooling, you need an assessment service with http/1.1 support, e.g., MOOC-Jutut (master). Additionally, you can log urllib3 info with the following in A+ settings:

```python
LOGGING['loggers'].update({
    'urllib3': {
        'level': 'DEBUG',
        'propagate': True,
    },
})
```

When the pool is started, the following entry should be in the log:

```
plus_1         | [2020-08-18 14:52:11,867: DEBUG/connectionpool] Starting new HTTP connection (1): 172.19.0.5:8082
```

If the server doesn't support keep-alive or it has expired, then you may see

```
plus_1         | [2020-08-18 15:02:52,799: DEBUG/connectionpool] Resetting dropped connection: grader
```

If the pool entry is reused, then there is no log entry.

# Have you updated the README or other relevant documentation?

The A+ protocol docs will include details of the headers added here as part of the protocol doc.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [x] I (developer) ~~have created unit tests and~~ the tests pass
- ~~I (developer) have created functional tests (Selenium tests) if applicable~~
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
