### PR TITLE
Wrap "double angle quotation marks" in aria-hidden

### DIFF
--- a/course/templates/course/_siblings.html
+++ b/course/templates/course/_siblings.html
@@ -11,11 +11,11 @@
     {% endif %}
     {% if accessible %}
     <a href="{{ next.link }}" class="pull-right">
-        {{ next.name|parse_localization }} &raquo;
+        {{ next.name|parse_localization }} <span aria-hidden="true">&raquo;</span>
     </a>
     {% else %}
     <span class="pull-right disabled">
-        {{ next.name|parse_localization }} &raquo;
+        {{ next.name|parse_localization }} <span aria-hidden="true">&raquo;</span>
         {% if is_course_staff %}
         <a href="{{ next.link }}">
             <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
@@ -34,11 +34,11 @@
     {% endif %}
     {% if accessible %}
     <a href="{{ previous.link }}" class="pull-left">
-        &laquo; {{ previous.name|parse_localization }}
+        <span aria-hidden="true">&laquo;</span> {{ previous.name|parse_localization }}
     </a>
     {% else %}
     <span class="pull-left disabled">
-        &laquo; {{ previous.name|parse_localization }}
+        <span aria-hidden="true">&laquo;</span> {{ previous.name|parse_localization }}
         {% if is_course_staff %}
         <a href="{{ previous.link }}">
             <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>


### PR DESCRIPTION
# Description

It's a little annoying when listening to pages with VoiceOver that the "double angled quotation marks" in the pagination navigation area get read out. 

Since they're mostly decorative (it's possible to tell, as we're inside a `nav` called "pagingation", that these will be the next and last pages), they are hidden from assistive technology as a whole. 

# Testing

Tested manually with VoiceOver

# Have you updated the README or other relevant documentation?

*Don't forget to update the documentation if it is relevant for this PR.*

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
