### PR TITLE
Add teacher disclaimer to accessibility statement

### DIFF
--- a/templates/accessibility_issues_en.html
+++ b/templates/accessibility_issues_en.html
@@ -1,4 +1,5 @@
 <h2>Known Issues</h2>
+<p>This information concerns the A+ platform, as it is provided. Institutions using A+, as well as creators of course content (teachers) are free to customise their content and styles, which may change the compliance described here.</p>
 <p>At present, A+ partly complies with the defined requirements for accessibility. Further improvements are needed, especially:</p>
 <ul>
 	<li>Some elements of the service are not keyboard accessible.</li>

--- a/templates/accessibility_issues_fi.html
+++ b/templates/accessibility_issues_fi.html
@@ -1,4 +1,5 @@
 <h2>Tunnetut ongelmat</h2>
+<p>Tämän sivun tiedot koskevat A+-alustaa sellaisena kuin se tarjotaan. A+-alustaa käyttävät instituutiot kuten myös kurssisisällön tuottajat (opettajat) kykenevät vapaasti muokkaamaan sisältöään ja sen ulkoasua, mikä voi muuttaa tässä kuvattua saavutettavuusvaatimusten noudattamista.</p>
 <p>Nykytilanteessa A+ täyttää osittain saavutettavuusvaatimukset. Lisäparannuksia vaaditaan, erityisesti seuraavissa toiminnallisuuksissa:</p>
 <ul>
 	<li>Joihinkin palvelun osiin ei pääse pelkällä näppäimistöllä.</li>


### PR DESCRIPTION
# Description

This adds a statement to the system-level accessibility statement noting that teachers may break accessibility of courses, and that other institutions using A+ may make their own customisations. 

Once we are agreed on some text, if someone wants to add a Finnish version, I'd be happy to add it here. 
# Testing

This only changes a tiny bit of text. 

# Have you updated the README or other relevant documentation?

*Don't forget to update the documentation if it is relevant for this PR.*

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
