### PR TITLE
Add aria support to anchor tags that list student submissions

### DIFF
--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -113,7 +113,7 @@
           <small>{{ entry.category|parse_localization }}</small>
         </td>
         <td class="submissions-dropdown dropdown">
-          <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button">
             <span class="badge">
               {% if entry.notified %}
               <span class="glyphicon glyphicon-comment{% if entry.unseen %} red{% endif %}"></span>

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -41,7 +41,7 @@
           </a>
       </li>
       <li class="dropdown menu-submission">
-          <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button"
+          <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button"
               aria-haspopup="true" aria-expanded="false">
               {% trans "My submissions" %}
               ({{ summary.get_submission_count }}{% if exercise.max_submissions %}/{{ exercise|max_submissions:profile }}{% endif %})

--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -58,7 +58,7 @@
                                 </a>
                             </li>
                             <li class="dropdown">
-                                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                                <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button">
                                     {% trans "My submissions" %}
                                     <span class="badge">
                                         {{ summary.get_submission_count }}


### PR DESCRIPTION
# Description

The dropdown menu that shows the student submissions use a `a` tag instead of a button. Therefore, we need to add some semantics to that tag. Maybe a better solution could be to use a button instead but adding some aria attributes also solve the problem.

Fixes #597 

# Testing

I tested the changes manually using [Chromevox](https://chrome.google.com/webstore/detail/chromevox-classic-extensi/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en)

# Have you updated the README or other relevant documentation?

There is no need to update any documentation.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
