### PR TITLE
Add a hidden link to open exercises in a new tab / full-page

### DIFF
--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -37,6 +37,9 @@
     </head>
     <body>
         <div id="exercise-all">
+            <a href="{{ exercise|url:'exercise' }}" target="_blank" rel="noopener" class="skip-link">
+                {% trans "Open this exercise in a new tab (recommended for keyboard and assistive technology users)" %}
+            </a>
             <div class="overlay-parent">
 
                 {% if issues and not submission_allowed %}

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-02 11:46+0200\n"
+"POT-Creation-Date: 2021-01-25 10:17+0200\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Markku Riekkinen <markku.riekkinen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -2436,6 +2436,14 @@ msgstr "Tutki palautusta"
 #: exercise/templates/exercise/exercise_plain.html
 msgid "View all submissions"
 msgstr "Näytä kaikki palautukset"
+
+#: exercise/templates/exercise/exercise_plain.html
+msgid ""
+"Open this exercise in a new tab (recommended for keyboard and assistive "
+"technology users)"
+msgstr ""
+"Avaa tämä tehtävä uudessa välilehdessä (suositellaan näppäimistön ja "
+"avustavan teknologian käyttäjille)"
 
 #: exercise/templates/exercise/exercise_plain.html
 #, python-format


### PR DESCRIPTION
# Description

Aplus does not support keyboard navigation for modal windows, and all
the current exercises use modal windows for different tasks, e.g., show
model response, inspect submission among other tasks. Therefore, the
exercises must be opened in full-page for users who use keyboard
navigation. We added hidden links that are shown only when the user
navigates the course with the keyboard.

Fixes #669
# Testing

I tested the changes manually.

# Have you updated the README or other relevant documentation?

There is no documentation related to this issue.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
