### PR TITLE
Modify <a> event handler and remove target='_blank'

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -667,11 +667,21 @@ $(function() {
  */
 (function (window) {
   $(document).on("click", "a[href]", function (event) {
+    // Remove the language query when the user navigate to the home page or profile page.
+    let keepLangQuery = true;
+    if (
+      event.target.href.replace(/\/$/, "") == window.location.origin ||
+      event.target.href.includes("accounts/accounts")
+    ) {
+      keepLangQuery = false;
+    }
+    // Keep the language query.
     if (
       event.target.className != "dropdown-toggle" &&
       event.target.protocol === window.location.protocol &&
       event.target.host === window.location.host && // hostname:port
-      (event.target.search === "" || event.target.search === "?") // no search
+      (event.target.search === "" || event.target.search === "?") && // no search
+      keepLangQuery
     ) {
       event.target.search = window.location.search; // copy query params
     }

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -82,15 +82,14 @@
                     {% trans "You are browsing this course in a different language than is set in your preferences." %}
                     {% if user_course_data %}
                         <div class="button-container">
-                            <form action="{{ url_without_language }}">
-                                <button type="submit" class="aplus-button--secondary aplus-button--md">
-                                    {% blocktrans trimmed with lang=user_language|language_name_translated %}
-                                    Browse the course in {{ lang }}
-                                    {% endblocktrans %}
-                                </button>
-                            </form>
+                            <a href="{{ url_secondary_query_language }}" class="aplus-button--secondary aplus-button--md">
+                                {% blocktrans trimmed with lang=user_language|language_name_translated %}
+                                Browse the course in {{ lang }}
+                                {% endblocktrans %}
+                            </a>
                             <form action="{{ instance|url:'set-enrollment-language' }}" method="post">
                                 {% csrf_token %}
+                                <input name="next" type="hidden" value="{{ url_secondary_query_language }}" />
                                 <input name="language" type="hidden" value="{{ query_language }}" />
                                 <button type="submit" class="aplus-button--secondary aplus-button--md">
                                     {% blocktrans trimmed with lang=query_language|language_name_translated %}

--- a/course/views.py
+++ b/course/views.py
@@ -245,7 +245,8 @@ class GroupsView(CourseInstanceMixin, BaseFormView):
         return kwargs
 
     def get_success_url(self):
-        return self.instance.get_url('groups')
+        url = self.instance.get_url('groups') + "?hl=" +self.request.GET.get('hl')
+        return url
 
     def form_valid(self, form):
         form.save()

--- a/course/views.py
+++ b/course/views.py
@@ -20,7 +20,7 @@ from django.utils.translation import gettext_lazy as _
 from authorization.permissions import ACCESS
 from exercise.cache.hierarchy import NoSuchContent
 from exercise.models import LearningObject
-from lib.helpers import settings_text, remove_query_param_from_url
+from lib.helpers import settings_text, remove_query_param_from_url, add_lang_query_param_from_url
 from lib.viewbase import BaseTemplateView, BaseRedirectMixin, BaseFormView, BaseView, BaseRedirectView
 from userprofile.viewbase import UserProfileView
 from .forms import GroupsForm, GroupSelectForm
@@ -285,8 +285,9 @@ class LanguageView(CourseInstanceMixin, BaseView):
     
     def post(self, request, *args, **kwargs):
         LANGUAGE_PARAMETER = 'language'
-        
-        next = remove_query_param_from_url(request.POST.get('next', request.GET.get('next')), 'hl')
+        # If the user change the language, the URL will use the hl query parameter
+        # to redirect the resources to the required language
+        next = add_lang_query_param_from_url(request.POST.get('next', request.GET.get('next')), 'hl')
         if ((next or not request.is_ajax()) and
                 not is_safe_url(url=next,
                                 allowed_hosts={request.get_host()}, 

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -95,6 +95,32 @@ def remove_query_param_from_url(url, param):
     query.pop(param, None)
     return urlunsplit(url._replace(query=urlencode(query, True)))
 
+def switch_lang_query_param_from_url(url, param, user_language):
+    """
+    Take an url with or without language query parameters. Return url with  an updated query parameter.
+    """
+    url = urlsplit(url)
+    query = parse_qs(url.query, keep_blank_values=True)
+
+    if query.get("hl") is not None:
+        query["hl"] = [user_language]
+
+    return urlunsplit(url._replace(query=urlencode(query, True)))
+
+def add_lang_query_param_from_url(url, param, lang="en"):
+    """
+    Take an url with or without language query parameters. Return url with an updated query parameter.
+    """
+    url = urlsplit(url)
+    query = parse_qs(url.query, keep_blank_values=True)
+
+    if query.get("hl") is not None:
+        if(query.get("hl")[0] ==  "en"):
+            query["hl"] = ["fi"]
+        else:
+            query["hl"] = ["en"]
+
+    return urlunsplit(url._replace(query=urlencode(query, True)))
 
 FILENAME_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ._-0123456789"
 


### PR DESCRIPTION
# Description

* Remove the attribute `target='_blank'` from the `<a>` tag utilised to
display/open the submitted files. Since the `<a>` tag is used to
display/open the file submitted by the students in a modal window and
not on a new tab, the `target='_blank' is unnecessary.
* In the commit 2b5c311 an event handler was added to listen to every
click event in the UI. However, this event handler only added new logic
to the `<a>` tag click event. Unfortunately, the new logic caused the
modal windows to malfunction. It is also important to notice that such
an event handler, which capture every click, may have an impact on
performance. Therefore, we replaced the listener, and now it only
responds to the clicks of the `<a>` tags, which in theory are in charge
of the course navigation.

Fixes #732


# Testing

I tested changes manually, The new code seems to work, but a more exhaustive course navigation should be done in order to verify that the query parameter (?hl=en) is working as intended.

# Have you updated the README or other relevant documentation?

There is no documentation related to these changes

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
