### PR TITLE
Reorder migrations

### DIFF
--- a/course/migrations/0047_enrollment_language.py
+++ b/course/migrations/0047_enrollment_language.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('course', '0047_delete_duplicate_enrollments'),
+        ('course', '0046_coursemodule_reading_opening_time'),
     ]
 
     operations = [

--- a/course/migrations/0048_delete_duplicate_enrollments.py
+++ b/course/migrations/0048_delete_duplicate_enrollments.py
@@ -29,8 +29,8 @@ def delete_duplicates(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('userprofile', '0003_auto_20160728_1139'),
-        ('course', '0046_coursemodule_reading_opening_time'),
+        ('userprofile', '0004_auto_20200721_1422'),
+        ('course', '0047_enrollment_language'),
     ]
 
     operations = [


### PR DESCRIPTION
# Description

The current production and test servers in Aalto were previously migrated to the for-o1-2020 hotfix branch. After said branch was merged in 32b86bf17a33a5c001cc4a3ac87c41b50d8e4100 the migrations were ordered incorrectly and could not applied to the database. This pull request fixes the order of the migrations in such a way that they can be successfully applied both to the existing databases as well as an empty database.

# Testing

The changes have been tested on a database dump taken from the production A+ in Aalto, as well as on a blank database.

**Note**: If the migrations have been run on a new database before these changes, the migrations will fail after applying these changes. Running `python3 manage.py migrate --fake` will successfully mark the renamed migrations as applied. I believe that is acceptable since the changes are required in order to migrate the existing production server database.

# Have you updated the README or other relevant documentation?

No extra documentation needed.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- ~~[ ] I (developer) have created unit tests and the tests pass~~
- ~~[ ] I (developer) have created functional tests (Selenium tests) if applicable~~
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- ~~[ ] Customer/Teacher has accepted the implementation of the feature~~
