### PR TITLE
Enable editing teachers from course details

### DIFF
--- a/edit_course/course_forms.py
+++ b/edit_course/course_forms.py
@@ -74,6 +74,10 @@ class CourseInstanceForm(forms.ModelForm):
         initial_queryset=UserProfile.objects.none(),
         required=False) # Not required because a course does not have to have any assistants.
 
+    teachers = UsersSearchSelectField(queryset=UserProfile.objects.all(),
+        initial_queryset=UserProfile.objects.none(),
+        required=False) # Not required because a course does not have to have any teachers.
+
     class Meta:
         model = CourseInstance
         fields = [
@@ -99,6 +103,8 @@ class CourseInstanceForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields['assistants'].initial_queryset = self.instance.assistants.all()
         self.fields['assistants'].widget.attrs["data-search-api-url"] = api_reverse("user-list")
+        self.fields['teachers'].initial_queryset = self.instance.course.teachers.all()
+        self.fields['teachers'].widget.attrs["data-search-api-url"] = api_reverse("user-list")
         if self.instance and self.instance.visible_to_students:
             self.fields["url"].widget.attrs["readonly"] = "true"
             self.fields["url"].help_text = _("The URL identifier is locked "
@@ -123,6 +129,10 @@ class CourseInstanceForm(forms.ModelForm):
         generate_url_key_validator()(self.cleaned_data["url"])
         return self.cleaned_data["url"]
 
+    def save(self, *args, **kwargs):
+        self.instance.course.teachers.set(self.cleaned_data['teachers'])
+        self.instance.course.save()
+        return super(CourseInstanceForm, self).save(*args, **kwargs) 
 
 class CourseIndexForm(forms.ModelForm):
 

--- a/edit_course/templates/edit_course/edit_instance.html
+++ b/edit_course/templates/edit_course/edit_instance.html
@@ -21,10 +21,6 @@
     {% csrf_token %}
     <legend>{% trans "Edit course details" %}</legend>
     {{ form|bootstrap }}
-    <div class="form-group">
-        <label>{% trans "Teachers" %}</label>
-        {% profiles course.teachers.all instance is_teacher %}</p>
-    </div>
     <button type="submit" class="aplus-button--default aplus-button--md">
         {% trans "Save" %}
     </button>


### PR DESCRIPTION
# Description

The teachers of a course should be editable via the course instance details page by the teachers so, that they don't need admin assistance whenever teachers need to be edited. However, teachers are defined for a course, not a course instance, so they cannot be simply saved for the course instance object.

Fixes #700

This pr has only been tested by hand so far, as it doesn't work as it should. Saving new teachers works ok, but for some reason the select multiple list item does not list the existing teachers as **selected** on page load, so the jQuery plugin does not convert them into buttons like it does for the assistants. Also due to this, the existing teachers do not get submitted via the form unless manually added via the search field. I assume this is because some user id's don't get matched at Django side, but haven't been able to pinpoint the actual problem.