### PR TITLE
Hotfix january modal window and event handler for the <a> tags

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -665,28 +665,16 @@ $(function() {
  * to the next
  * Note! Translation requires that at least 'hl' query parameter is copied
  */
-(function(window) {
-    window.addEventListener('click', function(event) {
-        if (
-            event.target.nodeName === 'A'
-            && event.target.href
-            && event.target.protocol === window.location.protocol
-            && event.target.host === window.location.host // hostname:port
-            && (event.target.search === '' || event.target.search === '?') // no search
-        ) {
-            event.preventDefault(); // stop default redirect
-            event.target.search = window.location.search; // copy query params
-            if (event.target.getAttribute('target') === '_blank') {
-                // Open a new window or tab.
-                window.open(
-                    event.target.href,
-                    '_blank',
-                    'location,menubar,resizable,scrollbars,status,noopener');
-            } else {
-                window.location.href = event.target.href; // redirect the current window
-            }
-        }
-    }, false);
-})(window);
+(function (window) {
+  $(document).on("click", "a[href]", function (event) {
+    if (
+      event.target.className != "dropdown-toggle" &&
+      event.target.protocol === window.location.protocol &&
+      event.target.host === window.location.host && // hostname:port
+      (event.target.search === "" || event.target.search === "?") // no search
+    ) {
+      event.target.search = window.location.search; // copy query params
+    }
+  });
 
-/* vim: set et ts=4 sw=4: */
+})(window);

--- a/exercise/templates/exercise/_file_link.html
+++ b/exercise/templates/exercise/_file_link.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if file.exists %}
-	<a href="{{ file.get_absolute_url }}"{% if not file.is_passed %} class="file-modal"{% endif %} target="_blank">{{ file.filename }}</a>
+	<a href="{{ file.get_absolute_url }}"{% if not file.is_passed %} class="file-modal"{% endif %}>{{ file.filename }}</a>
 	<a href="{{ file.get_absolute_url }}?download=yes" class="aplus-button--secondary aplus-button--xs" title="{% trans Download %}">
 		<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
 		{{ file.file_object.size|filesizeformat }}


### PR DESCRIPTION
# Description

This is a hotfix to solve some of the issues that have been caused for the JavaScript code added in the commit 2b5c311. However, I recommend working in the Pull Request #736 in order to allow the users to navigate the course content while using the `?hl=` query parameter.

Fixe #732
Fixes #745

# Testing

I tested the changes manually. I tested with some chapters of the O1 course and also the aplus manual.

# Have you updated the README or other relevant documentation?

*Don't forget to update the documentation if it is relevant for this PR.*

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
