### PR TITLE
Change enrollment checks to use QuerySet get method.

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -539,7 +539,10 @@ class CourseInstance(UrlMixin, models.Model):
         UserTagging.objects.create(tag=tag, user=user.userprofile, course_instance=self)
 
     def get_enrollment_for(self, user):
-        return Enrollment.objects.filter(course_instance=self, user_profile=user.userprofile).first()
+        try:
+            return Enrollment.objects.get(course_instance=self, user_profile=user.userprofile)
+        except Enrollment.DoesNotExist:
+            return None
 
     def get_user_tags(self, user):
         return self.taggings.filter(user=user.uesrprofile).select_related('tag')

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2908,6 +2908,10 @@ msgstr ""
 "Palauttaaksesi tehtäviä sinun pitää rekisteröityä ja ilmoittautua kurssin "
 "etusivulla."
 
+#: external_services/lti.py
+msgid "Course enrollment required for accessing the LTI service."
+msgstr "Kurssille ilmoittautuminen vaaditaan LTI-palveluun pääsemiseksi."
+
 #: external_services/models.py
 msgid "Url can not contain scheme or domain part."
 msgstr "Url ei voi sisältää skeema- tai verkkotunnusosaa."


### PR DESCRIPTION
Relies on the uniqueness of enrollments based on (course_instance, user_profile).
Requires exception handling for nonexisting entries.

Fixes #600.

# Description

Getting familiar with PR process by taking an old easy issue for fixing.
Note two inline question comments in code (i.e., this is not final PR):
1) forms.py is not affected by this issue (different query attributes), right?
2) In lti.py, should we still raise PermissionDenied exception in negative case or is the default raised by get method ok (ObjectDoesNotExist)? I couldn't yet figure out how to test lti.py

I think these were the only places in code affected by this issue (did a recursive search for enrollment using grep). Am I correct?

Fixes #600

# Testing

Tested models.py in both succesful and nonexisting case.
Couldn't yet figure out how to test lti.py.
No unit tests modified.


# Have you updated the README or other relevant documentation?

None relevant, I think.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [ ] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
