### PR TITLE
Fix tag popover buttons not showing due to new Bootstrap sanitize option

### DIFF
--- a/assets/js/buttons_popover.js
+++ b/assets/js/buttons_popover.js
@@ -20,6 +20,7 @@ $.fn.extend({
         buttons;
       const default_options = {
         html: true,
+        sanitize: false,
         placement: 'bottom',
         trigger: 'focus',
       }


### PR DESCRIPTION
# Description

Bootstrap 3.4 (used in a-plus 1.8) introduced a new sanitize option that is used in popovers. Injecting buttons as html was prevented by this change, so the tag popovers in the Participants page (at least) only showed the title. This is a quick fix only, later on it should investigated if using a proper whitelist is necessary to limit the elements that can be injected (see https://getbootstrap.com/docs/3.4/javascript/#js-sanitizer).