### PR TITLE
Create usertags using cached data

### DIFF
--- a/course/api/serializers.py
+++ b/course/api/serializers.py
@@ -57,7 +57,7 @@ class StudentBriefSerializer(UserBriefSerializer):
     data = serializers.SerializerMethodField()
 
     def get_tag_slugs(self, profile):
-        cached = CachedStudent(self.context['view'].instance.id, profile.user.id)
+        cached = CachedStudent(self.context['view'].instance.id, profile)
         return cached.data['tag_slugs']
 
     def get_summary_html(self, profile):

--- a/course/cache/students.py
+++ b/course/cache/students.py
@@ -10,21 +10,20 @@ from ..models import (
     UserTag,
     UserTagging,
 )
+from userprofile.models import UserProfile
 
 
 class CachedStudent(CachedAbstract):
     KEY_PREFIX = "student"
 
-    def __init__(self, course_instance, user):
-        super().__init__(course_instance, user)
+    def __init__(self, course_instance, userprofile):
+        super().__init__(course_instance, userprofile)
 
-    def _generate_data(self, course_instance, user, *, data=None):
-        if isinstance(user, int):
-            User = get_user_model()
-            # required for is_external for external/internal tag
-            user = User.objects.get(id=user)
-        tags = (UserTagging.objects.get_all(user.userprofile, course_instance)
-                if user else [])
+    def _generate_data(self, course_instance, userprofile, *, data=None):
+        if isinstance(userprofile, UserProfile):
+            tags = (UserTagging.objects.get_all(userprofile, course_instance))
+        else:
+            tags = []
         return {
             'tag_slugs': [t.slug for t in tags],
         }

--- a/course/templates/course/_profiles.html
+++ b/course/templates/course/_profiles.html
@@ -15,6 +15,6 @@
     {{ p.user.get_full_name }}
     ({% if p.student_id %}{{ p.student_id }}{% else %}{{ p.user.username }}{% endif %})
   </a>
-  {% tags p instance %}
+  {% tags p instance instance_usertags %}
 </div>
 {% endfor %}

--- a/course/templates/course/staff/group_delete.html
+++ b/course/templates/course/staff/group_delete.html
@@ -30,7 +30,7 @@
       <tbody>
         <tr>
           <td>{{ group.id }}</td>
-          <td>{% profiles group.members.all instance is_teacher %}</td>
+          <td>{% profiles group.members.all instance is_teacher instance_usertags %}</td>
           <td>{{ group.timestamp }}</td>
         </tr>
       </tbody>

--- a/course/templates/course/staff/groups.html
+++ b/course/templates/course/staff/groups.html
@@ -34,7 +34,7 @@
       {% for group in groups %}
       <tr>
         <td>{{ group.id }}</td>
-        <td>{% profiles group.members.all instance is_teacher %}</td>
+        <td>{% profiles group.members.all instance is_teacher instance_usertags %}</td>
         <td>{{ group.timestamp }}</td>
         <td>
           <a class="aplus-button--secondary aplus-button--xs" role="button" href="{% url 'groups-edit' course_slug=course.url instance_slug=instance.url group_id=group.id %}">

--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -9,6 +9,7 @@ from exercise.cache.content import CachedContent
 from course.models import CourseInstance, UserTagging
 from lib.localization_syntax import pick_localized
 from ..cache.menu import CachedTopMenu
+from course.cache.students import CachedStudent
 
 
 register = template.Library()
@@ -111,19 +112,20 @@ def avatars(profiles):
 
 
 @register.inclusion_tag("course/_profiles.html")
-def profiles(profiles, instance, is_teacher):
+def profiles(profiles, instance, is_teacher, instance_usertags):
     return {
         'instance': instance,
         'profiles': profiles,
         'is_teacher': is_teacher,
+        'instance_usertags': instance_usertags,
     }
 
 
 @register.simple_tag
-def tags(profile, instance):
-    tags = UserTagging.objects.get_all(profile, instance)
-    return mark_safe(' '.join(tag.html_label for tag in tags))
-
+def tags(profile, instance, instance_usertags):
+    # create html for tags belonging to user at a course instance
+    user_tags = CachedStudent(instance, profile).data
+    return mark_safe(' '.join(instance_usertags[slug].html_label for slug in user_tags['tag_slugs'] if slug in instance_usertags))
 
 @register.filter
 def enrollment_audience(enrollment_audience_val):

--- a/edit_course/templates/edit_course/edit_instance.html
+++ b/edit_course/templates/edit_course/edit_instance.html
@@ -23,7 +23,7 @@
     {{ form|bootstrap }}
     <div class="form-group">
         <label>{% trans "Teachers" %}</label>
-        {% profiles course.teachers.all instance is_teacher %}</p>
+        {% profiles course.teachers.all instance is_teacher instance_usertags %}</p>
     </div>
     <button type="submit" class="aplus-button--default aplus-button--md">
         {% trans "Save" %}

--- a/edit_course/views.py
+++ b/edit_course/views.py
@@ -20,7 +20,7 @@ from lib.viewbase import (
     BaseFormView,
 )
 from authorization.permissions import ACCESS
-from course.models import CourseInstance, UserTag, UserTagging
+from course.models import CourseInstance, UserTag, UserTagging, USERTAG_EXTERNAL, USERTAG_INTERNAL
 from course.viewbase import CourseInstanceBaseView, CourseInstanceMixin
 from exercise.cache.content import CachedContent
 from exercise.cache.exercise import invalidate_instance
@@ -35,6 +35,13 @@ class EditInstanceView(CourseInstanceMixin, BaseFormView):
     access_mode = ACCESS.TEACHER
     template_name = "edit_course/edit_instance.html"
     form_class = CourseInstanceForm
+
+    def get_common_objects(self):
+        super().get_common_objects()
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('instance_usertags')
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -70,6 +70,10 @@ class InspectSubmissionView(SubmissionBaseView):
     def get_common_objects(self):
         super().get_common_objects()
         self.get_summary_submissions()
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('instance_usertags')
 
 
 class ResubmitSubmissionView(SubmissionMixin, BaseRedirectView):
@@ -107,6 +111,13 @@ class AssessSubmissionView(SubmissionMixin, BaseFormView):
     access_mode = ACCESS.GRADING
     template_name = "exercise/staff/assess_submission.html"
     form_class = SubmissionReviewForm
+
+    def get_common_objects(self):
+        super().get_common_objects()
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('instance_usertags')
 
     def get_initial(self):
         return {
@@ -230,7 +241,10 @@ class UserResultsView(CourseInstanceBaseView):
             submissions = []
         self.enrollment_exercise = exercise
         self.enrollment_submissions = submissions
-        self.note('enrollment_exercise', 'enrollment_submissions')
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('enrollment_exercise', 'enrollment_submissions','instance_usertags')
 
 
 class CreateSubmissionView(ExerciseMixin, BaseRedirectView):
@@ -277,6 +291,10 @@ class EditSubmittersView(SubmissionMixin, BaseFormView):
     def get_common_objects(self):
         self.groups = self.instance.groups.all()
         self.note('groups')
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('groups','instance_usertags')
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/exercise/templates/exercise/_submission_info.html
+++ b/exercise/templates/exercise/_submission_info.html
@@ -38,7 +38,7 @@
               <script src="{% static 'django_colortag.js' %}"></script>
               <script src="{% static 'add_tagging_dropdown.js' %}"></script>
               {% endif %}
-              {% profiles submission.submitters.all instance is_teacher %}
+              {% profiles submission.submitters.all instance is_teacher instance_usertags %}
               {% else %}
               {{ submission.submitters.all|names }}
               {% endif %}

--- a/exercise/templates/exercise/staff/_assess_info.html
+++ b/exercise/templates/exercise/staff/_assess_info.html
@@ -21,7 +21,7 @@
               </a>
               {% endif %}
             </dt>
-            <dd>{% profiles submission.submitters.all instance is_teacher %}</dd>
+            <dd>{% profiles submission.submitters.all instance is_teacher instance_usertags %}</dd>
             <dt>{% trans "Status" %}</dt>
             <dd>{{ submission.status|submission_status }}</dd>
             <dt>{% trans "Submission time" %}</dt>

--- a/exercise/templates/exercise/staff/_submissions_table.html
+++ b/exercise/templates/exercise/staff/_submissions_table.html
@@ -59,7 +59,7 @@
         {% for submission in submissions %}
         <tr>
             <td>
-                {% profiles submission.submitters.all instance is_teacher %}
+              {% profiles submission.submitters.all instance is_teacher instance_usertags %}
             </td>
             <td data-datetime="{{ submission.submission_time|date:'Y-m-d H:i' }}">
                 {{ submission.submission_time }}

--- a/exercise/templates/exercise/staff/edit_submitters.html
+++ b/exercise/templates/exercise/staff/edit_submitters.html
@@ -36,7 +36,7 @@
               </a>
             </td>
             <td class="col-md-1">{{ group.id }}</td>
-            <td>{% profiles group.members.all instance is_teacher %}</td>
+            <td>{% profiles group.members.all instance is_teacher instance_usertags %}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/exercise/templates/exercise/staff/user_results.html
+++ b/exercise/templates/exercise/staff/user_results.html
@@ -70,7 +70,7 @@
   </a>
   {% endfor %}
   &nbsp;
-  {% tags student.userprofile instance %}
+  {% tags student.userprofile instance instance_usertags %}
 </p>
 
 {% user_results student %}

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -12,6 +12,7 @@ from django.views.static import serve
 from django.db import DatabaseError
 
 from authorization.permissions import ACCESS
+from course.models import CourseModule, USERTAG_EXTERNAL, USERTAG_INTERNAL
 from course.models import CourseModule
 from course.viewbase import CourseInstanceBaseView, EnrollableViewMixin
 from lib.remote_page import RemotePageNotFound, request_for_response
@@ -326,9 +327,12 @@ class SubmissionView(SubmissionBaseView):
     def get_common_objects(self):
         super().get_common_objects()
         self.page = { "is_wait": "wait" in self.request.GET }
-        self.note("page")
         #if not self.request.is_ajax():
         self.get_summary_submissions()
+        tags = [USERTAG_INTERNAL, USERTAG_EXTERNAL]
+        tags.extend(self.instance.usertags.all())
+        self.instance_usertags = {t.slug: t for t in tags}
+        self.note('page','instance_usertags')
 
 
 class SubmissionPlainView(SubmissionView):


### PR DESCRIPTION
# Description

This is a draft pull request for essentially enabling cache for the staff/Groups page, making the page reload very quickly even on a large course with hundreds of groups of tagged students.

Currently the template includes a (Django) tag which is resolved by a function that fetches all usertags for the course instance, essentially making the same database query for each group. While the Participants page uses the same logic, apparently the way Django arranges the db joins makes this page able to be cached properly, while the Groups page always needs to be queried again.

In this implementation, the tags are fetched once per page load and injected into the templates' "profile" tag using an "instance_usertags" tag. As the cachedStudent objects already contain a plaintext array of usertag slugs, we can use them to construct the usertags' html without performing a db query. In effect, this reduces the amount of queries (for a course with 2-person groups) from three to two per group when loading the Groups page for the first time, and from three to zero on subsequent loads (when students are cached).

On my test instance, a group page of 300 2-person groups, a reload of the page created 909 queries and took 4.8-4.9 seconds, while the cache-enabling code created 11 queries and took 0.9 seconds (measured with django-silk). Tests were ran on Docker with cache running on the same machine in a memcached docker image with the memory option of "-m 1024" (1024 MB).

This implementation includes a lot of repeated code for all view classes showing usertags, and therefore should probably be refactored before deploying. Formal tests have also not been ran.