### PR TITLE
Rewrite All results page

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -53,6 +53,9 @@ with api.register(r'courses',
     courses.register(r'aggregatedata',
                      exercise.api.csv.views.CourseAggregateDataViewSet,
                      basename='course-aggregatedata')
+    courses.register(r'resultsdata',
+                     exercise.api.csv.views.CourseResultsDataViewSet,
+                     basename='course-resultsdata')
     courses.register(r'mygroups',
                      course.api.views.CourseOwnStudentGroupsViewSet,
                      basename='course-mygroups')

--- a/assets/js-translations/teacher.fi.json
+++ b/assets/js-translations/teacher.fi.json
@@ -105,6 +105,14 @@
   "opiskelijoiden_tulokset",
 
   "Some students have unofficial points that are greater than zero. However, they are calculated as zero in the table until they are confirmed. This may be caused for example by missing feedback form.":
-  "Osalla opiskelijoista on epävirallisia pisteitä, jotka ovat enemmän kuin nolla. Nämä pisteet on silti laskettu nollana taulukossa, kunnes ne on vahvistettu. Tämä voi johtua esimerkiksi puuttuvasta palautelomakkeesta."
+  "Osalla opiskelijoista on epävirallisia pisteitä, jotka ovat enemmän kuin nolla. Nämä pisteet on silti laskettu nollana taulukossa, kunnes ne on vahvistettu. Tämä voi johtua esimerkiksi puuttuvasta palautelomakkeesta.",
 
+  "Search":
+  "Etsi",
+
+  " (<, > supported)":
+  " (<, > tuettu)",
+
+  "All":
+  "kaikki"
 }

--- a/course/api/full_serializers.py
+++ b/course/api/full_serializers.py
@@ -75,6 +75,7 @@ class CourseSerializer(CourseBriefSerializer):
     )
     data = NestedHyperlinkedIdentityField(view_name='api:course-submissiondata-list')
     aggregate_data = NestedHyperlinkedIdentityField(view_name='api:course-aggregatedata-list')
+    results_data = NestedHyperlinkedIdentityField(view_name='api:course-resultsdata-list')
     groups = NestedHyperlinkedIdentityField(view_name='api:course-groups-list')
     my_groups = NestedHyperlinkedIdentityField(view_name='api:course-mygroups-list')
 
@@ -95,6 +96,7 @@ class CourseSerializer(CourseBriefSerializer):
             'my_data',
             'data',
             'aggregate_data',
+            'results_data',
             'groups',
             'my_groups',
         )

--- a/exercise/api/csv/aggregate_points.py
+++ b/exercise/api/csv/aggregate_points.py
@@ -1,0 +1,86 @@
+from django.conf import settings
+from collections import OrderedDict
+
+# Generate students' results from this course instance
+# Only exercises in which student has submitted answers will be returned
+# to save bandwidth. Exercise points are returned in the form:
+# xx Count: yy, xx Total: zz
+# where xx is the exercise id, yy the submission count and zz the exercise points.
+# For convenience, we also return the total submission count and points for student
+
+def aggregate_points(request, profiles, taggings, exercises, aggregate, number):
+    DEFAULT_FIELDS = [
+      'UserID', 'StudentID', 'Email', 'FirstName', 'LastName', 'Tags',
+    ]
+    OBJECT_FIELDS = [
+      '{} Count', '{} Total',
+    ]
+
+    d = 1 + (len(number.split('.')) if number else 0)
+    exercise_fields = []
+
+    num = None
+    for e in exercises:
+        if e['type'] == 'exercise':
+            for n in OBJECT_FIELDS:
+                exercise_fields.append(n.format(e['id']))
+
+    agg = {}
+    # Gather exercise points per student
+    for row in aggregate:
+        ex = row['exercise_id']
+
+        values = [row['count'],row['total']]
+        user_row = agg.get(row['submitters__user_id'], {})
+        user_row[ex] = values
+        agg[row['submitters__user_id']] = user_row
+
+    # Prefetch all tag_id - user_id pairs at once from DB to avoid multiple queries
+    # TODO: Ideally this should probably be done in api.csv.views
+    all_tags = list(taggings.all().values('user_id','tag_id'))
+
+    sheet = []
+
+    for profile in profiles:
+        uid = profile.user.id
+        user_row = agg.get(uid, {})
+        user_tags = [settings.EXTERNAL_USER_LABEL.lower() if profile.is_external else settings.INTERNAL_USER_LABEL.lower()]
+        # Instead of filtering the Django resultset (which causes a new DB query),
+        # we find the users' tags manually from the prefetched array of dicts
+        other_tags = list(item for item in all_tags if item["user_id"] == profile.id)
+        #other_tags = all_tags.all().filter(user_id=profile.id)
+        for tag in other_tags:
+            user_tags.append(str(tag['tag_id']))
+        #user_tags.extend(tags.get(uid, []))
+        row = OrderedDict([
+            ('UserID', uid),
+            ('Email', profile.user.email),
+            ('StudentID', profile.student_id),
+            ('Name', profile.user.first_name + ' ' + profile.user.last_name),
+            ('Tags', '|'.join(user_tags)),
+        ])
+
+        # Add submitted exercise count and points of the user as labeled dictionary items
+        # so for example if agg[uid] is {14: [1,10]}, it is turned into:
+        # "14 Count": 1
+        # "14 Total": 10
+        #
+        if uid in agg:
+            student_totalsubs = 0
+            student_totalscore = 0
+            try:
+                for e in agg[uid]:
+                    row[str(e) + ' Count'] = agg[uid][e][0]
+                    student_totalsubs += agg[uid][e][0]
+                    row[str(e) + ' Total'] = agg[uid][e][1]
+                    student_totalscore += agg[uid][e][1]
+            except KeyError:
+                pass
+
+            # Add totals per student
+            row['Count'] = student_totalsubs
+            row['Total'] = student_totalscore
+
+        sheet.append(row)
+
+    return sheet, DEFAULT_FIELDS + exercise_fields

--- a/exercise/api/serializers.py
+++ b/exercise/api/serializers.py
@@ -31,6 +31,7 @@ class ExerciseBriefSerializer(AplusModelSerializer):
             'max_points',
             'max_submissions',
             'hierarchical_name',
+            'difficulty',
         )
 
 

--- a/exercise/static/exercise/css/results_staff.css
+++ b/exercise/static/exercise/css/results_staff.css
@@ -5,19 +5,7 @@
 .nav-tabs>li.active>a,
 .nav-tabs>li.active>a:hover,
 .nav-tabs>li.active>a:focus {
-    background-color: #A9A9A9 !important;
-}
-
-/*
- * Table export
- */
-
-#export-button-menu {
-    background-color : #A9A9A9;
-}
-
-caption.tableexport-caption button {
-    margin: 0px 10px 0px 10px;
+	background-color: #A9A9A9 !important;
 }
 
 /*
@@ -25,28 +13,29 @@ caption.tableexport-caption button {
  */
 
 .student-id,
-.student-name,
-#table-body td.indicator-heading {
-    background-color: rgb(188, 232, 241);
-    font-weight: bold;
+.student-name {
+	background-color: rgb(188, 232, 241);
+	font-weight: bold;
 }
 
-#table-body td.indicator-heading {
-    filter: brightness(85%);
+table#table-points thead#table-heading th.indicator-heading {
+	filter: brightness(85%);
 }
 
-
-.indi-normal-val,
-.indi-pct-val {
-    background-color: white;
-    font-weight: bold;
-}
-.indi-normal-val {
-    text-align: left;
-    border-bottom: none !important;
+table#table-points thead#table-heading th {
+	top: 0;
+	border-bottom-width: 1px;
 }
 
-.indi-pct-val {
-    text-align: right;
-    border-top: none !important;
+table#table-points thead th:not(.indicator-heading) {
+	background-color: white;
+}
+
+table#table-points thead th div.ratio {
+	text-align: right;
+	font-style: italic;
+	font-weight: normal;
+}
+table#table-points thead th div.ratio::after {
+	content: "%";
 }

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -3,664 +3,996 @@
         $(document.currentScript) :
         $('script').last()); // Ugly solution for IE11
 
+    /**
+     * Simple hack to select DataTables language file depending on the HTML body class
+     */
+    var pageLanguageUrl = '';
+
+    /**
+     * URL to fetch exercise data from
+     */
     const exercisesUrl = currentScript.data("exercisesUrl");
-    const studentsUrl = currentScript.data("studentsUrl");
+
+    /**
+     * URL to fetch usertags from
+     */
     const usertagsUrl = currentScript.data("usertagsUrl");
-    const pointsUrl = currentScript.data("pointsUrl");
 
-    let _exerciseSelection;
-    let _allExercises = [];
+    /**
+     * URL to fetch student data and submission results from
+     * TODO: slip in the format parameter in a more elegant fashion
+     */
+    var pointsUrl = currentScript.data("pointsUrl") + '?format=json';
+
+    /**
+     * Stores the exercise data loaded via ajax call
+     */
     let _exercises;
-    let _students;
-    let _usertags;
-    let _points = {};
-    let _ajaxCompleted = false;
 
-    let tableExportVar;
-
-    /* TODO: Use better logic for translations.
-     * Currently only some translations wait for aplus:translation-ready and most of them do not,
-     * since the translations become available during the script.
+    /**
+     * Stores the usertags data loaded via ajax call
      */
-    $(document).on("aplus:translation-ready", function() {
-        // TableExport plugin
-        // https://tableexport.v5.travismclarke.com/#tableexport
-        TableExport.prototype.formatConfig.xlsx.buttonContent = _("Export to xlsx (Excel)");
-        TableExport.prototype.formatConfig.csv.buttonContent = _("Export to csv (LibreOffice)");
-        TableExport.prototype.formatConfig.txt.buttonContent = _("Export to txt");
-        tableExportVar = $("#table-points").tableExport({
-            "position": "top",
-            "bootstrap": "true",
-            "filename": _("student_results"),
-        });
+    let _usertags = [];
 
-        // Move the default TableExport download buttons inside a single dropdown menu
-        $("caption.tableexport-caption").children("button").each(function() {
-            $("#export-button-menu").append($(this).detach());
-        });
-    });
-
-    // Make the table headings and student IDs stick when scrolling table
-    $('#table-points-div').scroll(function(ev) {
-        $('thead#table-heading th').css('transform', 'translateY(' + this.scrollTop + 'px)');
-        $('tbody td.stick-on-scroll').css('transform', 'translateX(' + this.scrollLeft + 'px)');
-    });
-
-
-    // Booleans to allow teacher to choose with checkboxes what data indicators they want to see
-    let _totalSubmTrue = false;
-    let _avgSubmTrue = false;
-    let _maxSubmTrue = false;
-    let _totalStuSubmTrue = false;
-    let _totalStuMaxTrue = false;
-    let _avgPTrue = false;
-    let _maxPTrue = false;
-    let _showOfficial = true;
-
-    $("input.total-subm-checkbox").change(function() {
-        _totalSubmTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.avg-subm-checkbox").change(function() {
-        _avgSubmTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.max-subm-checkbox").change(function() {
-        _maxSubmTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.total-stu-subm-checkbox").change(function() {
-        _totalStuSubmTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.total-stu-max-checkbox").change(function() {
-        _totalStuMaxTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.avg-p-checkbox").change(function() {
-        _avgPTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.max-p-checkbox").change(function() {
-        _maxPTrue = this.checked;
-        exerciseSelectionChange();
-    });
-
-    $("input.official-checkbox").change(function() {
-        _showOfficial = this.checked;
-        exerciseSelectionChange();
-    });
-
-
-    // Set up the tooltip for checkboxes, look docs below for tooltip
-    // https://getbootstrap.com/docs/3.3/javascript/
-    $('[data-toggle="tooltip"]').tooltip({
-        "trigger": "hover",
-    });
-
-    $('[data-toggle="tooltip"]').on('click', function() {
-        $(this).tooltip('hide');
-    })
-
-
-    // Event listener for tag filters
-    $('.filter-users button').on('click', function(event) {
-        event.preventDefault();
-        let icon = $(this).find('.glyphicon');
-        if (icon.hasClass('glyphicon-unchecked')) {
-            icon.removeClass('glyphicon-unchecked').addClass('glyphicon-check');
-        } else {
-            icon.removeClass('glyphicon-check').addClass('glyphicon-unchecked');
-        }
-        exerciseSelectionChange();
-    });
-
-    /*
-     * Creates the html for indicator data row. This is called for each row that has
-     * checkbox checked for its indicator data.
-     * @param  {string} tooltipTitle The text that is shown when hovering over heading.
-     * @param  {string} headingTitle The heading text.
-     * @return {string} Returns the html that creates the data indicator rows in table.
+    /**
+     * Stores all difficulty levels of current course instance
+     * with an array of exercise ids belonging to that difficulty level
+     * { difficulty_level(str): [exercise_id(int)] }
      */
-    function createIndicatorRow(tooltipTitle, headingTitle, dataValues) {
-        // Data indicator headings have title and tooltip info that is shown when hovering mouse on the heading title
-        let indicatorHeadingHtml = "";
-        if (dataValues && dataValues.length > 0) {
-            indicatorHeadingHtml +=
-                '<tr class="no-filtering"><td style="border-right: none !important; border-bottom: none !important;"' +
-                'class="indicator-heading stick-on-scroll" data-toggle="tooltip" ' +
-                'title="' + tooltipTitle + '">' + headingTitle +
-                '</td><td style="border-left: none !important; border-bottom: none !important;"' +
-                'class="indicator-heading stick-on-scroll" data-toggle="tooltip" ' +
-                'title="' + tooltipTitle + '"></td>';
+    let _difficulties = {};
+
+    /**
+     * Difficulty levels lookup table in reverse (for performance),
+     * i.e. from exercise id to difficulty level
+     * { exercise_id(int): difficulty_level(str) }
+     */
+    let _reverseDifficulties = {};
+
+    /**
+     * Difficulty levels present in the user-filtered data
+     * [difficulty_level(str)]
+     */
+    let _activeDifficulties = [];
+
+    /**
+     * Global to store the currently visible summary item ids as strings
+     * [summary_item(str)]
+     */
+    let _activeSummaryItems = [];
+
+    /**
+     * Enum for _displayMode
+     */
+    const dm = { DIFFICULTY: 1, MODULE: 2, EXERCISE: 3 }
+
+    /**
+     * We need a string version of the enum when creating a css class name
+     */
+    const dmRev = { 1: 'difficulty', 2: 'module', 3: 'exercise' }
+
+    /**
+     * Global to store the current display mode: difficulty, module, or exercise
+     * This is implemented as enum for better performance, but probably does
+     * not save that many ms compared to using a string index.
+     */
+    let _displayMode = dm.DIFFICULTY;
+
+    /**
+     * The DataTables jQuery plugin instance is stored here. This is actually used only
+     * when reloading data from backend due to toggling official/unofficial points, while
+     * most of the code uses dtVar which gets defined in the initComplete callback of DataTables.
+     */
+    var dtApi;
+
+    /**
+     * Due to issues with getting the DataTables custom search work with dynamic columns,
+     * we keep the points columns search values in this object. The custom search plugin
+     * compares each active column with the data value for each row.
+     */
+    var colSearchVals = {};
+
+    /**
+     * Summary row enumerations, faster to evaluate than string indices so why not
+     */
+    const sv = {
+        TOTAL_SUBS: 1,
+        AVG_SUBS_PER_STUD: 2,
+        MAX_SUBS: 3,
+        STUDS_WITH_SUBS: 4,
+        STUDS_WITH_MAX_POINTS: 5,
+        AVG_PTS_PER_STUD: 6,
+        MAX_PTS: 7
+    }
+
+    /**
+     * A look-up table of summary rows available for the user to select
+     *
+     * TITLE   defines the row header text in table
+     * ROW     defines the order these are presented in the table
+     * INITVAL is either an integer for integer-valued properties,
+     *         empty array for array variables that are combined as unions
+     *         and array with a string for array variables combined as intersections
+     */
+    const summaries = {
+        [sv.TOTAL_SUBS]: {
+            TITLE: "Total submissions",
+            ROW: 0,
+            INITVAL: 0
+        },
+        [sv.AVG_SUBS_PER_STUD]: {
+            TITLE: "Average submissions per student with submissions",
+            ROW: 1,
+            INITVAL: 0
+        },
+        [sv.MAX_SUBS]: {
+            TITLE: "Maximum submissions",
+            ROW: 2,
+            INITVAL: 0
+        },
+        [sv.STUDS_WITH_SUBS]: {
+            TITLE: "Students with submissions",
+            ROW: 3,
+            INITVAL: []
+        },
+        [sv.STUDS_WITH_MAX_POINTS]: {
+            TITLE: "Students with max points",
+            ROW: 4,
+            INITVAL: ['no_ex']
+        },
+        [sv.AVG_PTS_PER_STUD]: {
+            TITLE: "Average points per student with submissions",
+            ROW: 5,
+            INITVAL: 0
+        },
+        [sv.MAX_PTS]: {
+            TITLE: "Maximum points",
+            ROW: 6,
+            INITVAL: 0
+        },
+    }
+
+    /**
+     * The index of our "Tags" column (some operations depend on this)
+     * TODO: make it better
+     */
+    const TAGS_COL_ID = 4;
+
+    /**
+     * The index of our "Total" column (some operations depend on this)
+     * TODO: make it better
+     */
+    const TOTAL_COL_ID = 6;
+
+    /**
+     * Holds the contents of summary rows which are recreated from this data
+     * on every DataTable redraw.
+     */
+    var summArray = [];
+    for(var s in summaries) {
+        summArray[s] = [];
+    }
+
+    /**
+     * Save DOM references as constants for fewer jQuery lookups
+     */
+    const pointsTableRef = $('#table-points'); // Main points table
+    // Initial selects to build multiselects from
+    const moduleSelectRef = $("#module-selection");
+    const exerciseSelectRef = $("#exercise-selection");
+    // Summary Checkboxes and tag buttons references
+    const summaryCheckboxesRef = $("input.summary-checkbox");
+    const tagButtonsRef = $("button.tag-button");
+
+    /**
+     * Holds the selector for manipulating multiselect items
+     * after they are added into the DOM
+     */
+    let multiSelectSelector;
+
+    /**
+     * Stores the getBoundingClientRect() result
+     * (the initial Y-location of the data table headers).
+     * Needed to make the headers remain visible when scrolling down.
+     */
+    let initialTableYOffset;
+
+    /**
+     * A debounce function from Underscore.js, taken from
+     * https://davidwalsh.name/javascript-debounce-function
+     * Used in some operations that we don't want to perform too often
+     * with large tables, so the browser can keep up.
+     */
+    // Returns a function, that, as long as it continues to be invoked, will not
+    // be triggered. The function will be called after it stops being called for
+    // N milliseconds. If `immediate` is passed, trigger the function on the
+    // leading edge, instead of the trailing.
+    function debounce(func, wait, immediate) {
+        var timeout;
+        return function() {
+            var context = this, args = arguments;
+            var later = function() {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    };
+
+    /**
+     * Search function for individual columns
+     * This is made a separate function so it can be easily debounced
+     * @param {number} col column to target the search to
+     * @param {string} search string to search for
+     */
+    function bigColumnSearch(col,search) {
+        dtVar.column(col).search(search);
+        recalculateTable(); // draw() is called at the end of this
+        $('th.col-' + col + '.sorting').find('input').focus(); // return focus to search box after searching
+    }
+
+    /**
+     * Due to the complexity of recalculateTable, we debounce the point
+     * columns' value searches so that in large courses the UI remains
+     * responsive.
+     */
+    var recalculateTableDebounced = debounce(bigColumnSearch, 500);
+
+    /**
+     * Also debounce the update of table headers y position for sticky scrolling
+     * when doing a page resize.
+     */
+    var refreshTableYPositionDebounced = debounce(refreshTableYPosition, 500);
+
+    /**
+     * Gets initial y position for rendered table header (and updates it when window width changes)
+     * TODO: Header row sticks to <menu height> px too low when mobile menu is open
+     */
+    function refreshTableYPosition() {
+        // Need to scroll to top first so we get correct coordinates
+        window.scroll(0,0);
+        initialTableYOffset = document.getElementById('table-heading').getBoundingClientRect();
+
+        // Detach previous scroll event handler with old values
+        $(window).off('scroll');
+
+        /**
+         * Make the headers stick when scrolling page (TODO: find a less hacky method)
+         */
+        $(window).scroll(function(ev) {
+            if(pageYOffset > initialTableYOffset.top) {
+                $('thead#table-heading th').css('transform', 'translateY(' + (this.pageYOffset - initialTableYOffset.top) +  'px)');
+            } else {
+                $('thead#table-heading th').css('transform', 'translateY(0px)');
+            }
+        });
+    }
+
+    /**
+     * Clears all search fields in column headers and DataTables internals
+     */
+    function clearSearch() {
+        colSearchVals = {}; // clear our custom search columns bookkeeping
+        $( 'thead#table-heading input').val(''); // clear column search box values
+        // clear checked tag filters
+        tagButtonsRef.children('span').removeClass('glyphicon-unchecked').removeClass('glyphicon-check').addClass('glyphicon-unchecked');
+        $('.withsubs-checkbox').prop('checked', false); // clear "show only students with submissions" checkbox
+        $('div.filter-users input.tags-operator').first().prop('checked',true); // reset tags search operator to first option (AND)
+        dtVar.search(''); // clear general DataTables search
+        dtVar.columns().search(''); // clear ALL column-specific searches
+        recalculateTableDebounced(); // finally refresh the table with no filtering
+    }
+
+    /**
+     * Clears search fields related to dynamically generated columns
+     */
+     function clearPointsSearch() {
+         // clear our custom search columns bookkeeping for dynamic columns
+        /*const colSearchValsAsArray = Object.entries(colSearchVals);
+        const staticColsArray = dtVar.columns('.static');
+        colSearchVals = colSearchValsAsArray.filter(([key,val]) => staticColsArray.includes(key));*/
+        colSearchVals = {}; // clear our custom search columns bookkeeping
+
+        // clear column search boxes for non-text columns (the first three columns)
+        $( 'thead#table-heading input').not('.textval').val('');
+        // clear searches of points columns
+        dtVar.columns('.points').search('');
+        recalculateTableDebounced(); // finally refresh the table
+    }
+
+    /**
+     * Does a search on the tags column based on the tag selections by user
+     */
+    function searchForSelectedTags() {
+        let activeTags = [];
+        tagButtonsRef.each(function() {
+            //if($(this).children('span').hasClass('glyphicon-check')) activeTags.push(_reverseUsertags[$(this).data('tag-slug')]);
+            if($(this).children('span').hasClass('glyphicon-check')) activeTags.push($(this).data('tag-name'));
+        })
+        if($('input[name="tags-operator"]:checked').val() === 'and') {
+            dtVar.column(TAGS_COL_ID).search(activeTags.join(" "), false, true );
         } else {
-            indicatorHeadingHtml +=
-                '<tr class="no-filtering"><td style="border-right: none !important;" colspan="2"' +
-                'class="indicator-heading stick-on-scroll" data-toggle="tooltip" ' +
-                'title="' + tooltipTitle + '">' + headingTitle +
-                '</td><td style="border-left: none !important; border-top: none !important;"' +
-                'class="indicator-heading stick-on-scroll" data-toggle="tooltip" ' +
-                'title="' + tooltipTitle + '"></td>';
+            dtVar.column(TAGS_COL_ID).search(activeTags.join("|"), true, false );
         }
-
-        let normalValuesHtml = '';
-        let pctValuesHtml =
-            '<tr class="no-filtering tableexport-ignore">'
-        let sumValue = 0;
-        dataValues.forEach(function(value) {
-            sumValue += value[0];
-        });
-        sumValue = Number.isInteger(sumValue) ? sumValue : sumValue.toFixed(2);
-
-        // Empty data cells for total and tags in data indicators
-        if (dataValues && dataValues.length > 0) {
-            normalValuesHtml +=
-                '<td class="indi-normal-val"></td>'
-                + '<td class="indi-normal-val">' + sumValue + '</td>';
-            pctValuesHtml +=
-                '<td style="border-right: none !important; border-top: none !important;"'
-                + 'class="indicator-heading stick-on-scroll" data-toggle="tooltip" '
-                + 'title="' + tooltipTitle + '"></td>'
-                + '<td style="border-left: none !important; border-top: none !important;"'
-                + 'class="indicator-heading stick-on-scroll" data-toggle="tooltip" '
-                + 'title="' + tooltipTitle + '"></td>'
-                + '<td class="indi-pct-val"></td>'
-                + '<td class="indi-pct-val"></td>';
-        }
-
-        // Normal and percentage values on seperate rows in data indicators
-        dataValues.forEach(function(value) {
-            let normalValue = Number.isInteger(value[0]) ? value[0] : value[0].toFixed(2);
-            normalValuesHtml += '<td class="indi-normal-val">' + normalValue + '</td>';
-            pctValuesHtml += '<td class="indi-pct-val">' + value[1].toFixed(2) + '%</td>';
-        });
-
-        normalValuesHtml += '</tr>';
-        pctValuesHtml += '</tr>';
-
-        return indicatorHeadingHtml + normalValuesHtml + pctValuesHtml;
+        recalculateTableDebounced();
+        //dtVar.draw();
     }
 
 
-    /*
-     * Creates the table with student points based on
-     * selected exercises, data indicators, tags and grouping method.
-     * @param {string} showMethod The grouping method: show all, show by difficulties, show by modules
+    /**
+     * Recreates summary rows html and append it to the datatable header
+     * based on which summary items are selected via checkboxes
      */
-    window.createPointTable = function(showMethod) {
-        if (!_ajaxCompleted) {
-            return;
+    function recreateSummaryRows() {
+        let rowStart = '<tr class="summaryitem"><th class="student-id stick-on-scroll indicator-heading" colspan="2" style="transform: translateX(0px);">';
+        let rowEnd = '</tr>';
+        var tableheading = $('thead#table-heading');
+        var newHeading = '';
+        tableheading.find('tr.summaryitem').remove(); // Remove existing summary rows
+
+        for(var i in _activeSummaryItems) {
+            let cells = '';
+            /**
+             * TODO: This indexing is somewhat hacky, but at least at this time the sv enum
+             * (1,2,3,..) is just off by one from summary row numbering (0,1,2,...)
+             */
+            let item = parseInt(_activeSummaryItems[i]) + 1;
+            var cols = dtVar.columns('.' + dmRev[_displayMode]);
+
+            for(var d in cols[0]) {
+                if(summArray[item] !== undefined) {
+                    // Only add cell if the column is currently visible
+                    if(dtVar.columns(cols[0][d]).visible()[0]) {
+                        cells += '<th>' + summArray[item][cols.indexes()[d]] + '</th>';
+                    }
+                }
+            }
+            newHeading += (rowStart + _(summaries[item]['TITLE']) + '</td><th></th><th>' + summArray[item][TOTAL_COL_ID] + '</th>' + cells + rowEnd);
+        }
+        // Append all summary rows' html at once for better performance
+        tableheading.append($(newHeading));
+    }
+
+    /**
+     * Recalculates the whole datatable (row and column sums and summary rows)
+     * when any of the filtering parameters or the display mode changes.
+     * We keep track of summaries of each display mode separately, and finally
+     * assign the calculated totals for the current displaymode.
+     * As this function is ran each time we change the displaymode, we only
+     * do calculations and assignments required for that mode.
+     */
+    function recalculateTable() {
+        let selectedModules = moduleSelectRef.val();
+        let selectedExercises = exerciseSelectRef.val();
+        var pointsGrandTotal = 0;
+        var pointsModuleTotal = [];
+
+        /**
+         * Initialize arrays to store total summaries. Some summaries need to keep
+         * track of unique students, and are therefore initialized as arrays.
+         */
+        let tSummaries = [];
+        for(var s in summaries) {
+            if(summaries[s]['INITVAL'] === 0) {
+                tSummaries[s] = summaries[s]['INITVAL'];
+            } else {
+                tSummaries[s] = [];
+            }
         }
 
-        // Pick only students that have the selected tags
-        // Use same logic for tag filtering as in participants.js
-        let filteredStudentPool = [];
-        _students.forEach(function(student) {
-            const tagSlugFilters = $.makeArray($('.filter-users button:has(.glyphicon-check)'))
-            .map(function(elem) {
-                return $(elem).data('tagSlug');
-            });
-            let studentTagSlugs = student.tag_slugs;
+        // Initialize arrays to store module summaries
+        let mSummaries = [];
+        for(var s in summaries) {
+            mSummaries[s] = [];
+        }
 
-            // Set intercetion tags ∩ filters
-            const intersect = studentTagSlugs.filter(function (tag) {
-                return tagSlugFilters.indexOf(tag) >= 0;
-            });
+        // Initialize arrays to store exercise summaries
+        let eSummaries = [];
+        for(var s in summaries) {
+            eSummaries[s] = [];
+        }
 
-            // Only create the row for a student, if they have one of the tags that are currently selected
-            if (intersect.length === tagSlugFilters.length) {
-                filteredStudentPool.push(student);
-            }
-        });
-
-        $("#table-heading").empty();
-        $("#table-body").empty();
-
-        let htmlTablePoints = "";
-        let pointKeys = [];
-
-        let totalSubmitters = {};
-        let totalMaxSubmitters = {};
-        let totalSubmissions = {};
-        let maxAllowedSubmissions = {};
-        let maxPoints = {};
-        let maxPointsTotal = 0;
-        let totalPoints = {};
-
-
-        // Gather information that is same for all students from the first student for better performance
-        const firstStudent = _students[0];
-        const sidFirst = firstStudent.id;
-        let moduleChecklist = [];
-
-        $(_exerciseSelection).each(function() {
-            const moduleID = $(this).data("moduleId");
-            const module = _points[sidFirst].modules.filter(
-                function(m) {
-                    return m.id == moduleID;
-            })[0];
-            const exerciseID = $(this).data("exerciseId");
-            const exercise = module.exercises.filter(
-                function(exercise) {
-                    return exercise.id == exerciseID;
+        if(_displayMode === dm.DIFFICULTY) {
+            var pointsDifficultyTotal = [];
+            var dSummaries = [];
+            // Reset the active difficulties
+            _activeDifficulties = [];
+            // Initialize arrays to store summaries per difficulty level
+            for(var s in summaries) {
+                dSummaries[s] = [];
+                for(diff in _difficulties) {
+                    pointsDifficultyTotal[diff] = 0;
+                    if(summaries[s]['INITVAL'] === 0) {
+                        dSummaries[s][diff] = summaries[s]['INITVAL'];
+                    } else {
+                        dSummaries[s][diff] = (summaries[s]['INITVAL'].length > 0 ? ['no_ex'] : []);
+                    }
                 }
-            )[0];
-
-            if (showMethod === "difficulty") {
-                maxPoints[exercise.difficulty] = maxPoints[exercise.difficulty] + exercise.max_points || exercise.max_points;
-                maxPointsTotal += exercise.max_points;
-                if (pointKeys.indexOf(exercise.difficulty) === -1) {
-                    pointKeys.push(exercise.difficulty);
-                    pointKeys.sort();
-                }
-                _allExercises.forEach(function(exAll) {
-                    if (exAll.id === exercise.id) {
-                        maxAllowedSubmissions[exercise.difficulty] = maxAllowedSubmissions[exercise.difficulty] + exAll.max_submissions || exAll.max_submissions;
-                    }
-                });
             }
+        }
 
-            if (showMethod === "module") {
-                if (moduleChecklist.indexOf(module) === -1) {
-                    moduleChecklist.push(module);
-                    pointKeys.push(module.name);
-                }
+        // No need to go through modules, if no exercises selected
+        if(selectedModules !== null && selectedExercises !== null) {
+            // The main loop through all modules
+            for(moduleIdx in _exercises) {
+                var modId = _exercises[moduleIdx].id; // Unique module id
+                pointsModuleTotal[modId] = 0;
 
-                _allExercises.forEach(function(exAll) {
-                    if (exAll.id === exercise.id) {
-                        maxAllowedSubmissions[module.name] = maxAllowedSubmissions[module.name] + exAll.max_submissions || exAll.max_submissions;
-                        maxPoints[module.name] = maxPoints[module.name] + exercise.max_points || exercise.max_points;
-                        maxPointsTotal += exercise.max_points;
-                    }
-                });
+                var moduleScores = []; // array of all students' cumulative points per module
 
-            }
+                // Only take into account the modules currently selected from the menu
+                if(selectedModules.includes('mod-m' + modId)) {
+                    // Get the "physical" index id of this module in our datatable
+                    var modIdx = dtVar.column('.mod-m' + modId).index();
 
-            if (showMethod === "all") {
-                maxPoints[exercise.name] = exercise.max_points;
-                maxPointsTotal += exercise.max_points;
-                pointKeys.push(exercise.name);
-
-                _allExercises.forEach(function(exAll) {
-                    if (exAll.id === exercise.id) {
-                        maxAllowedSubmissions[exercise.name] = exAll.max_submissions;
-                    }
-                });
-            }
-
-        });
-
-        // Gather personal information for each student, eg. individual points
-        filteredStudentPool.forEach(function(student) {
-            let points = {};
-            let unofficialPoints = {};
-            const sid = student.id;
-
-            // Calculate points for each difficulty by grouping each each difficulty category exercises together
-            if (showMethod === "difficulty") {
-                let submittedDifficulty = {};
-
-                $(_exerciseSelection).each(function() {
-                    const moduleID = $(this).data("moduleId");
-                    const exerciseID = $(this).data("exerciseId");
-                    const exercise = _points[sid].modules.filter(
-                        function(m) {
-                            return m.id == moduleID;
-                        })[0].exercises.filter(
-                        function(exercise) {
-                            return exercise.id == exerciseID;
-                        }
-                    )[0];
-
-                    const exercisePoints = exercise.official ? exercise.points : 0;
-                    points[exercise.difficulty] = points[exercise.difficulty] + exercisePoints || exercisePoints;
-                    unofficialPoints[exercise.difficulty] = unofficialPoints[exercise.difficulty] + exercise.points || exercise.points;
-                    totalPoints[exercise.difficulty] = totalPoints[exercise.difficulty] + exercisePoints || exercisePoints;
-                    if (exercise.submission_count > 0) {
-                        totalSubmissions[exercise.difficulty] = totalSubmissions[exercise.difficulty] + exercise.submission_count || exercise.submission_count;
-                        if (submittedDifficulty[exercise.difficulty] === undefined) {
-                            totalSubmitters[exercise.difficulty] = totalSubmitters[exercise.difficulty] + 1 || 1;
-                            submittedDifficulty[exercise.difficulty] = true;
-                        }
-                        if (points[exercise.difficulty] === maxPoints[exercise.difficulty]) {
-                            totalMaxSubmitters[exercise.difficulty] = totalMaxSubmitters[exercise.difficulty] + 1 || 1;
-                        }
-                    }
-                });
-            }
-
-            // Calculate points for each module by grouping each each module's exercises together
-            if (showMethod === "module") {
-                let moduleChecklist = [];
-
-                $(_exerciseSelection).each(function() {
-                    const moduleID = $(this).data("moduleId");
-                    const module = _points[sid].modules.filter(
-                        function(m) {
-                            return m.id == moduleID;
-                    })[0];
-                    const exerciseID = $(this).data("exerciseId");
-                    const exercise = module.exercises.filter(
-                        function(exercise) {
-                            return exercise.id == exerciseID;
-                        }
-                    )[0];
-
-                    const exercisePoints = exercise.official ? exercise.points : 0;
-                    points[module.name] = points[module.name] + exercisePoints || exercisePoints;
-                    unofficialPoints[module.name] = unofficialPoints[module.name] + exercise.points || exercise.points;
-                    totalPoints[module.name] = totalPoints[module.name] + exercisePoints || exercisePoints;
-
-                    if (moduleChecklist.indexOf(module) === -1) {
-                        moduleChecklist.push(module);
-                        if (module.submission_count > 0) {
-                            totalSubmissions[module.name] = totalSubmissions[module.name] + module.submission_count || module.submission_count;
-                            totalSubmitters[module.name] = totalSubmitters[module.name] + 1 || 1;
-                            if (points[module.name] === maxPoints[module.name]) {
-                                totalMaxSubmitters[module.name] = totalMaxSubmitters[module.name] + 1 || 1;
+                    /**
+                     * Cannot assign the array values directly as these are passed by reference.
+                     */
+                    for(var s in summaries) {
+                        if(summaries[s]['INITVAL'] === 0) {
+                            mSummaries[s][modId] = summaries[s]['INITVAL'];
+                        } else {
+                            // Only init if empty array
+                            if(summaries[s]['INITVAL'].length === 0) {
+                                mSummaries[s][modId] = [];
                             }
                         }
                     }
-                });
-            }
 
-            // Calculate points for each exercise
-            if (showMethod === "all") {
-                $(_exerciseSelection).each(function() {
-                    const moduleID = $(this).data("moduleId");
-                    const exerciseID = $(this).data("exerciseId");
-                    const exercise = _points[sid].modules.filter(
-                        function(m) {
-                            return m.id == moduleID;
-                        })[0].exercises.filter(
-                        function(exercise) {
-                            return exercise.id == exerciseID;
-                        }
-                    )[0];
+                    // Only need to process exercises if there are some
+                    if(_exercises[moduleIdx].exercises.length > 0) {
 
-                    const exercisePoints = exercise.official ? exercise.points : 0;
-                    points[exercise.name] = exercisePoints;
-                    unofficialPoints[exercise.name] = exercise.points;
-                    totalPoints[exercise.name] = totalPoints[exercise.name] + exercisePoints || exercisePoints;
-                    if (exercise.submission_count > 0) {
-                        totalSubmissions[exercise.name] = totalSubmissions[exercise.name] + exercise.submission_count || exercise.submission_count;
-                        totalSubmitters[exercise.name] = totalSubmitters[exercise.name] + 1 || 1;
-                        if (exercisePoints === exercise.max_points) {
-                            totalMaxSubmitters[exercise.name] = totalMaxSubmitters[exercise.name] + 1 || 1;
+                        // Loop through the exercises in current module
+                        for(exerciseIdx in _exercises[moduleIdx].exercises) {
+                            var exId = _exercises[moduleIdx].exercises[exerciseIdx].id; // Unique exercise id
+
+                            // Only take into account the exercises currently selected from the menu
+                            if(selectedExercises.includes('ex-' + exId)) {
+                                /**
+                                 * Get the "physical" column index id on datatable for this exercise.
+                                 * Note, that this is always required for filtering the table to calculate sums.
+                                 */
+                                var exIdx = dtVar.column('.ex-' + exId).index();
+
+                                for(var s in summaries) {
+                                    if(summaries[s]['INITVAL'] === 0) {
+                                        eSummaries[s][exId] = summaries[s]['INITVAL'];
+                                    } else {
+                                        // Only initialize this if INITVAL array is zero-length
+                                        if(summaries[s]['INITVAL'].length === 0) {
+                                            eSummaries[s][exId] = [];
+                                        }
+                                    }
+                                }
+
+                                // Maximum submissions (constant, has been fetched from the exercises API)
+                                var maxSubs = _exercises[moduleIdx].exercises[exerciseIdx].max_submissions;
+
+                                // Maximum points (constant, has been fetched from the exercises API)
+                                var maxPoints = _exercises[moduleIdx].exercises[exerciseIdx].max_points;
+
+                                /**
+                                 * Calculate a sum of submission count column
+                                 * (excluding rows filtered out by searching for string/tag).
+                                 * Note, that this column is always hidden in the datatable and used for calculations only
+                                 */
+                                var totalSubs = dtVar.column(exIdx - 1, {search: 'applied'}).data().sum();
+
+                                /**  
+                                 * Calculate a sum of total points column
+                                 * (excluding rows filtered out by searching for string/tag).
+                                 */
+                                var totalPoints = dtVar.column(exIdx, {search: 'applied'}).data().sum();
+
+                                /**
+                                 * Filter the visible student rows with submission count > 0.
+                                 * Save these students into an array studentsWithSubs
+                                 * and the amount (array length) to numStudentsWithSubs
+                                 */
+                                let studentsWithSubs = [];
+                                const numStudentsWithSubs = dtVar
+                                    .column(exIdx - 1, {search: 'applied'})
+                                    .data()
+                                    .filter( function ( value, index ) {
+                                        if(value > 0) {
+                                            studentsWithSubs.push(dtVar.column(0).data()[index]);
+                                            return true;
+                                        } else return false;
+                                    }
+                                ).length;
+
+                                /**
+                                 * Calculate the submission averages based on the previous filtering operations
+                                 */
+                                let avgSubsPerStudent;
+                                let avgPointsPerStudentWithSubs;
+                                if(numStudentsWithSubs > 0) {
+                                    avgSubsPerStudent = parseFloat((totalSubs / numStudentsWithSubs).toFixed(2));
+                                    avgPointsPerStudentWithSubs = parseFloat((totalPoints / numStudentsWithSubs).toFixed(2));
+                                    // Also add points to the module total
+                                    pointsModuleTotal[modId] += totalPoints;
+                                } else {
+                                    avgSubsPerStudent = 0;
+                                    avgPointsPerStudentWithSubs = 0;
+                                }
+
+                                /**
+                                 * Filter visible student rows and compare each with the maximum points
+                                 * from this exercise. Add matching students to maxPointsStudents array.
+                                 */
+                                let maxPointsStudents = [];
+                                if(maxPoints > 0) {
+                                    studentsWithMaxPoints = dtVar
+                                        .column(exIdx, {search: 'applied'})
+                                        .data()
+                                        .filter( function ( value, index ) {
+                                            if(value === maxPoints) {
+                                                maxPointsStudents.push(dtVar.column(0).data()[index]);
+                                                return true;
+                                            } else return false;
+                                        }
+                                    );
+                                } else {
+                                    studentsWithMaxPoints = [];
+                                    // If no max points in this exercise, no max points for the module, either
+                                    mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] = [];
+                                }
+
+                                /**
+                                 * If exercise mode chosen from GUI, put the per-exercise stats in place to datatable.
+                                 * Note, that exercise points are always calculated as they are required in other modes.
+                                 */
+                                if(_displayMode === dm.EXERCISE) {
+                                    // Fill in the summary cells for this exercise
+                                    summArray[sv.MAX_SUBS][exIdx] = maxSubs;
+                                    summArray[sv.MAX_PTS][exIdx] = maxPoints;
+                                    summArray[sv.TOTAL_SUBS][exIdx] = totalSubs;
+                                    summArray[sv.AVG_SUBS_PER_STUD][exIdx] = avgSubsPerStudent;
+                                    summArray[sv.AVG_PTS_PER_STUD][exIdx] = avgPointsPerStudentWithSubs;
+                                    summArray[sv.STUDS_WITH_SUBS][exIdx] = numStudentsWithSubs;
+                                    summArray[sv.STUDS_WITH_MAX_POINTS][exIdx] = studentsWithMaxPoints.length;
+                                }
+
+                                /**
+                                 * If module mode chosen from GUI, calculate the per-module stats
+                                 * and put them in place to datatable.
+                                 */
+                                if(_displayMode === dm.MODULE) {
+                                    // Calculate per module total points for students
+
+                                    // First assignment for a module
+                                    if(!moduleScores.length) {
+                                        moduleScores = dtVar.column(exIdx, {search: 'applied'})
+                                        .data();
+                                    } else {
+                                        // If we already have points from exercises of this module, sum points by student
+                                        var sum = dtVar.column(exIdx, {search: 'applied'}).data()
+                                        .map(function (num, idx) {
+                                            return num + moduleScores[idx];
+                                        });
+                                        moduleScores = sum; // TODO: assign by value?????
+                                    }
+
+                                    // Add the maximum submissions of this exercise to module totals
+                                    mSummaries[sv.MAX_SUBS][modId] += maxSubs;
+                                    // Add the maximum points of this exercise to module totals
+                                    mSummaries[sv.MAX_PTS][modId] += maxPoints;
+                                    // Add the total submissions of this exercise to module totals
+                                    mSummaries[sv.TOTAL_SUBS][modId] += totalSubs;
+
+                                    // Only count distinct students for the module stats
+                                    if(studentsWithSubs.length > 0) {
+                                        studentsWithSubs.forEach(value => {
+                                            if(!mSummaries[sv.STUDS_WITH_SUBS][modId].includes(value)) {
+                                                mSummaries[sv.STUDS_WITH_SUBS][modId].push(value);
+                                            }
+                                        });
+                                    }
+
+                                    /**
+                                     * Calculate the total students with max points for the current module.
+                                     * If this is the first exercise of this module, initialize the students array
+                                     * and if there are students with maximum points, add them into it
+                                     */
+                                    if(mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] === undefined) {
+                                        mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] = [];
+                                        if(maxPointsStudents.length > 0) {
+                                            maxPointsStudents.forEach(value => {
+                                                mSummaries[sv.STUDS_WITH_MAX_POINTS][modId].push(value);
+                                            });
+                                        }
+                                    } else {
+                                        // Only proceed if there are still candidates for full points for this module
+                                        if(mSummaries[sv.STUDS_WITH_MAX_POINTS][modId].length > 0) {
+                                            if(maxPointsStudents.length > 0) {
+                                                // Remove any students from the existing list who don't have max points from this exercise
+                                                var intersectionArray = mSummaries[sv.STUDS_WITH_MAX_POINTS][modId].filter(function(n) {
+                                                    return maxPointsStudents.indexOf(n) !== -1;
+                                                });
+                                                mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] = intersectionArray;
+                                            } else {
+                                                // No full points from this exercise, remove all candidates
+                                                mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] = [];
+                                            }
+                                        }
+                                    }
+                                }
+
+                                /**
+                                 * If difficulty mode chosen from GUI, calculate the per-difficulty stats.
+                                 */
+                                if(_displayMode === dm.DIFFICULTY) {
+                                    // Get the difficulty level of current exercise
+                                    const exDifficulty = _exercises[moduleIdx].exercises[exerciseIdx].difficulty;
+                                    if(!_activeDifficulties.includes(exDifficulty)) {
+                                        _activeDifficulties.push(exDifficulty);
+                                    }
+                                    pointsDifficultyTotal[exDifficulty] += parseInt(totalPoints);
+
+                                    // Summaries that are simple sums of values
+                                    dSummaries[sv.TOTAL_SUBS][exDifficulty] += totalSubs;
+                                    dSummaries[sv.MAX_SUBS][exDifficulty] += maxSubs;
+                                    dSummaries[sv.MAX_PTS][exDifficulty] += maxPoints;
+
+                                                                    /**
+                                     * Calculate the total students with max points for the current module.
+                                     * If this is the first exercise of this module, initialize the students array
+                                     * and if there are students with maximum points, add them into it
+                                     */
+                                    if(dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty].includes('no_ex')) {
+                                        dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty] = [];
+                                        if(maxPointsStudents.length > 0) {
+                                            maxPointsStudents.forEach(value => {
+                                                dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty].push(value);
+                                            });
+                                        }
+                                    } else {
+                                        // Only proceed if there are still candidates for full points for this difficulty
+                                        if(dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty].length > 0) {
+                                            if(maxPointsStudents.length > 0) {
+                                                // Remove any students from the existing list who don't have max points from this exercise
+                                                var intersectionArray = dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty].filter(function(n) {
+                                                    return maxPointsStudents.indexOf(n) !== -1;
+                                                });
+                                                dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty] = intersectionArray;
+                                            } else {
+                                                // No full points from this exercise, remove all candidates
+                                                dSummaries[sv.STUDS_WITH_MAX_POINTS][exDifficulty] = [];
+                                            }
+                                        }
+                                    }
+
+                                    // Students with submissions: create union of all distinct students
+                                    if(studentsWithSubs.length > 0) {
+                                        studentsWithSubs.forEach(value => {
+                                            if(!dSummaries[sv.STUDS_WITH_SUBS][exDifficulty].includes(value)) {
+                                                dSummaries[sv.STUDS_WITH_SUBS][exDifficulty].push(value);
+                                            }
+                                        });
+                                    }
+                                }
+
+                                /**
+                                 * Calculate total summaries (regardless of mode)
+                                 */
+                                tSummaries[sv.MAX_SUBS] += maxSubs;
+                                tSummaries[sv.MAX_PTS] += maxPoints;
+                                tSummaries[sv.TOTAL_SUBS] += totalSubs;
+
+                                if(tSummaries[sv.STUDS_WITH_SUBS] === undefined) {
+                                    tSummaries[sv.STUDS_WITH_SUBS] = [];
+                                }
+                                if(studentsWithSubs.length > 0) {
+                                    studentsWithSubs.forEach(value => {
+                                        if(!tSummaries[sv.STUDS_WITH_SUBS].includes(value)) {
+                                            tSummaries[sv.STUDS_WITH_SUBS].push(value);
+                                        }
+                                    });
+                                }
+
+                                //console.log('done with exercise ' + exId + ' of module ' + modId);
+                            }
                         }
+
+                    // Need to clear the students array from 'no_ex' if no exercises found for this module
+                    } else {
+                        mSummaries[sv.STUDS_WITH_MAX_POINTS][modId] = ['no_ex'];
                     }
 
-                });
+                    /**
+                     * Put the calculated module summaries in place to datatable, if in module mode
+                     */
+                    if(_displayMode === dm.MODULE && modIdx > 0) {
+
+                        /**
+                         * Calculate averages for this module
+                         */
+                        if(mSummaries[sv.STUDS_WITH_SUBS][modId].length > 0) {
+                            mSummaries[sv.AVG_SUBS_PER_STUD][modId] = parseFloat((mSummaries[sv.TOTAL_SUBS][modId] / mSummaries[sv.STUDS_WITH_SUBS][modId].length).toFixed(2));
+                        } else mSummaries[sv.AVG_SUBS_PER_STUD][modId] = 0;
+
+                        if(mSummaries[sv.STUDS_WITH_SUBS][modId].length > 0) {
+                            mSummaries[sv.AVG_PTS_PER_STUD][modId] = parseFloat((pointsModuleTotal[modId] / mSummaries[sv.STUDS_WITH_SUBS][modId].length).toFixed(2));
+                        } else mSummaries[sv.AVG_PTS_PER_STUD][modId] = 0;
+
+                        // Put per-module sums in place to datatable
+                        if(moduleScores[0] !== undefined) {
+                            // Get rows which are currently visible (matching the search parameters)
+                            const rows = dtVar.rows({search: 'applied'}).indexes();
+                            dtVar.column(modIdx,{search: 'applied'})
+                                .data()
+                                .each(function(value, index) {
+                                    dtVar.cell(rows[index],modIdx).data(moduleScores[index]);
+                                });
+                        }
+
+                        for(var s in summaries) {
+                            if(summaries[s]["INITVAL"] === 0) {
+                                if(mSummaries[s][modId] === undefined) mSummaries[s][modId] = 0;
+                                // Init value is integer, use the value directly
+                                summArray[s][modIdx] = mSummaries[s][modId];
+                            } else {
+                                // Init value is array, use the array size
+                                if(mSummaries[s][modId] === undefined) {
+                                    mSummaries[s][modId] = [];
+                                    summArray[s][modIdx] = 0;
+                                } else {
+                                    if(mSummaries[s][modId].includes('no_ex')) {
+                                        summArray[s][modIdx] = 0;
+                                    } else {
+                                        summArray[s][modIdx] = mSummaries[s][modId].length;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                pointsGrandTotal += pointsModuleTotal[modId];
+            } // End loop for each module
+        }
+        /**
+         * Do the difficulty stuff if in this mode
+         */
+        if(_displayMode === dm.DIFFICULTY) {
+
+            /**
+             * First calculate averages for each difficulty
+             */
+            for(var d in _difficulties) {
+                if(dSummaries[sv.STUDS_WITH_SUBS][d].length > 0) {
+                    dSummaries[sv.AVG_SUBS_PER_STUD][d] = parseFloat((dSummaries[sv.TOTAL_SUBS][d] / dSummaries[sv.STUDS_WITH_SUBS][d].length).toFixed(2));
+                } else dSummaries[sv.AVG_SUBS_PER_STUD][d] = 0;
+
+                if(dSummaries[sv.STUDS_WITH_SUBS][d].length > 0) {
+                    dSummaries[sv.AVG_PTS_PER_STUD][d] = parseFloat((pointsDifficultyTotal[d] / dSummaries[sv.STUDS_WITH_SUBS][d].length).toFixed(2));
+                } else dSummaries[sv.AVG_PTS_PER_STUD][d] = 0;
             }
 
-            // Create the table row for a single student from the points above
-            htmlTablePoints += '<tr><td class="student-id stick-on-scroll">' + student.student_id + '</td>';
-            htmlTablePoints +=
-                '<td class="student-name stick-on-scroll">'
-                + '<a href="' + student.summary_html + '">'
-                + _points[sid].full_name + '</td>';
+            /**
+             * Then put the calculated difficulty summaries in place to datatable
+             */
+            for(var d in _difficulties) {
+                const diffIdx = dtVar.column('.diff-' + d).index(); // difficulty index id in datatable
+                if(diffIdx > 0) {
+                    for(var s in summaries) {
+                        if(summaries[s]["INITVAL"] === 0) {
+                            if(dSummaries[s][d] === undefined) dSummaries[s][d] = 0;
+                            // Init value is integer, use the value directly
+                            summArray[s][diffIdx] = dSummaries[s][d];
+                        } else {
+                            // Init value is array, use the array size
+                            if(dSummaries[s][d] === undefined) {
+                                dSummaries[s][d] = [];
+                                summArray[s][diffIdx] = 0;
+                            } else {
+                                summArray[s][diffIdx] = dSummaries[s][d].length;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-            if (pointKeys.length > 0) {
-                let tagHtml = "";
-                const studentTags = student.tag_slugs;
+        /**
+         * Calculate the total students with max points for all items, depending on mode.
+         */
+        tSummaries[sv.STUDS_WITH_MAX_POINTS] = ['no_ex'];
 
-                studentTags.forEach(function(tagSlug) {
-                    _usertags.forEach(function(usertag) {
-                        if (usertag.slug === tagSlug) {
-                            tagHtml += django_colortag_label(usertag, ' ')[0].outerHTML;
+        if(_displayMode === dm.MODULE) {
+            for(var m in mSummaries[sv.STUDS_WITH_MAX_POINTS]) {
+                if(tSummaries[sv.STUDS_WITH_MAX_POINTS].length > 0) {
+                    // If this module had exercises, it needs to be counted for totals
+                    if(!mSummaries[sv.STUDS_WITH_MAX_POINTS][m].includes('no_ex')) {
+                        // Remove any students from the existing list who don't have max points from this exercise
+                        var intersectionArray = mSummaries[sv.STUDS_WITH_MAX_POINTS][m].filter(function(n) {
+                            return tSummaries[sv.STUDS_WITH_MAX_POINTS].indexOf(n) !== -1;
+                        });
+                        tSummaries[sv.STUDS_WITH_MAX_POINTS] = intersectionArray;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Handle the case where no exercises were processed (=> show 0 students with max points)
+         */
+        if(tSummaries[sv.STUDS_WITH_MAX_POINTS].includes('no_ex')) {
+            tSummaries[sv.STUDS_WITH_MAX_POINTS] = [];
+        };
+
+        /**
+         * Calculate total averages
+         */
+        tSummaries[sv.AVG_SUBS_PER_STUD] = (tSummaries[sv.STUDS_WITH_SUBS].length > 0 ? parseFloat((tSummaries[sv.TOTAL_SUBS] / tSummaries[sv.STUDS_WITH_SUBS].length).toFixed(2)) : 0);
+        tSummaries[sv.AVG_PTS_PER_STUD] = (tSummaries[sv.STUDS_WITH_SUBS].length > 0 ? parseFloat((pointsGrandTotal / tSummaries[sv.STUDS_WITH_SUBS].length).toFixed(2)) : 0);
+
+        /**
+         * Put the calculated totals in place to datatable, regardless of mode
+         */
+        for(var s in summaries) {
+            if(summaries[s]["INITVAL"] === 0) {
+                if(tSummaries[s] === undefined) tSummaries[s] = 0;
+                // Init value is integer, use the value directly
+                summArray[s][TOTAL_COL_ID] = tSummaries[s];
+            } else {
+                // Init value is array, use the array size
+                if(tSummaries[s] === undefined) {
+                    tSummaries[s] = [];
+                    summArray[s][TOTAL_COL_ID] = 0;
+                } else {
+                    if(tSummaries[s].includes('no_ex')) {
+                        summArray[s][TOTAL_COL_ID] = 0;
+                    } else {
+                        summArray[s][TOTAL_COL_ID] = tSummaries[s].length;
+                    }
+                }
+            }
+            /**
+             * Calculate percentages of total for the summary columns 
+             */
+            const componentCols = dtVar.columns('.' + dmRev[_displayMode]);
+            for(var c in componentCols[0]) {
+                const compVal = summArray[s][componentCols[0][c]];
+                let totalVal;
+                if(s === sv.STUDS_WITH_MAX_POINTS || s === sv.STUDS_WITH_SUBS) {
+                    totalVal = dtVar.rows({search: 'applied'})[0].length;
+                } else {
+                    totalVal = summArray[s][TOTAL_COL_ID];
+                }
+                const ratio = totalVal > 0 ? parseFloat(compVal * 100 / totalVal).toFixed(2) : 0;
+                //console.log(ratio);
+                if(ratio > 0) {
+                    summArray[s][componentCols[0][c]] = compVal + '<div class="ratio">' + ratio + '</div>';
+                }
+            };
+        }
+
+        /**
+         * Hide all columns and then show the currently active ones, depending on display mode
+         */
+        dtVar.columns('.module').visible( false,false );
+        dtVar.columns('.exercise').visible( false,false );
+        dtVar.columns('.difficulty').visible( false,false );
+
+        switch(_displayMode) {
+            case dm.DIFFICULTY:
+                _activeDifficulties.forEach(function(value) {
+                    dtVar.columns('.difficulty.diff-' + value ).visible( true,false );
+                });
+                break;
+            case dm.EXERCISE:
+                if(selectedExercises !== null) {
+                    selectedExercises.forEach(function(value) {
+                        dtVar.columns( '.exercise.' + value  ).visible( true,false );
+                    });
+                }
+                break;
+            case dm.MODULE:
+                if(selectedModules !== null) {
+                    selectedModules.forEach(function(value) {
+                        // We don't want to show modules with no exercises even if selected
+                        let moduleId = parseInt(value.replace('mod-m',''));
+                        if(moduleId > 0) {
+                            let moduleInfo =_exercises.find((x) => x.id === moduleId);
+                            if(moduleInfo.exercises.length > 0) {
+                                dtVar.columns( '.module.' + value  ).visible( true,false );
+                            }
                         }
                     });
-                });
-
-                let allPointsTotal = 0;
-                let allUnofficialTotal = 0;
-                pointKeys.forEach(function(name) {
-                    const point = points[name] || 0;
-                    const unofficialPoint = unofficialPoints[name] || 0;
-                    allPointsTotal += point;
-                    allUnofficialTotal += unofficialPoint;
-                });
-
-                htmlTablePoints += '<td>' + tagHtml + '</td>';
-
-                if (!_showOfficial && allUnofficialTotal > allPointsTotal) {
-                    htmlTablePoints += '<td>' + allPointsTotal + '<span class="text-danger"> (' + allUnofficialTotal + ')</span></td>';
                 }
-                else {
-                    htmlTablePoints += '<td>' + allPointsTotal + '</td>';
-                }
-            }
-
-            pointKeys.forEach(function(name) {
-                const point = points[name] || 0;
-                const unofficialPoint = unofficialPoints[name] || 0;
-                if (!_showOfficial && unofficialPoint > point) {
-                    htmlTablePoints += '<td>' + point + '<span class="text-danger"> (' + unofficialPoint + ')</span></td>';
-                }
-                else {
-                    htmlTablePoints += '<td>' + point + '</td>';
-                }
-            });
-            htmlTablePoints += "</tr>";
-        });
-
-        // Calculate the data indicators, e.g. average points, max points
-        // Append headings, data indicators and student points to the html table
-
-        $("#table-heading").append('<tr id="table-heading-row"></tr>')
-        $("#table-heading-row").append('<th id="student-count">' + _("Student ID") + '</th>');
-        $("#table-heading-row").append('<th>' + _("Student name") + '</th>');
-        if (_exerciseSelection && _exerciseSelection.length > 0) {
-            $("#table-heading-row").append('<th>' + _("Tags") + '</th>');
-            $("#table-heading-row").append('<th>' + _("Total") + '</th>');
+                break;
         }
-
-
-        pointKeys.forEach(function(name) {
-            if (showMethod === "difficulty" && name === "") {
-                $("#table-heading-row").append('<th scope="col">' + _("No difficulty") + '</th>');
-            } else {
-                $("#table-heading-row").append('<th scope="col">' + name + '</th>');
-            }
-        });
-
-
-        let htmlTableIndicators = "";
-
-        if (_totalSubmTrue) {
-            let dataVals = [];
-            let sumValue = 0;
-            pointKeys.forEach(function(name) {
-                sumValue += totalSubmissions[name] || 0;
-            });
-
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    totalSubmissions[name] || 0,
-                    totalSubmissions[name] / sumValue * 100 || 0,
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Total number of submissions. Calculates all student submission counts together.'),
-                _('Total submissions'),
-                dataVals
-            );
-        }
-
-        if (_avgSubmTrue) {
-            let dataVals = [];
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    totalSubmissions[name] / totalSubmitters[name] || 0,
-                    totalSubmissions[name] / totalSubmitters[name] / maxAllowedSubmissions[name] * 100 || 0
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('How many submissions a single student has used on the exercise on average.'
-                  + ' Only accounts for students with one or more submissions.'
-                ),
-                _('Average submissions per student with submissions'),
-                dataVals
-            );
-        }
-
-        if (_maxSubmTrue) {
-            let dataVals = [];
-            let sumValue = 0;
-            pointKeys.forEach(function(name) {
-                sumValue += maxAllowedSubmissions[name] || 0;
-            });
-
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    maxAllowedSubmissions[name] || 0,
-                    maxAllowedSubmissions[name] / sumValue * 100 || 0,
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Maximum number of available submissions for the exercise.'),
-                _('Maximum submissions'),
-                dataVals
-            );
-        }
-
-        if (_totalStuSubmTrue) {
-            let dataVals = [];
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    totalSubmitters[name] || 0,
-                    totalSubmitters[name] / filteredStudentPool.length * 100 || 0
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Number of students that have one or more exercise submissions.'),
-                _('Students with submissions'),
-                dataVals
-            );
-        }
-
-        if (_totalStuMaxTrue) {
-            let dataVals = [];
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    totalMaxSubmitters[name] || 0,
-                    totalMaxSubmitters[name] / totalSubmitters[name] * 100 || 0
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Number of students that have received maximum points from the exercise.'),
-                _('Students with max points'),
-                dataVals
-            );
-        }
-
-        if (_avgPTrue) {
-            let dataVals = [];
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    totalPoints[name] / totalSubmitters[name] || 0,
-                    totalPoints[name] / totalSubmitters[name] / maxPoints[name] * 100 || 0
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Average points received for the exercise.'
-                  + ' Only accounts for students with one or more submissions.'
-                ),
-                _('Average points per student with submissions'),
-                dataVals
-            );
-        }
-
-        if (_maxPTrue) {
-            let dataVals = [];
-            pointKeys.forEach(function(name) {
-                dataVals.push([
-                    maxPoints[name] || 0,
-                    maxPoints[name] / maxPointsTotal * 100 || 0
-                ]);
-            });
-
-            htmlTableIndicators += createIndicatorRow(
-                _('Maximum points for the exercise.'),
-                _('Maximum points'),
-                dataVals
-            );
-        }
-
-        $("#table-body").append(htmlTableIndicators);
-        $("#table-body").append(htmlTablePoints);
-        $(".colortag-active").css("margin-right", "5px");
-        $("#student-count").append(
-            ' (<span id="selected-number">' + filteredStudentPool.length + '</span> / '
-            + '<span id="participants-number">'+ _students.length + '</span>'
-            + _(' students selected') + ')'
-        );
-        tableExportVar.reset();
-        $('#table-points').find("caption").remove(); // Remove the recreated TableExport buttons (they are already in dropdown)
-        $('.filtered-table').aplusTableFilter();
-
+        // Finally redraw table
+        dtVar.draw();
     }
 
-
-    /*
-     * Handles the module selection when teacher selects or unselects a module(s).
-     * If a module is selected, select and show all the module's exercises in exercise selection.
-     * If a module is unselected, unselect and hide all module's exercises in exercise selection.
+    /**
+     * Change display mode (difficulty, module or exercise view)
+     * @param {string} newMode display mode to change to
      */
-    function moduleSelectionChange() {
-        const selectedModules = $('#module-selection option:selected');
-        const nonSelectedModules = $('#module-selection option').filter(function() {
+    window.changeDisplayMode = function(newMode) {
+        if(newMode != _displayMode) {
+            // Clear existing points column searches to not confuse user with hidden search options
+            // (do not clear searches in student id, name or tags fields)
+            for(var i in colSearchVals) {
+                dtVar.columns(i).search('');
+            }
+            colSearchVals = {};
+            $( 'thead#table-heading input.numval').val('');
+            // Scroll table sideways to starting position in case we have fewer columns to display than before
+            $("#table-points-div").scrollLeft(0);
+            _displayMode = newMode;
+        }
+
+        changeExerciseSelection();
+    }
+
+    /**
+     * Return html for tags separated with pipe (|) characters
+     * @param {array} tags array of tags to use
+     * @returns parsed html string for user tags display
+     */
+    function userTagsToHTML(tags) {
+        if(tags.length) {
+            let html = '';
+            tags.split('|').forEach(function(tag) {
+                html += '<span class="colortag colortag-active label label-xs" style="color: ' + _usertags[tag].font_color + '; background-color: ' + _usertags[tag].color + '; margin-right: 5px;">' + _usertags[tag].name + '</span>';
+            })
+            return html;
+        } else return '';
+    }
+
+    /**
+     * Things to do when user makes changes in the modules popup menu
+     */
+    function changeModuleSelection() {
+        // Show all popup-selected modules and assignments and hide unselected ones
+        const selectedModules = moduleSelectRef.find('option:selected');
+        const nonSelectedModules = moduleSelectRef.find('option').filter(function() {
             return !$(this).is(':selected');
         });
 
         selectedModules.each(function() {
             let showModuleClass = '.' + $(this).val();
-            $(showModuleClass).removeClass("hidden disabled");
-            $(showModuleClass).prop("selected", true);
+            multiSelectSelector.find(showModuleClass).removeClass("hidden disabled");
+            multiSelectSelector.find(showModuleClass).prop("selected", true);
+            exerciseSelectRef.find(showModuleClass).prop("selected", true);
+            if(_displayMode === dm.MODULE) {
+                dtVar.columns( showModuleClass ).visible( true,false );
+            }
         });
 
         nonSelectedModules.each(function() {
             let hideModuleClass = '.' + $(this).val();
-            $(hideModuleClass).addClass("hidden disabled");
-            $(hideModuleClass).prop("selected", false);
+            multiSelectSelector.find(hideModuleClass).addClass("hidden disabled");
+            multiSelectSelector.find(hideModuleClass).prop("selected", false);
+            exerciseSelectRef.find(hideModuleClass).prop("selected", false);
         });
+        exerciseSelectRef.multiselect('refresh');
 
-        $("#exercise-selection").multiselect('refresh');
-        exerciseSelectionChange();
+        changeExerciseSelection();
     }
 
-
-    /*
-     * Keeps the _exerciseSelection up to date with currently selected exercises.
-     * Always recreates the table based on the currently active group.
+    /**
+     * Things to do when user makes changes in the exercises popup menu
      */
-    function exerciseSelectionChange() {
-        _exerciseSelection = $('#exercise-selection option:selected');
-
-        if ($("#all-exercises").hasClass("active")) {
-            createPointTable("all");
-        } else if ($("#difficulty-exercises").hasClass("active")) {
-            createPointTable("difficulty");
-        } else if ($("#module-exercises").hasClass("active")) {
-            createPointTable("module");
-        } else {
-            return;
-        }
+    function changeExerciseSelection() {
+        // If we have changed the selected exercises, we need to clear any filters for
+        // dynamically generated columns, as these may no longer give correct results
+        clearPointsSearch();
+        // Nothing much here, just refresh the table
+        pointsTableRef.width('100%');
+        recalculateTable();
     }
 
-    /*
+    /* TODO: Use better logic for translations.
+     * Currently only some translations wait for aplus:translation-ready and most of them do not,
+     * since the translations become available during the script.
+     */
+
+        /*
      * Multiselect button text
      * This is copied from TableExport plugin source code
      * and changed for translations and nothing else.
@@ -704,161 +1036,486 @@
         }
     }
 
-    let ajaxEnabled = true;
+    /**
+     * Parse the search string of points column headers
+     * @param {string} input user-typed string to search for
+     * @returns
+     */
+    function parsePointsSearchVal(input) {
+        if(input.length > 1) {
+            var val = input.split('>');
 
-    let ajaxSettings = {
-        _retryCount: 0,
-        _retryLimit: 3,
-        timeout: 0,
-        beforeSend: function(xhr, settings) {
-            return ajaxEnabled;
-        },
-        error: function(xhr, statusText, errorThrown) {
-            this._retryCount++;
-            if (this.retryCount <= this._retryLimit) {
-                console.log("Retrying ajax:", statusText);
-                //const req = this;
-                //setTimeout(function() {$.ajax(req);}, 1000);
-                setTimeout($.ajax, 1000, this);
-            } else {
-                stopAjax = true;
-                $("#ajax-failed-alert").show();
-                $("#results-loading-animation").hide();
+            if (val.length === 2) {
+                return ['>',val[1]];
+            }
+
+            val = input.split('<');
+
+            if (val.length === 2) {
+                return ['<',val[1]];
             }
         }
-    };
-
-    function gatherFromAPIPaging(url) {
-        function gather(cur_result, url) {
-            return $.ajax(
-                $.extend({}, ajaxSettings, {url: url})
-            ).then(function(response) {
-                cur_result = cur_result.concat(response.results)
-                if (response.next) {
-                    return gather(cur_result, response.next);
-                } else {
-                    return cur_result
-                }
-            }, function(reason) {
-                throw new Error("Pagination ajax failed: " + reason.statusText);
-            });
-        }
-        return gather([], url);
+        // Plain value
+        return [null, input];
     }
 
-    /*
-     * The following code is responsible for handling all the ajax calls to get the data from /api/v2/
-     * The code also initializes the module and exercise selection options.
-     * Creates the table for the first time, when all ajax calls have finished.
-     * READER WARNING: You are entering callback hell.
+    /**
+     * Add search fields to each header row (excluding the always hidden cols
+     * containing submission counts and other helper columns).
      */
-    $.when(gatherFromAPIPaging(exercisesUrl), gatherFromAPIPaging(studentsUrl), gatherFromAPIPaging(usertagsUrl))
-        .done(function(exercisesPagedResults, studentsPagedResults, usertagsPagedResults) {
-        _exercises = exercisesPagedResults;
-        _students = studentsPagedResults;
-        _usertags = usertagsPagedResults;
+    function addHeaderSearchInputs() {
+        $('#table-points thead tr:eq(0) th').not('.always-hidden').each( function (i) {
+            /**
+             * We need to find the column index with 'always-hidden' columns skipped.
+             * Since this is not provided us, let's dig it from the column header
+             * where the current search box lives.
+             * TODO: Find a better way to do this
+             */
+            var realIndex = 0;
+            const colClasses = $(this)[0].className.split(/\s+/);
+            idx = colClasses.findIndex(function(item) { return item.startsWith('col-') });
+            if(idx > -1) {
+                realIndex = colClasses[idx].split('-')[1];
+            }
 
-        let requiredPointAjaxCalls = _students.length;
-        let requiredUserAjaxCalls = _students.length;
-        let requiredExerciseAjaxCalls = 0;
-        _exercises.forEach(function(module) {
-            module.exercises.forEach(function(exercise) {
-                requiredExerciseAjaxCalls++;
+            if(realIndex < TOTAL_COL_ID) {
+                /**
+                 * Create column search boxes for other than points columns
+                 */
+                $(this).append( '<br><input type="text" class="form-control input-sm textval" style="z-index: 4" placeholder="' + _("Search") + '" />' );
+                $( 'input.textval', this ).on( 'keyup change clear', function () {
+                    if ( dtVar.column(realIndex).search() !== this.value ) {
+                        recalculateTableDebounced(realIndex, this.value);
+                    }
+                } );
+            } else {
+                /**
+                 * Create search boxes for points columns
+                 */
+                $(this).append( '<br><input type="text" class="form-control input-sm numval" placeholder="' + _("Search") + _(" (<, > supported)") + '" />' );
+                $( 'input.numval', this ).on('keyup change clear', function () {
+                    if(this.value === '') delete colSearchVals[realIndex];
+                    else colSearchVals[realIndex] = parsePointsSearchVal(this.value);
+                    recalculateTableDebounced(realIndex, '');
+                });
+            }
+            // Prevent resorting when clicking the search box
+            $( 'input', this ).click(function(e) {
+                e.stopPropagation();
             });
         });
+    }
 
-        let completedPointAjaxCalls = 0;
-        let completedExerciseAjaxCalls = 0;
-        let successFirstStudent = false;
 
-        let checkIfAllAjaxCompleted = function() {
-            const exercises_progress = completedExerciseAjaxCalls + " / " + requiredExerciseAjaxCalls;
-            const points_progress = completedPointAjaxCalls + " / " + requiredPointAjaxCalls;
-            const progress_report = exercises_progress + "<br>" + points_progress;
-            $("#results-loading-progress").html(progress_report);
-            if (completedPointAjaxCalls === requiredPointAjaxCalls &&
-                completedExerciseAjaxCalls === requiredExerciseAjaxCalls) {
-                _ajaxCompleted = true;
-                exerciseSelectionChange();
-                $("#results-loading-animation").hide();
-                $("#results-loading-progress").hide();
-                $("#table-export-dropdown > button").removeAttr('disabled');
-                $("#table-points-div").show();
-            }
+    /**
+     * Loads new data on page load, and when "Show only official points" checkbox clicked
+     * @param {*} show_unofficial
+     */
+    function loadStudentData(show_unofficial) {
+        // Destroy old data table if it exists
+        // Also multiselects and event handlers that will be recreated
+        if(dtApi !== undefined) {
+            dtApi.destroy();
+            moduleSelectRef.multiselect('destroy');
+            exerciseSelectRef.multiselect('destroy');
+            moduleSelectRef.find('option').remove();
+            exerciseSelectRef.find('option').remove();
+            pointsTableRef.find('tr').remove();
+            $('.filter-users button').off('click');
+            $('#difficulty-exercises').tab('show');
         }
+        if(show_unofficial) pointsUrl = pointsUrl + "&show_unofficial=true";
+        $.when(
+            $.ajax(exercisesUrl),
+            $.ajax(pointsUrl),
+            $.ajax(usertagsUrl)
+        ).done(function(exerciseJson, pointsJson, userTags) {
+            userTags[0].results.forEach(function(entry) {
+                if(entry.id === null) {
+                    // TODO: usertags are rendered in an Aalto-specific way as there's no API to return them?
+                    _usertags[entry.name.toLowerCase()] = {color: entry.color, font_color: entry.font_color, name: entry.name, slug: entry.slug};
+                } else {
+                    _usertags[entry.id] = {color: entry.color, font_color: entry.font_color, name: entry.name, slug: entry.slug};
+                }
+                // Just save the bare minimum for rendering at this point
+            });
 
-        _students.forEach(function(student) {
-            const sid = student.id;
-            $.ajax(
-                $.extend({}, ajaxSettings, {url: pointsUrl + sid + '/'})
-            ).then(function(data) {
-                _points[sid] = data;
-                completedPointAjaxCalls++;
-                if (!successFirstStudent) {
-                    successFirstStudent = true;
-                    const firstStudentPoints = Object.values(_points)[0];
-                    firstStudentPoints.modules.forEach(function(module) {
-                        $("#module-selection").append(
-                            '<option value="module-' + module.id + '"'
+            // TODO: Get the link to students in a proper way
+            const participantsLink = $('li.menu-participants').find('a').attr('href');
+
+            let columns = [
+                {data: "UserID", title: "UserID", class: "always-hidden col-0", type: "num", searchable: false},
+                {data: "Email", title: "Email", class: "always-hidden col-1", type: "string", searchable: true},
+                {data: "StudentID", title: _("Student ID"), type: "string", width: "6em", class: "student-id stick-on-scroll col-2" },
+                //{data: "FirstName", title: "FirstName"},
+                //{data: "LastName", title: "LastName"},
+                {data: "Name", title: _("Student name"), class: "student-name stick-on-scroll col-3", type: "html", render: function(data, type, row) { return (row['UserID'] > 0 ? '<a href="' + participantsLink + row['UserID'] + '">' + data + '</a>' : ''); } },
+                {data: "Tags", title: _("Tags"), class: "tags col-4", render: function(data) { return userTagsToHTML(data); }, type: "html" },
+                {data: "Count", title: "Count", class: "col-5", visible: false, defaultContent: 0, type: "num"},
+                {data: "Total", title: _("Total"), width: "6em", class: "points total col-6", defaultContent: 0, type: "num"}
+            ];
+
+            // Store exercises globally
+            _exercises = exerciseJson[0].results;
+
+            // Create select boxes for modules and exercises
+            // Add the actual data columns for datatable
+            // Add column numbers so these can be used when searching by column
+            exerciseJson[0].results.forEach(function(module) {
+                columns.push({data: 'm' + module.id + ' Count', title: 'm' + module.id + ' Count', class: "always-hidden col-" + columns.length + '"', type: "num", defaultContent: 0, searchable: false, visible: false});
+                columns.push({data: 'm' + module.id + ' Total', title: module.display_name, class: 'points module ' + 'mod-m' + module.id + ' col-' + columns.length, type: "num", defaultContent: 0, visible: true});
+
+                moduleSelectRef.append(
+                    '<option value="mod-m' + module.id + '"'
+                    + 'selected>'
+                    + module.display_name
+                    + '</option>'
+                );
+                if(module.exercises.length > 0) {
+                    exerciseSelectRef.append(
+                        '<optgroup class="mod-m' + module.id + '"'
+                        + 'value="mod-m' + module.id + ' col-' + columns.length + '"'
+                        + 'label="' + module.display_name + '"'
+                        + '></optgroup'
+                    );
+                    module.exercises.forEach(function(exercise) {
+                        columns.push({data: exercise.id + ' Count', title: exercise.id + ' Count', class: "always-hidden col-" + columns.length, type: "num", defaultContent: 0, searchable: false, visible: false});
+                        columns.push({data: exercise.id + ' Total', title: exercise.display_name, class: 'points exercise ' + 'ex-' + exercise.id + ' col-' + columns.length, type: "num", defaultContent: 0, visible: true});
+                        $("#exercise-selection > optgroup:last-child").append(
+                            '<option data-mod-id="m' + module.id + '"'
+                            + 'data-ex-id="' + exercise.id + '"'
+                            + 'class="mod-m'+ module.id + '"'
+                            + 'value="ex-'+ exercise.id + '"'
                             + 'selected>'
-                            + module.name
+                            + exercise.display_name
                             + '</option>'
                         );
-                        $("#exercise-selection").append(
-                            '<optgroup class="module-' + module.id + '"'
-                            + 'value="module-' + module.id + '"'
-                            + 'label="' + module.name + '"'
-                            + '></optgroup'
-                        );
-                        module.exercises.forEach(function(exercise) {
-                            $("#exercise-selection > optgroup:last-child").append(
-                                '<option data-module-id="' + module.id + '"'
-                                + 'data-exercise-id="' + exercise.id + '"'
-                                + 'class="module-'+ module.id + '"'
-                                + 'value="exercise-'+ exercise.id + '"'
-                                + 'selected>'
-                                + exercise.name
-                                + '</option>'
-                            );
-                        });
-                    });
-
-                    $('#module-selection').multiselect({
-                        includeSelectAllOption: true,
-                        onDeselectAll: moduleSelectionChange,
-                        onSelectAll: moduleSelectionChange,
-                        onChange: moduleSelectionChange,
-                        buttonText: buttonText,
-                        selectAllText: _("Select all"),
-                    });
-
-                    $('#exercise-selection').multiselect({
-                        includeSelectAllOption: true,
-                        enableClickableOptGroups: true,
-                        onDeselectAll: exerciseSelectionChange,
-                        onSelectAll: exerciseSelectionChange,
-                        onChange: exerciseSelectionChange,
-                        maxHeight: 500,
-                        buttonText: buttonText,
-                        selectAllText: _("Select all"),
-                    });
-                }
-                checkIfAllAjaxCompleted();
+                        if(_difficulties[exercise.difficulty] !== undefined) {
+                            _difficulties[exercise.difficulty].push(exercise.id);
+                        } else {
+                            _difficulties[exercise.difficulty] = [exercise.id];
+                        }
+                    })
+                 }
             });
-        });
 
-        _exercises.forEach(function(module) {
-            module.exercises.forEach(function(exercise) {
-                $.ajax(
-                    $.extend({}, ajaxSettings, {url: exercise.url})
-                ).then(function(data) {
-                    _allExercises.push(data);
-                    completedExerciseAjaxCalls++;
-                    checkIfAllAjaxCompleted();
+            // Create reverse lookup array for _difficulties (check difficulty by exercise id)
+            for(let propName in _difficulties)
+            {
+                let numsArr = _difficulties[propName];
+                numsArr.forEach(function(num){
+                    _reverseDifficulties[num]=propName;
                 });
-            });
-        });
+            }
 
+            // Add columns for difficulty levels. Empty difficulty is labeled as 'No difficulty' in the datatable
+            if(Object.keys(_difficulties).length) {
+                for(diff in _difficulties) {
+                    columns.push({data: diff, title: (diff === '' ? _('No difficulty') : diff), class: 'points difficulty diff-' + diff + ' col-' + columns.length, type: "num", defaultContent: 0, visible: true});
+                }
+            }
+
+            // Augment the raw points received from the API by
+            // adding colums for modules/_difficulties and filling in missing zeroes
+            pointsJson[0].forEach(function(points, index) {
+                // Only fill in row if student has submissions, otherwise defaults to 0 by definition
+                if(points['Count'] !== undefined) {
+                    //let studentTotalSubmissions = 0;
+                    let studentTotalPoints = 0;
+                    let moduleTotalPoints = 0;
+                    for(diff in _difficulties) {
+                        points[diff] = 0;
+                    }
+                    for(moduleIdx in _exercises) {
+                        let moduleSubmissions = 0;
+                        moduleTotalPoints = 0;
+                        const moduleId = _exercises[moduleIdx].id;
+                        if(_exercises[moduleIdx].exercises.length > 0) {
+                            for(exerciseIdx in _exercises[moduleIdx].exercises) {
+                                const exId = _exercises[moduleIdx].exercises[exerciseIdx].id; // store exercise id for code readability
+
+                                if(points[exId + ' Count'] === undefined) {
+                                    // Fill out missing zero values
+                                    points[exId + ' Count'] = 0;
+                                    points[exId + ' Total'] = 0;
+                                } else {
+                                    if(points[exId + ' Total'] === undefined) {
+                                        points[exId + ' Total'] = 0;
+                                    }
+                                    // Add exercise points and submissions to module totals
+                                    moduleSubmissions += points[exId + ' Count'];
+                                    moduleTotalPoints += points[exId + ' Total'];
+                                    if(_reverseDifficulties[exId] !== undefined) {
+                                        points[_reverseDifficulties[exId]] += points[exId + ' Total'];
+                                    }
+                                }
+                            }
+                        }
+                        // Add submission count and points for module
+                        points['m' + moduleId + ' Count'] = 0;
+                        points['m' + moduleId + ' Total'] = 0;
+                        //studentTotalSubmissions += moduleSubmissions;
+                        studentTotalPoints += moduleTotalPoints;
+                    }
+                }
+            });
+
+            /**
+             * If the body has class 'lang-fi', use the Finnish translation for DataTables
+             */
+            pageLanguageUrl = $('body').hasClass('lang-fi') ? 'https://cdn.datatables.net/plug-ins/1.10.24/i18n/Finnish.json' : '';
+
+            /**
+             * Initialize the DataTables plugin for the main table
+             */
+            dtApi = $('#table-points').DataTable( {
+                data: pointsJson[0],
+                renderer: "bootstrap",
+                columns: columns,
+                deferRender: true,
+                //fixedHeader: true, // cannot use fixedHeader as it doesn't work with sideways scrolling
+                //"scrollX": true, // not using scrollX as we do this manually via JavaScript translateX
+                lengthMenu: [[10, 50, 100, 500, -1], [10, 50, 100, 500, "All"]],
+                pageLength: 50, // Set the length to 50 for faster initial load time
+                language: {
+                    url: pageLanguageUrl
+                },
+                /**
+                 * When DataTables has initialized itself, we need to present the initial view for the user.
+                 * For this, we need to make sure some things are prepared:
+                 * - Search boxes for columns need to be rendered before hiding other than difficulty columns
+                 * - Active difficulties are initialized to include all available difficulties
+                 * After that, we change the display mode to trigger table values calculations etc.
+                 */
+                initComplete: function() {
+                    dtVar = this.api();
+                    addHeaderSearchInputs(); // need to be added when columns of all modes are still in DOM
+                    for(diff in _difficulties) {
+                        _activeDifficulties.push(diff);
+                    }
+                    // Make sure all hidden columns are hidden
+                    dtVar.columns('.always-hidden').visible(false,false);
+                    changeDisplayMode(dm.DIFFICULTY);
+                },
+                /**
+                 * Calculate the Total column for all students in DataTables row callback
+                 * based on all columns visible after the total column
+                 */
+                rowCallback: function( row, data, displayNum, displayIndex, dataIndex ) {
+                    var api = this.api();
+                    var visibleCols = api.columns().indexes('visible');
+                    var sum = api.cells(dataIndex, api.columns()
+                        .indexes()
+                        .filter(function(value,index){return index > (TOTAL_COL_ID + 1) && (visibleCols[index] !== null)}))
+                        .data()
+                        .sum()
+                    api.cell(dataIndex, TOTAL_COL_ID).data(sum);
+                },
+                /**
+                 * On each table redraw, also recreate the summary rows
+                 */
+                drawCallback: function( settings ) {
+                    if(_activeSummaryItems.length > 0) {
+                        recreateSummaryRows();
+                    }
+                },
+                /**
+                 * Configure the DataTables-generated DOM
+                 * (order of elements and Bootstrap classes)
+                 */
+                dom: "<'row'<'col-md-4 col-sm-6'l><'col-md-4 col-sm-6'B><'col-md-4 col-sm-12'f>>" +
+                        "<'row'<'col-sm-12'i>>" +
+                        "<'row'<'col-sm-12'tr>>" +
+                        "<'row'<'col-sm-5'i><'col-sm-7'p>>",
+                /**
+                 * Data export buttons
+                 */
+                buttons: [
+                    {
+                        extend: 'csvHtml5',
+                        exportOptions: {
+                            columns: ':visible'
+                        }
+                    },
+                    {
+                        extend: 'copyHtml5',
+                        exportOptions: {
+                            columns: ':visible'
+                        }
+                    },
+                    {
+                        extend: 'excelHtml5',
+                        exportOptions: {
+                            columns: ':visible'
+                        }
+                    },
+                    {
+                        text: 'Reset filters',
+                        action: function ( e, dt, node, config ) {
+                            clearSearch();
+                        }
+                    }
+                ],
+            });
+
+            /**
+             * Custom search plugin for handling the range search for points columns.
+             * Parsing of the search string to operator/value is offloaded to
+             * parsePointsSearchVal function so it does not need to be done on each comparison
+             */
+            $.fn.dataTable.ext.search.push(
+                function(settings, data) {
+                    for(var c in colSearchVals) {
+                        var colVal = parseFloat(data[c]) || 0;
+                        var operator = colSearchVals[c][0];
+                        var searchVal = parseFloat(colSearchVals[c][1]) || 0;
+
+                        if(operator === '>') {
+                            if (colVal > searchVal) {
+                                continue;
+                            } else return false;
+                        }
+                        if(operator === '<') {
+                            if (colVal < searchVal) {
+                                continue;
+                            } else return false;
+                        }
+                        if(colVal === searchVal) continue;
+                        else return false;
+                    }
+                    return true; // if no objections, row should be included
+                }
+            );
+
+            // Initialize the bootstrap-multiselect plugin for module selection
+            moduleSelectRef.multiselect({
+                includeSelectAllOption: true,
+                onDeselectAll: changeModuleSelection,
+                onSelectAll: changeModuleSelection,
+                onChange: changeModuleSelection,
+                buttonText: buttonText,
+                selectAllText: _("Select all"),
+            });
+
+            // Initialize the bootstrap-multiselect plugin for exercise selection
+            exerciseSelectRef.multiselect({
+                includeSelectAllOption: true,
+                enableClickableOptGroups: true,
+                onDeselectAll: changeExerciseSelection,
+                onSelectAll: changeExerciseSelection,
+                onChange: changeExerciseSelection,
+                maxHeight: 500,
+                buttonText: buttonText,
+                selectAllText: _("Select all"),
+            });
+
+            // Save the jQuery DOM instance for later
+            multiSelectSelector = $(".multiselect-container");
+
+            // Make the first columns stick when scrolling table
+            $('#table-points-div').scroll(function(ev) {
+                $('#table-points .stick-on-scroll').css('transform', 'translateX(' + this.scrollLeft + 'px)');
+            });
+            /**
+             * Need new table top coordinate when window resized and elements possibly moved.
+             * This is debounced for more responsive UI while scaling.
+             */
+            $( window ).resize(function() {
+                refreshTableYPositionDebounced();
+            });
+
+            /**
+             * Event handlers for (de)selecting all summary rows at once
+             */
+            $('#summary-all').change(function() {
+                if($(this).prop('checked')) {
+                    summaryCheckboxesRef.prop('checked', true);
+                    _activeSummaryItems = ["0","1","2","3","4","5","6"];
+                } else {
+                    summaryCheckboxesRef.prop('checked', false);
+                    _activeSummaryItems = [];
+                    recreateSummaryRows();
+                }
+                dtVar.draw();
+            });
+
+            /**
+             * Event handlers for summary row selection checkboxes
+             */
+            $('.summary-checkbox').change(function() {
+                _activeSummaryItems = [];
+                summaryCheckboxesRef.each(function() {
+                    if($(this).prop('checked')) _activeSummaryItems.push($(this).val());
+                });
+                /**
+                 * If this was the last summary item checked, need to force summary rows
+                 * removal as the DataTables draw callback is not called for some reason.
+                 */
+                if(_activeSummaryItems.length === 0) {
+                    $('thead#table-heading').find('tr.summaryitem').remove();
+                    $('#summary-all').prop('checked', false); // also uncheck the "All" box
+                }
+                dtVar.draw();
+            });
+
+            /**
+             * Show only students with submissions checkbox is handled by
+             * dynamically creating/removing this DataTables search filter.
+             * Note: if the same method is applied for more functionality in the future,
+             * we need to make sure to pop the correct plugin from the array each time.
+             */
+            $('.withsubs-checkbox').change(function() {
+                if($(this).prop('checked')) {
+                    // DataTables search filter, returns true if student has submissions
+                    $.fn.dataTable.ext.search.push(
+                        function( settings, searchData ) {
+                            var subs = parseInt( searchData[5] ) || 0; // Number of submissions of student
+                            return subs > 0;
+                        }
+                    );
+                } else {
+                    $.fn.dataTable.ext.search.pop();
+                }
+                // Make a dummy search with empty string so the newly added plugin is applied
+                dtVar.search('');
+                recalculateTableDebounced();
+            });
+
+            /**
+             * Event listener and display logic for tag filters
+             */
+            $('.filter-users button').on('click', function(event) {
+                event.preventDefault();
+                let icon = $(this).find('.glyphicon');
+                if (icon.hasClass('glyphicon-unchecked')) {
+                    icon.removeClass('glyphicon-unchecked').addClass('glyphicon-check');
+                } else {
+                    icon.removeClass('glyphicon-check').addClass('glyphicon-unchecked');
+                }
+                searchForSelectedTags();
+            });
+
+            // Initialize data table position for fixing top header (see TODO)
+            // moved to the end of this function as it takes less time that way
+            refreshTableYPosition();
+        });
+    };
+
+    // Event listener for AND/OR tag operator
+    $('input.tags-operator').change(function(){
+        searchForSelectedTags();
+    });
+
+    /**
+     * To toggle whether only official points are displayed, we need to refetch the
+     * data from backend. This is because the frontend logic is already very complex.
+     */
+    $('input.official-checkbox').change(function(){
+        loadStudentData(!$(this).prop('checked'));
+    });
+
+    $(document).on("aplus:translation-ready", function() {
+        loadStudentData(false);
     });
 
 })(jQuery, document, window);

--- a/exercise/templates/exercise/staff/results.html
+++ b/exercise/templates/exercise/staff/results.html
@@ -17,27 +17,24 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/css/bootstrap-multiselect.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/js/bootstrap-multiselect.min.js"></script>
 
-<!--Required libraries for exporting table data to xlsx, csv or txt.-->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/TableExport/5.2.0/css/tableexport.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.14.3/xlsx.core.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/TableExport/5.2.0/js/tableexport.min.js"></script>
+<!-- DataTables plugin with Bootstrap 3 styling and Buttons/export support -->
+<!-- To upgrade plugin versions, go to https://datatables.net/download/index -->
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/jszip-2.5.0/dt-1.10.24/b-1.7.0/b-html5-1.7.0/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/bs/jszip-2.5.0/dt-1.10.24/b-1.7.0/b-html5-1.7.0/datatables.min.js"></script>
+<!-- DataTables plugin for calculating a sum during data filtering -->
+<script src="https://cdn.datatables.net/plug-ins/1.10.22/api/sum().js"></script>
 
 <!--Custom for loading animation (loading_animation.css) and other extra customizations (results_staff.css)
     results_staff.js is the main script for this page. -->
-<link rel="stylesheet" href="{% static 'exercise/css/loading_animation.css' %}" />
+<!--<link rel="stylesheet" href="{% static 'exercise/css/loading_animation.css' %}" />-->
 <link rel="stylesheet" href="{% static 'exercise/css/results_staff.css' %}" />
 <script
 	src="{% static 'exercise/results_staff.js' %}"
 	data-exercises-url="{% url 'api:course-exercises-list' version=2 course_id=instance.id %}"
-	data-students-url="{% url 'api:course-students-list' version=2 course_id=instance.id %}"
 	data-usertags-url="{% url 'api:course-usertags-list' version=2 course_id=instance.id %}"
-	data-points-url="{% url 'api:course-points-list' version=2 course_id=instance.id %}"
+	data-points-url="{% url 'api:course-resultsdata-list' version=2 course_id=instance.id %}"
 	defer>
 </script>
-
-<!--Filtering for table rows-->
-<script src="{% static 'js/filter.js' %}"></script>
 
 <!--Colortags-->
 <script src="{% static 'django_colortag.js' %}"></script>
@@ -46,142 +43,138 @@
 {% block columns %}
 
 <div class="col-md-12">
-
 	<div id="main-body">
+		<div class="col-md-6 col-sm-12">
+			<!--Selection options for modules and exercises-->
+			<table style="margin: 10px;">
+				<tbody>
+					<tr>
+						<td style="padding: 5px 10px 5px 10px;">
+							<label for="module-selection">{% trans "Select modules: " %}</label>
+						</td>
+						<td style="padding: 5px 10px 5px 10px;">
+							<select id="module-selection" multiple="multiple">
+							</select>
+						</td>
+					</tr>
 
-		<!--Selection options for modules and exercises-->
-		<table style="margin: 10px;">
-			<tbody>
-				<tr>
-					<td style="padding: 5px 10px 5px 10px;">
-						<label for="module-selection">{% trans "Select modules: " %}</label>
-					</td>
-					<td style="padding: 5px 10px 5px 10px;">
-						<select id="module-selection" multiple="multiple">
-						</select>
-					</td>
-				</tr>
+					<tr>
+						<td style="padding: 5px 10px 5px 10px;">
+							<label for="exercise-collection">{% trans "Select exercises: " %}</label>
+						</td>
+						<td style="padding: 5px 10px 5px 10px;">
+							<select id="exercise-selection" multiple="multiple">
+							</select>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
 
-				<tr>
-					<td style="padding: 5px 10px 5px 10px;">
-						<label for="exercise-collection">{% trans "Select exercises: " %}</label>
-					</td>
-					<td style="padding: 5px 10px 5px 10px;">
-						<select id="exercise-selection" multiple="multiple">
-						</select>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+		<div class="col-md-6 col-sm-12">
+			<!--Tags-->
+			<div style="padding: 10px 10px 30px 10px;" class="filter-users">
+				<small>{% trans "Filter users" %}:</small>
+				<span class="radio-inline">
+					<label><input type="radio" class="tags-operator" name="tags-operator" value="and" checked>AND</label>
+				</span>
+				<span class="radio-inline">
+					<label><input type="radio" class="tags-operator" name="tags-operator" value="or">OR</label>
+				</span>
+				<br>
+				{% for tag in tags %}
+				<button class="btn btn-default btn-xs tag-button" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-tag-slug="{{ tag.slug }}" data-tag-name="{{ tag.name }}">
+					<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+					{{ tag.name }}
+				</button>
+				{% endfor %}
+			</div>
+		</div>
 
+		<div class="col-sm-12">
+			<h4>{% trans "Options" %}</h4>
+			<span class="has-error">
+				<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
+				title="{% trans 'Points are official if the submission is within deadline and submission count limits. Submission must be also accepted and confirmed (for example, in case of mandatory feedback).' %}">
+					<input type="checkbox" class="official-checkbox" value="official" checked>
+					{% trans "Show only official points" %}
+			</label>
+			</span>
+			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
+				title="{% trans 'Show only students with submissions' %}">
+				<input type="checkbox" class="withsubs-checkbox" value="withsubs">
+				{% trans "Show only students with submissions" %}
+			</label>
+		</div>
 
-		<!--Checkboxes to select extra information about data-->
-		<div style="margin: 10px;">
+		<div class="col-sm-12" style="padding-bottom: 20px">
+			<!--Checkboxes to select extra information about data-->
 			<h4>{% trans "Summaries" %}</h4>
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
+				title="{% trans 'Select or deselect all summaries.' %}">
+				<input type="checkbox" id="summary-all" value="all">
+				{% trans "All" %}
+			</label>
+			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Total number of submissions. Calculates all student submission counts together.' %}">
-				<input type="checkbox" class="total-subm-checkbox" value="total-subm">
+				<input type="checkbox" id="summary-0" class="summary-checkbox" value="0">
 				{% trans "Total submissions" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="ml-10 checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'How many submissions a single student has used on the exercise on average. Only accounts for students with one or more submissions.' %}">
-				<input type="checkbox" class="avg-subm-checkbox" value="avg-subm">
+				<input type="checkbox" id="summary-1" class="summary-checkbox" value="1">
 				{% trans "Average submissions per student" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="ml-10 checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Maximum number of available submissions for the exercise.' %}">
-				<input type="checkbox" class="max-subm-checkbox" value="max-subm">
+				<input type="checkbox" id="summary-2" class="summary-checkbox" value="2">
 				{% trans "Maximum submissions" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Number of students that have one or more exercise submissions.' %}">
-				<input type="checkbox" class="total-stu-subm-checkbox" value="total-stu-subm">
+				<input type="checkbox" id="summary-3" class="summary-checkbox" value="3">
 				{% trans "Students with submissions" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Number of students that have received maximum points from the exercise.' %}">
-				<input type="checkbox" class="total-stu-max-checkbox" value="total-stu-max">
+				<input type="checkbox" id="summary-4" class="summary-checkbox" value="4">
 				{% trans "Students with max points" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Average points received for the exercise per student. Only accounts for students with one or more submissions.' %}">
-				<input type="checkbox" class="avg-p-checkbox" value="avg-p">
+				<input type="checkbox" id="summary-5" class="summary-checkbox" value="5">
 				{% trans "Average points per student" %}
 			</label>
 
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% trans 'Maximum points for the exercise.' %}">
-				<input type="checkbox" class="max-p-checkbox" value="max-p">
+				<input type="checkbox" id="summary-6" class="summary-checkbox" value="6">
 				{% trans "Maximum points" %}
 			</label>
-
-			<div class="has-error">
-				<div class="checkbox">
-					<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
-						title="{% trans 'Points are official if the submission is within deadline and submission count limits. Submission must be also accepted and confirmed (for example, in case of mandatory feedback).' %}">
-						<input type="checkbox" class="official-checkbox" value="official" checked>
-						{% trans "Show only official points" %}
-					</label>
-				</div>
-			</div>
 		</div>
-
-
-		<!--Tags-->
-		<div style="margin: 10px 10px 10px 20px;" class="filter-users">
-			<small>{% trans "Filter users" %}:</small>
-			{% for tag in tags %}
-			<button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-tag-slug="{{ tag.slug }}">
-				<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
-				{{ tag.name }}
-			</button>
-			{% endfor %}
-		</div>
-
 
 		<!--Navigation bar to choose how data is shown-->
-		<div role="navigation" aria-label="{% trans "View selection" %}">
-			<ul style="margin: 10px 0px 50px 0px;" id="exercise-nav-tabs" class="nav nav-tabs">
-				<li id="difficulty-exercises" role="presentation" class="active">
-					<a onclick="createPointTable('difficulty');" data-toggle="tab" href="#">{% trans "Show exercises by difficulty" %}</a>
-				</li>
-				<li id="module-exercises" role="presentation">
-					<a onclick="createPointTable('module');" data-toggle="tab" href="#">{% trans "Show exercises by module" %}</a>
-				</li>
-				<li id="all-exercises" role="presentation">
-					<a onclick="createPointTable('all');" data-toggle="tab" href="#">{% trans "Show all exercises" %}</a>
-				</li>
-			</ul>
-		</div>
-
-
-		<!--Dropdown button for table exports. The buttons are added inside results_staff.js-->
-		<div id="table-export-dropdown" class="dropdown d-inline-block">
-			<button disabled class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">{% trans "Export Data" %}
-				<span class="caret"></span>
-			</button>
-			<ul id="export-button-menu" class="dropdown-menu">
-
-			</ul>
-		</div>
-
-		<!--Alerts-->
-		<div id="alerts" style="margin: 30px">
-			<div id="ajax-failed-alert" class="alert alert-danger collapse" role="alert">
-				{% trans "Data couldn't be fetched. Please check your internet connection." %}
-			</div>
-		</div>
+		<ul id="exercise-nav-tabs" class="nav nav-tabs" role="tablist" style="padding-top: 20px">
+			<li id="difficulty-exercises" role="presentation" class="active">
+				<a onclick="changeDisplayMode(1);" role="tab" aria-controls="table-points-div" data-toggle="tab" href="#difficulty">{% trans "Show exercises by difficulty" %}</a>
+			</li>
+			<li id="module-exercises" role="presentation">
+				<a onclick="changeDisplayMode(2);" role="tab" aria-controls="table-points-div" data-toggle="tab" href="#module">{% trans "Show exercises by module" %}</a>
+			</li>
+			<li id="all-exercises" role="presentation">
+				<a onclick="changeDisplayMode(3);" role="tab" aria-controls="table-points-div" data-toggle="tab" href="#exercise">{% trans "Show all exercises" %}</a>
+			</li>
+		</ul>
 
 		<!--Data table-->
-		<div style="display: none;" id="table-points-div" class="table-responsive">
-			<table id="table-points" class="table table-striped table-bordered table-condensed filtered-table">
+		<div id="table-points-div" class="table-responsive" role="tabpanel" style="padding: 20px 0px 0px 0px;">
+			<table id="table-points" class="table table-striped table-bordered table-condensed">
 				<thead id="table-heading">
-					<tr id="table-heading-row"></tr>
 				</thead>
 				<tbody id="table-body">
 
@@ -190,26 +183,5 @@
 		</div>
 
 	</div>
-
-
-	<!--Loading animation-->
-	<div class="row">
-		<div class="col-md-12">
-			<div id="results-loading-animation" class="loading-animation">
-				<span></span>
-				<span></span>
-				<span></span>
-			</div>
-		</div>
-	</div>
-
-
-	<!--Loading progress-->
-	<div class="row">
-		<div class="col-md-12">
-			<div id="results-loading-progress" class="text-center"></div>
-		</div>
-	</div>
-
 </div>
 {% endblock columns %}

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2895,10 +2895,6 @@ msgid "Show all exercises"
 msgstr "Näytä kaikki tehtävät"
 
 #: exercise/templates/exercise/staff/results.html
-msgid "Export Data"
-msgstr "Vie Tiedostoon"
-
-#: exercise/templates/exercise/staff/results.html
 msgid "Data couldn't be fetched. Please check your internet connection."
 msgstr "Tietojen lataaminen ei onnistunut. Tarkista yhteys palveluun."
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 16:21+0300\n"
+"POT-Creation-Date: 2021-05-12 15:10+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Markku Riekkinen <markku.riekkinen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -1068,12 +1068,33 @@ msgid "Assistants"
 msgstr "Assistentit"
 
 #: edit_course/course_forms.py
+#: edit_course/templates/edit_course/edit_content.html
+msgid "Exercise categories"
+msgstr "Tehtäväkategoriat"
+
+#: edit_course/course_forms.py
+#: edit_course/templates/edit_course/edit_content.html
+msgid "Course modules"
+msgstr "Kurssimoduulit"
+
+#: edit_course/course_forms.py
 msgid "Content chapters"
 msgstr "Sisältökappaleet"
 
 #: edit_course/course_forms.py
 msgid "Exercises"
 msgstr "Harjoitukset"
+
+#: edit_course/course_forms.py
+#: external_services/templates/external_services/edit_menu.html
+#: external_services/templates/external_services/list_menu.html
+msgid "Menu items"
+msgstr "Valikon linkit"
+
+#: edit_course/course_forms.py
+#: edit_course/templates/edit_course/usertag_list.html
+msgid "Student tags"
+msgstr "Opiskelijamerkinnät"
 
 #: edit_course/course_forms.py
 msgid "The URL is already taken."
@@ -1378,11 +1399,6 @@ msgstr "Hae uusin käännösloki"
 msgid "Previous modification of this course instance took place at"
 msgstr "Kurssia on viimeksi muokattu"
 
-#: edit_course/course_forms.py
-#: edit_course/templates/edit_course/edit_content.html
-msgid "Exercise categories"
-msgstr "Tehtäväkategoriat"
-
 #: edit_course/templates/edit_course/edit_content.html
 msgid "Edit category"
 msgstr "Muokkaa kategoriaa"
@@ -1390,11 +1406,6 @@ msgstr "Muokkaa kategoriaa"
 #: edit_course/templates/edit_course/edit_content.html
 msgid "Add new category"
 msgstr "Lisää uusi kategoria"
-
-#: edit_course/course_forms.py
-#: edit_course/templates/edit_course/edit_content.html
-msgid "Course modules"
-msgstr "Kurssimoduulit"
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "Edit module"
@@ -1675,11 +1686,6 @@ msgstr "Muokkaa opiskelijamerkintää"
 #: edit_course/templates/edit_course/usertag_list.html
 msgid "Add new student tag"
 msgstr "Lisää uusi opiskelijamerkintä"
-
-#: edit_course/course_forms.py
-#: edit_course/templates/edit_course/usertag_list.html
-msgid "Student tags"
-msgstr "Opiskelijamerkinnät"
 
 #: edit_course/templates/edit_course/usertag_list.html
 msgid "Tag"
@@ -2167,8 +2173,7 @@ msgid "Total points"
 msgstr "Yhteispisteet"
 
 #: exercise/templates/exercise/_enrollment_success.html
-msgid ""
-"You have successfully enrolled in the course!"
+msgid "You have successfully enrolled in the course!"
 msgstr "Kurssille ilmoittautuminen onnistui!"
 
 #: exercise/templates/exercise/_enrollment_success.html
@@ -2509,12 +2514,11 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                                                %(points)s points required "
-"to pass.\n"
-"                                            "
+"\t\t\t\t\t\t\t\t\t\t\t\t%(points)s points required to pass.\n"
+"\t\t\t\t\t\t\t\t\t\t\t"
 msgstr ""
 "\n"
-"Suoritusmerkintään vaaditaan %(points)s pistettä"
+"Suoritusmerkintään vaaditaan %(points)s pistettä."
 
 #: exercise/templates/exercise/exercise_plain.html
 msgid "Show model answer"
@@ -2541,6 +2545,10 @@ msgstr "Palautuksen tiedot"
 #: exercise/templates/exercise/staff/_assess_info.html
 msgid "Submission time"
 msgstr "Palautusaika"
+
+#: exercise/templates/exercise/staff/_assess_info.html
+msgid "Grading time"
+msgstr "Arvosteluaika"
 
 #: exercise/templates/exercise/staff/_assess_info.html
 msgid "grader output"
@@ -2596,8 +2604,8 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"    %(count)s submissions\n"
-"    "
+"\t\t%(count)s submissions\n"
+"\t\t"
 msgstr ""
 "\n"
 "%(count)s palautusta"
@@ -2616,8 +2624,8 @@ msgstr "Tutki"
 #, python-format
 msgid ""
 "\n"
-"                    Late <small>-%(percent)s%%</small>\n"
-"                    "
+"\t\t\t\t\t\t\t\t\t\tLate <small>-%(percent)s%%</small>\n"
+"\t\t\t\t\t\t\t\t\t\t"
 msgstr ""
 "\n"
 "Myöhässä <small>-%(percent)s%%</small>"
@@ -2635,11 +2643,11 @@ msgid "Module selection"
 msgstr "Moduulin valinta"
 
 #: exercise/templates/exercise/staff/analytics.html
+#: exercise/templates/exercise/staff/results.html
 msgid "All"
 msgstr "Kaikki"
 
 #: exercise/templates/exercise/staff/analytics.html
-#: exercise/templates/exercise/staff/results.html
 msgid "View selection"
 msgstr "Näkymän valinta"
 
@@ -2797,8 +2805,34 @@ msgid "Select exercises: "
 msgstr "Valitse tehtävät: "
 
 #: exercise/templates/exercise/staff/results.html
+msgid "Options"
+msgstr "Valinnat"
+
+#: exercise/templates/exercise/staff/results.html
+msgid ""
+"Points are official if the submission is within deadline and submission "
+"count limits. Submission must be also accepted and confirmed (for example, "
+"in case of mandatory feedback)."
+msgstr ""
+"Pisteet ovar virallisia jos palautus on tehty määräajassa ja sallittujen "
+"palautuskertojen sisällä. Palautus täytyy olla myös hyväksytty ja "
+"varmistettu (esimerkiksi pakollisen palautteen yhteydessä)."
+
+#: exercise/templates/exercise/staff/results.html
+msgid "Show only official points"
+msgstr "Näytä vain viralliset pisteet"
+
+#: exercise/templates/exercise/staff/results.html
+msgid "Show only students with submissions"
+msgstr "Näytä vain palauttaneet opiskelijat"
+
+#: exercise/templates/exercise/staff/results.html
 msgid "Summaries"
 msgstr "Yhteenvedot"
+
+#: exercise/templates/exercise/staff/results.html
+msgid "Select or deselect all summaries."
+msgstr "Valitse kaikki yhteenvedot tai poista valinta kaikista"
 
 #: exercise/templates/exercise/staff/results.html
 msgid ""
@@ -2869,20 +2903,6 @@ msgid "Maximum points"
 msgstr "Enimmäispisteet"
 
 #: exercise/templates/exercise/staff/results.html
-msgid ""
-"Points are official if the submission is within deadline and submission "
-"count limits. Submission must be also accepted and confirmed (for example, "
-"in case of mandatory feedback)."
-msgstr ""
-"Pisteet ovar virallisia jos palautus on tehty määräajassa ja sallittujen "
-"palautuskertojen sisällä. Palautus täytyy olla myös hyväksytty ja "
-"varmistettu (esimerkiksi pakollisen palautteen yhteydessä)."
-
-#: exercise/templates/exercise/staff/results.html
-msgid "Show only official points"
-msgstr "Näytä vain viralliset pisteet"
-
-#: exercise/templates/exercise/staff/results.html
 msgid "Show exercises by difficulty"
 msgstr "Näytä tehtävät vaikeusasteittain"
 
@@ -2893,10 +2913,6 @@ msgstr "Näytä tehtävät moduulettain"
 #: exercise/templates/exercise/staff/results.html
 msgid "Show all exercises"
 msgstr "Näytä kaikki tehtävät"
-
-#: exercise/templates/exercise/staff/results.html
-msgid "Data couldn't be fetched. Please check your internet connection."
-msgstr "Tietojen lataaminen ei onnistunut. Tarkista yhteys palveluun."
 
 #: exercise/templates/exercise/staff/submissions_summary.html
 msgid "Submissions summary"
@@ -3433,12 +3449,6 @@ msgstr ""
 #: external_services/templates/external_services/edit_menu.html
 msgid "Add menu item"
 msgstr "Lisää linkki"
-
-#: edit_course/course_forms.py
-#: external_services/templates/external_services/edit_menu.html
-#: external_services/templates/external_services/list_menu.html
-msgid "Menu items"
-msgstr "Valikon linkit"
 
 #: external_services/templates/external_services/list_menu.html
 msgid "Link"


### PR DESCRIPTION
# Description

This is a complete rewrite of the All results page (JavaScript parts mostly). It also adds 'difficulty' field to ExerciseBriefSerializer, and defines a new API endpoint based on the old csv endpoint aggregate_points.py. I have tried to keep the existing functionality wherever possible, even though the page works very differently now.

This implementation fetches exercises, usertags, and student points by only three ajax calls regardless of the student count, and loads the results into a DataTable object (https://www.datatables.net/). Data is reloaded only in the case when user wishes to changing from official to unofficial points view, or vice versa. Using the DataTables jQuery plugin brings new functionality like column sorting, but also makes some things more difficult. DataTables also replaces the old CSV/Excel/Text export functionality, which was done via another external plugin.

This implementation does not use the A-plus table filter functionality, so only the operators < and > are in use for searching the points columns. It may be possible to adapt the existing filter.js to work with this implementation, but at least with this page I didn't really see the need for it. There is also no translation for the search field placeholders.

I have tried to optimize the backend code so that the number of database calls is reasonable. It doesn't use the cached student objects, but I think that would not increase performance.

Known issues:
- Need to create proper URLs for the ajax calls for results.html (exercisesUrl and pointsUrl) so, that dynamic links are passed to results_staff.js instead of the currently hardcoded links used in testing.
- When the user has defined a filter for Total column, for example, and removes some module(s) from view, the displayed results may no longer reflect the search. This is a chicken-and-egg problem, as we need to know the filtered-out students before calculating the summaries and totals, but at the same time filter out those who end up being outside the filtering conditions. This needs to be fixed by clearing the Total results whenever the user changes the modules/exercises selection, and clearing the module column searches when the exercises selections change.
- Some Finnish translations are missing, but I'm not sure if they are even used/required in the teachers' view.

Fixes #777

# Testing

Not formally tested, and probably needs work to comply with the common A-plus style. The new API endpoint also probably belongs to somewhere else than where it is now. As there is a lot of JS code and jQuery is involved, expect to find undiscovered bugs and edge cases. I have tested the performance with the default sample course with up to 1000 students and 18000+ exercise submissions, and in that case (on my reasonably powerful desktop machine) a full page reload takes less than 5 seconds.

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.