### PR TITLE
Implemented sitemap. Fixes #520

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.humanize',
+    'django.contrib.sitemaps',
 
     # 3rd party applications
     'bootstrapform',

--- a/aplus/urls.py
+++ b/aplus/urls.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
+from django.urls import path
 
 import shibboleth_login.urls
 import social_django.urls
-import userprofile.urls
-import course.urls, course.long_urls
-import exercise.urls
+import userprofile.urls, userprofile.sitemaps
+import course.urls, course.long_urls, course.sitemaps
+import exercise.urls, exercise.sitemaps
 import edit_course.urls
 import deviations.urls
 import notification.urls
@@ -19,6 +21,12 @@ import redirect_old_urls.urls
 
 
 admin.autodiscover()
+
+all_sitemaps = {
+    **course.sitemaps.all_sitemaps,
+    **exercise.sitemaps.all_sitemaps,
+    **userprofile.sitemaps.all_sitemaps,
+}
 
 #  Pay attention to the order the URL patterns will be matched!
 urlpatterns = [
@@ -38,6 +46,8 @@ urlpatterns = [
     url(r'^', include(notification.urls)),
     url(r'^', include(exercise.urls)),
     url(r'^', include(course.urls)),
+    path('sitemap.xml', sitemap, { 'sitemaps': all_sitemaps },
+        name='django.contrib.sitemaps.views.sitemap'),
 ]
 
 if settings.DEBUG:

--- a/course/models.py
+++ b/course/models.py
@@ -483,6 +483,10 @@ class CourseInstance(UrlMixin, models.Model):
 
     def is_valid_language(self, lang):
         return lang == "" or lang in [key for key,name in settings.LANGUAGES]
+    
+    @property
+    def languages(self):
+        return self.language.strip('|').split('|')
 
     @property
     def default_language(self):

--- a/course/sitemaps.py
+++ b/course/sitemaps.py
@@ -1,0 +1,53 @@
+from django.contrib import sitemaps
+from django.urls.base import reverse
+from django.utils import timezone
+
+from .models import CourseInstance, CourseModule
+
+
+class CourseStaticViewSitemap(sitemaps.Sitemap):
+    priority = 0.5
+    changefreq = 'monthly'
+
+    def items(self):
+        return [
+            'home',
+            'archive',
+        ]
+
+    def location(self, item):
+        return reverse(item)
+
+
+class InstanceSitemap(sitemaps.Sitemap):
+    priority = 1.0
+    changefreq = 'daily'
+
+    def items(self):
+        return CourseInstance.objects.filter(
+            view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+        )
+
+    def location(self, item):
+        return item.get_display_url()
+
+
+class ModuleSitemap(sitemaps.Sitemap):
+    priority = 0.2
+    changefreq = 'daily'
+
+    def items(self):
+        return CourseModule.objects.filter(
+            course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            opening_time__lte=timezone.now(),
+        )
+
+    def location(self, item):
+        return item.get_display_url()
+
+
+all_sitemaps = {
+    'course_static': CourseStaticViewSitemap,
+    'course_instance': InstanceSitemap,
+    'course_module': ModuleSitemap,
+}

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -23,6 +23,13 @@
 
 {% block title %}{{ course.name|parse_localization }} | {{ block.super }} {% endblock %}
 
+{% block alternates %}
+{% for language in instance.languages %}
+<link rel="alternate" hreflang="{{ language }}" href="{{ request.get_full_path|localized_url:language }}" />
+{% endfor %}
+<link rel="alternate" hreflang="x-default" href="{{ request.get_full_path|localized_url:instance.default_language }}" />
+{% endblock %}
+
 {% block content %}
 <div data-taggings="{{ get_taggings|join:' ' }}"  class="row">
     <div class="col-sm-2 hidden-xs">

--- a/course/templatetags/base.py
+++ b/course/templatetags/base.py
@@ -4,7 +4,7 @@ from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
-from lib.helpers import settings_text
+from lib.helpers import remove_query_param_from_url, settings_text, update_url_params
 
 
 register = template.Library()
@@ -67,3 +67,15 @@ def site_advert():
 @register.simple_tag
 def tracking_html():
     return mark_safe(settings.TRACKING_HTML)
+
+
+@register.filter
+def localized_url(path, language=None):
+    base_url = settings.BASE_URL
+    if base_url.endswith('/'):
+        base_url = base_url[:-1]
+    path = remove_query_param_from_url(path, 'hl')
+    if not language:
+        language = settings.LANGUAGE_CODE.split('-')[0]
+    path = update_url_params(path, { 'hl': language })
+    return base_url + path

--- a/exercise/sitemaps.py
+++ b/exercise/sitemaps.py
@@ -1,0 +1,58 @@
+from django.contrib import sitemaps
+from django.urls.base import reverse
+from django.utils import timezone
+
+from course.models import CourseInstance
+from .models import BaseExercise, CourseChapter, LearningObject
+
+
+class BaseExerciseSitemap(sitemaps.Sitemap):
+    priority = 0.2
+    changefreq = 'daily'
+
+    def items(self):
+        return BaseExercise.objects.filter(
+            course_module__course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            course_module__opening_time__lte=timezone.now(),
+            status__in=[LearningObject.STATUS.READY, LearningObject.STATUS.UNLISTED],
+            audience=LearningObject.AUDIENCE.COURSE_AUDIENCE,
+        )
+
+    def location(self, item):
+        return item.get_display_url()
+
+
+class CourseChapterSitemap(sitemaps.Sitemap):
+    priority = 1.0
+    changefreq = 'daily'
+
+    def items(self):
+        return CourseChapter.objects.filter(
+            course_module__course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            course_module__opening_time__lte=timezone.now(),
+            status__in=[LearningObject.STATUS.READY, LearningObject.STATUS.UNLISTED],
+            audience=LearningObject.AUDIENCE.COURSE_AUDIENCE,
+        )
+
+    def location(self, item):
+        return item.get_display_url()
+
+
+class TableOfContentsSitemap(sitemaps.Sitemap):
+    priority = 0.2
+    changefreq = 'monthly'
+
+    def items(self):
+        return CourseInstance.objects.filter(
+            view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+        )
+
+    def location(self, item):
+        return reverse('toc', kwargs=item.get_url_kwargs())
+
+
+all_sitemaps = {
+    'exercise_exercise': BaseExerciseSitemap,
+    'exercise_chapter': CourseChapterSitemap,
+    'exercise_toc': TableOfContentsSitemap,
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,15 @@
 
 	<title>{% block title %}{% brand_name %}{% endblock %}</title>
 
+	{% block alternates %}
+	{% get_available_languages as LANGUAGES %}
+	{% get_language_info_list for LANGUAGES as languages %}
+	{% for language in languages %}
+	<link rel="alternate" hreflang="{{ language.code }}" href="{{ request.get_full_path|localized_url:language.code }}" />
+	{% endfor %}
+	<link rel="alternate" hreflang="x-default" href="{{ request.get_full_path|localized_url }}" />
+	{% endblock %}
+
 	<script src="https://code.jquery.com/jquery-1.12.4.min.js"
 		integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ"
 		crossorigin="anonymous"></script>

--- a/userprofile/sitemaps.py
+++ b/userprofile/sitemaps.py
@@ -1,0 +1,22 @@
+from django.contrib import sitemaps
+from django.urls.base import reverse
+
+
+class UserProfileStaticViewSitemap(sitemaps.Sitemap):
+    priority = 0.1
+    changefreq = 'yearly'
+
+    def items(self):
+        return [
+            'privacy_notice',
+            'accessibility_statement',
+            'support_channels',
+        ]
+
+    def location(self, item):
+        return reverse(item)
+
+
+all_sitemaps = {
+    'userprofile_static': UserProfileStaticViewSitemap,
+}


### PR DESCRIPTION
# Description

**What?**

Implement the `sitemap.xml` endpoint to A+ (see https://www.sitemaps.org/protocol.html for specification). Additionally, link between alternate language versions of a page in the `<head>` element.

**Why?**

Should improve results in Google search, and also provide a way for Google to be able to serve the correct localization of a course based on the user's language preferences.

**How?**

Added `django.contrib.sitemaps` to the installed components, and the path to `sitemap.xml` in the main `urls.py` file. Each module with public content (course, exercise, userprofile) has its own `sitemaps.py` file, which defines the URLs that should appear in the combined sitemap. For courses (and models related to courses), only the ones that are public and have already started are listed in the sitemap.

Updated the `base.html` template to include a list of `<link>` elements in the `<head>`, one for each supported language, plus one with `x-default` as its language, which links to the site's default language version. These links are overridden in `course_base.html` to only list the languages supported by that course, and `x-default` refers to the course's default language.

Fixes #520


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the sitemap contains links to all public and started courses and their modules/chapters/exercises. Also tested that courses that are not public or haven't started yet, are not listed. Tested that the `<link>` elements appear in the `<head>`, and their languages match the site's/course's language settings.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*