### PR TITLE
Implement new exercise tree endpoint. Fixes #603

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -32,6 +32,9 @@ with api.register(r'courses',
     courses.register(r'exercises',
                      course.api.views.CourseExercisesViewSet,
                      basename='course-exercises')
+    courses.register(r'tree',
+                     course.api.views.CourseExerciseTreeViewSet,
+                     basename='course-tree')
     courses.register(r'students',
                      course.api.views.CourseStudentsViewSet,
                      basename='course-students')

--- a/course/api/views.py
+++ b/course/api/views.py
@@ -68,6 +68,27 @@ class CourseExercisesViewSet(NestedViewSetMixin,
         return self.get_member_object('module', 'Exercise module')
 
 
+class CourseExerciseTreeViewSet(CourseResourceMixin,
+                                viewsets.ViewSet):
+    """
+    This viewset returns the chapters and exercises of the course in a tree-like
+    structure. To build the tree, it uses the `CachedContent` class, which
+    contains the course's chapters and exercises in a hierarchical structure.
+    The CachedContent instance is accessed through the `self.content` attribute,
+    which is defined in the `CourseInstanceBaseMixin` base class.
+    """
+    serializer_class = TreeCourseModuleSerializer
+
+    def list(self, request, *args, **kwargs):
+        serializer = self.serializer_class(
+            self.content.data['modules'],
+            many=True,
+            context={ 'request': request }
+        )
+        response_data = { 'modules': serializer.data }
+        return Response(response_data)
+
+
 class CourseStudentsViewSet(NestedViewSetMixin,
                             MeUserMixin,
                             CourseResourceMixin,


### PR DESCRIPTION
# Description

**What?**

Add new exercise tree endpoint (`/api/v2/courses/{course_id}/tree`) to A+ API. The new endpoint presents the learning objects of a course in a tree-like hierarchy, unlike the regular `exercises` endpoint, which presents them as a flat list.

**Why?**
The flat exercise list does not sort the exercises in the hierarchical order. This new endpoint is also necessary for the IntelliJ plugin.

**How?**

Created a new viewset (`CourseExerciseTreeViewSet`) which accesses the cached content of the course instance, and two new serializers for outputting the data (`TreeCourseModuleSerializer`, `TreeExerciseSerializer`). The viewset doesn't derive from `ReadOnlyModelViewSet` and the serializers don't inherit from `AplusModelSerializer` because they don't operate on model objects. Instead, they operate on `dict`s that the course instance's cached content contains.

The reason for using the cached content is that it is already in a hierarchical structure.

Fixes #603


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the exercise tree was returned correctly in cases where there are multiple modules, where the hierarchy is deeply nested, where a module has no exercises, and other cases.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*