### PR TITLE
Grader IP verification in a Kubernetes environment

### DIFF
--- a/aplus/local_settings.example.py
+++ b/aplus/local_settings.example.py
@@ -121,3 +121,7 @@
 #        'level': 'DEBUG',
 #    },
 #})
+#
+## Kubernetes deployment specific settings
+# KUBERNETES_MODE = True
+# KUBERNETES_NAMESPACE = 'my-k8s-namespace'

--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -322,6 +322,10 @@ REST_FRAMEWORK = {
 OVERRIDE_SUBMISSION_HOST = None
 REMOTE_PAGE_HOSTS_MAP = None
 
+# Kubernetes deployment specific settings, unused otherwise
+KUBERNETES_MODE = False
+KUBERNETES_NAMESPACE = "default"
+
 # Maximum submissions limit for exercises that allow unofficial submissions.
 # The exercise-specific max submissions limit may then be exceeded, however,
 # this limit will prevent students from spamming massive amounts of submissions.

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -5,3 +5,5 @@ wheel
 # This extra library is required if postgres is used as the database
 psycopg2 >= 2.8.6, < 3
 lz4 ~= 3.1.3
+# Required for Kubernetes based deployment
+kubernetes == 12.0.1


### PR DESCRIPTION
# Description

**What?**

Verification layer for grading job results submitted to A+ in a Kubernetes environment.

**Why?**

The existing authentication code for receiving grading results from mooc-grader checks whether the grader service host IP matches the IP the jobs were submitted in. In a Kubernetes environment this doesn't work, as A+ refers to mooc-grader via a service URL / IP address, which differs from mooc-grader container's internal IP address.

**How?**

The new solution adds two new global configuration flags, KUBERNETES_MODE and KUBERNETES_NAMESPACE. If KUBERNETES_MODE is set to True, instead of the previously defined authentication layer, A+ now queries the registered Kubernetes API server for mooc-grader pod IP addresses in the KUBERNETES_NAMESPACE, and checks if the request IP matches one of those, essentially providing the same functionality as before.

# Testing

**What type of test did you run?**

- [x] Manual testing.

Built and run A+ container in a k8s cluster and deployed A+ and mooc-grader via Helm. Verified that requests from grader pods worked, while requests from other pods / outside the cluster didn't get through.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [x] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*