### PR TITLE
Fix scrolling and layout issues on All results page

### DIFF
--- a/assets/js-translations/teacher.fi.json
+++ b/assets/js-translations/teacher.fi.json
@@ -54,7 +54,7 @@
   "Organisaatio",
 
   "Student ID":
-  "Opiskelijanumero",
+  "Opiskelija\u00ADnumero",
 
   " students selected":
   " opiskelijaa valittuna",

--- a/assets/js-translations/teacher.fi.json
+++ b/assets/js-translations/teacher.fi.json
@@ -62,6 +62,9 @@
   "No difficulty":
   "Ei vaikeusastetta",
 
+  "The percentage indicates the distribution of the total.":
+  "Prosenttiosuus ilmaisee osuuden kokonaissummasta.",
+
   "Total submissions":
   "Palautuksia yhteensä",
 
@@ -75,10 +78,10 @@
   "Tehtävän palauttaneet opiskelijat",
 
   "Students with max points":
-  "Opiskelijoiden lkm joilla on täydet pisteet",
+  "Opiskelijoiden lkm, joilla on täydet pisteet",
 
   "Average points per student with submissions":
-  "Pisteiden keskiarvo per opiskelija jolla on vähintään yksi palautus",
+  "Pisteiden keskiarvo per opiskelija, jolla on vähintään yksi palautus",
 
   "Maximum points":
   "Enimmäispisteet",
@@ -86,23 +89,23 @@
   "Total number of submissions. Calculates all student submission counts together.":
   "Palautusten lukumäärä. Laskee kaikkien opiskelijoiden kaikkien palautusten lukumäärän yhteen.",
 
-  "How many submissions a single student has used on the exercise on average. Only accounts for students with one or more submissions.":
-  "Kuinka monta palautusta opiskelija on käyttänyt tehtävään keskimäärin. Lasketaan vain opiskelijat, joilla on vähintään yksi palautus.",
+  "How many submissions a single student has used on the assignment or group of assignments on average. Only accounts for students with one or more submissions.":
+  "Kuinka monta palautusta opiskelija on käyttänyt tehtävään tai tehtäväjoukkoon keskimäärin. Lasketaan vain opiskelijat, joilla on vähintään yksi palautus.",
 
-  "Maximum number of available submissions for the exercise.":
-  "Kuinka monta palautusta tehtävässä on mahdollista käyttää.",
+  "Maximum number of available submissions for the assignment or group of assignments.":
+  "Kuinka monta palautusta tehtävässä tai tehtäväjoukossa on mahdollista käyttää.",
 
-  "Number of students that have one or more exercise submissions.":
+  "Number of students that have one or more assignment submissions.":
   "Opiskelijoiden lukumäärä, joilla on vähintään yksi palautus.",
 
-  "Number of students that have received maximum points from the exercise.":
-  "Opiskeljoiden lukumäärä, jotka ovat saaneet täydet pisteet tehtävästä.",
+  "Number of students that have received maximum points from the assignment or group of assignments.":
+  "Opiskelijoiden lukumäärä, jotka ovat saaneet täydet pisteet tehtävästä tai tehtäväjoukosta.",
 
-  "Average points received for the exercise. Only accounts for students with one or more submissions.":
-  "Kuinka monta pistettä opiskelijat ovat saaneet tehtävästä keskimäärin. Lasketaan vain opiskelijat, joilla on vähintään yksi palautus.",
+  "Average points received for the assignment or group of assignments. Only accounts for students with one or more submissions.":
+  "Kuinka monta pistettä opiskelijat ovat saaneet tehtävästä tai tehtäväjoukosta keskimäärin. Lasketaan vain opiskelijat, joilla on vähintään yksi palautus.",
 
-  "Maximum points for the exercise.":
-  "Tehtävän enimmäispisteet.",
+  "Maximum points for the assignment or group of assignments.":
+  "Tehtävän tai tehtäväjoukon enimmäispisteet.",
 
   "Export to xlsx (Excel)":
   "Vie xlsx tiedostoon (Excel)",

--- a/exercise/static/exercise/css/results_staff.css
+++ b/exercise/static/exercise/css/results_staff.css
@@ -12,32 +12,95 @@
  * Table
  */
 
-.student-id,
-.student-name {
-	background-color: rgb(188, 232, 241);
-	font-weight: bold;
+ #table-points-div {
+	max-height: calc(100vh - 12em);
+	max-width: 100vw;
+	overflow: scroll;
 }
 
-table#table-points thead#table-heading th.indicator-heading {
-	filter: brightness(85%);
-}
-
-table#table-points thead#table-heading th {
-	top: 0;
-	border-bottom-width: 1px;
-}
-
-table#table-points thead th:not(.indicator-heading) {
+#table-heading th {
+	min-width: 6em;
+	width: 15vw;
+	max-width: calc(12em + 26px);
 	background-color: white;
+	position: -webkit-sticky; /* Safari */
+	position: sticky;
+	top: 6px;
+	z-index: 2;
 }
 
-table#table-points thead th div.ratio {
+#table-heading th.student-name,
+#table-heading th.student-id,
+#table-heading th.total {
+	max-width: calc(8em + 26px);
+}
+
+#table-heading .form-control { /* Search bars in heading cells */
+	min-width: 6em;
+	width: min(12em, 14vw);
+}
+
+#table-heading th.student-name .form-control,
+#table-heading th.student-id .form-control,
+#table-heading th.total .form-control {
+	max-width: 8em;
+}
+
+#table-heading th,
+#table-heading td {
+	border-top-width: 1px;
+	border-bottom-width: 1px;
+} 
+
+#table-heading th.stick-on-scroll:not(.indicator-heading) {
+    left: 0;
+    z-index: 3;
+}
+
+#table-heading th.stick-on-scroll.indicator-heading {
+	left: 0;
+}
+
+tbody td.stick-on-scroll {
+    position: -webkit-sticky; /* Safari */
+    position: sticky;
+    left: 0;
+    z-index: 1;
+}
+
+#table-heading th.stick-on-scroll,
+tbody td.stick-on-scroll {
+	background-color: #d6d6d6 100%;
+}
+
+#table-heading th.stick-on-scroll:nth-child(2),
+tbody td.stick-on-scroll:nth-child(2) {
+    left: min(calc(8em + 10px), calc(14vw + 26px));
+}
+
+#table-heading th.stick-on-scroll:nth-child(3),
+tbody td.stick-on-scroll:nth-child(3) {
+    left: min(calc(16em + 20px), calc(28vw + 52px));
+}
+
+table#table-points thead td div.ratio {
 	text-align: right;
 	font-style: italic;
 	font-weight: normal;
 }
-table#table-points thead th div.ratio::after {
+table#table-points thead td div.ratio::after {
 	content: "%";
+}
+
+.student-id,
+.student-name,
+#table-heading th.indicator-heading {
+    background-color: rgb(188, 232, 241);
+    font-weight: bold;
+}
+
+#table-heading th.indicator-heading {
+    filter: brightness(85%);
 }
 
 div.dt-note {

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -104,6 +104,7 @@
         MAX_PTS: 7
     }
 
+    const percentOfTotalTooltip = "The percentage indicates the distribution of the total."
     /**
      * A look-up table of summary rows available for the user to select
      *
@@ -116,36 +117,55 @@
     const summaries = {
         [sv.TOTAL_SUBS]: {
             TITLE: "Total submissions",
+            TOOLTIP: "Total number of submissions. Calculates all student submission counts together.",
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip,
             ROW: 0,
             INITVAL: 0
         },
         [sv.AVG_SUBS_PER_STUD]: {
             TITLE: "Average submissions per student with submissions",
+            TOOLTIP: (
+                "How many submissions a single student has used on the assignment or group of assignments on average. " +
+                "Only accounts for students with one or more submissions."
+            ),
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip, // should be replaced if the percentage calculation is changed
             ROW: 1,
             INITVAL: 0
         },
         [sv.MAX_SUBS]: {
             TITLE: "Maximum submissions",
+            TOOLTIP: "Maximum number of available submissions for the assignment or group of assignments.",
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip,
             ROW: 2,
             INITVAL: 0
         },
         [sv.STUDS_WITH_SUBS]: {
             TITLE: "Students with submissions",
+            TOOLTIP: "Number of students that have one or more assignment submissions.",
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip, // should be replaced if the percentage calculation is changed
             ROW: 3,
             INITVAL: []
         },
         [sv.STUDS_WITH_MAX_POINTS]: {
             TITLE: "Students with max points",
+            TOOLTIP: "Number of students that have received maximum points from the assignment or group of assignments.",
             ROW: 4,
             INITVAL: ['no_ex']
         },
         [sv.AVG_PTS_PER_STUD]: {
             TITLE: "Average points per student with submissions",
+            TOOLTIP: (
+                "Average points received for the assignment or group of assignments. " +
+                "Only accounts for students with one or more submissions."
+            ),
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip, // should be replaced if the percentage calculation is changed
             ROW: 5,
             INITVAL: 0
         },
         [sv.MAX_PTS]: {
             TITLE: "Maximum points",
+            TOOLTIP: "Maximum points for the assignment or group of assignments.",
+            PERCENTAGE_TOOLTIP: percentOfTotalTooltip,
             ROW: 6,
             INITVAL: 0
         },
@@ -296,7 +316,7 @@
      * based on which summary items are selected via checkboxes
      */
     function recreateSummaryRows() {
-        let rowStart = '<tr class="summaryitem"><th class="stick-on-scroll indicator-heading" colspan="3">';
+        let rowStart = '<tr class="summaryitem">';
         let rowEnd = '</tr>';
         var tableheading = $('thead#table-heading');
         var newHeading = '';
@@ -304,11 +324,26 @@
 
         for(var i in _activeSummaryItems) {
             let cells = '';
+
             /**
              * TODO: This indexing is somewhat hacky, but at least at this time the sv enum
              * (1,2,3,..) is just off by one from summary row numbering (0,1,2,...)
              */
             let item = parseInt(_activeSummaryItems[i]) + 1;
+
+            let header = (
+                '<th class="stick-on-scroll indicator-heading" colspan="3" ' +
+                'data-toggle="tooltip" data-container="body" title="' +
+                _(summaries[item]['TOOLTIP']) +
+                (summaries[item]['PERCENTAGE_TOOLTIP']
+                    ? '\n' + _(summaries[item]['PERCENTAGE_TOOLTIP'])
+                    : ''
+                ) +
+                '">' +
+                _(summaries[item]['TITLE']) +
+                '</th>'
+            );
+
             var cols = dtVar.columns('.' + dmRev[_displayMode]);
 
             for(var d in cols[0]) {
@@ -319,7 +354,7 @@
                     }
                 }
             }
-            newHeading += (rowStart + _(summaries[item]['TITLE']) + '</td><td></td><td></td><td>' + summArray[item][TOTAL_COL_ID] + '</td>' + cells + rowEnd);
+            newHeading += (rowStart + header + '</td><td></td><td></td><td>' + summArray[item][TOTAL_COL_ID] + '</td>' + cells + rowEnd);
         }
         // Append all summary rows' html at once for better performance
         tableheading.append($(newHeading));

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -241,36 +241,6 @@
     var recalculateTableDebounced = debounce(bigColumnSearch, 500);
 
     /**
-     * Also debounce the update of table headers y position for sticky scrolling
-     * when doing a page resize.
-     */
-    var refreshTableYPositionDebounced = debounce(refreshTableYPosition, 500);
-
-    /**
-     * Gets initial y position for rendered table header (and updates it when window width changes)
-     * TODO: Header row sticks to <menu height> px too low when mobile menu is open
-     */
-    function refreshTableYPosition() {
-        // Need to scroll to top first so we get correct coordinates
-        window.scroll(0,0);
-        initialTableYOffset = document.getElementById('table-heading').getBoundingClientRect();
-
-        // Detach previous scroll event handler with old values
-        $(window).off('scroll');
-
-        /**
-         * Make the headers stick when scrolling page (TODO: find a less hacky method)
-         */
-        $(window).scroll(function(ev) {
-            if(pageYOffset > initialTableYOffset.top) {
-                $('thead#table-heading th').css('transform', 'translateY(' + (this.pageYOffset - initialTableYOffset.top) +  'px)');
-            } else {
-                $('thead#table-heading th').css('transform', 'translateY(0px)');
-            }
-        });
-    }
-
-    /**
      * Clears all search fields in column headers and DataTables internals
      */
     function clearSearch() {
@@ -326,7 +296,7 @@
      * based on which summary items are selected via checkboxes
      */
     function recreateSummaryRows() {
-        let rowStart = '<tr class="summaryitem"><th class="student-id stick-on-scroll indicator-heading" colspan="3" style="transform: translateX(0px);">';
+        let rowStart = '<tr class="summaryitem"><th class="stick-on-scroll indicator-heading" colspan="3">';
         let rowEnd = '</tr>';
         var tableheading = $('thead#table-heading');
         var newHeading = '';
@@ -345,11 +315,11 @@
                 if(summArray[item] !== undefined) {
                     // Only add cell if the column is currently visible
                     if(dtVar.columns(cols[0][d]).visible()[0]) {
-                        cells += '<th>' + summArray[item][cols.indexes()[d]] + '</th>';
+                        cells += '<td>' + summArray[item][cols.indexes()[d]] + '</td>';
                     }
                 }
             }
-            newHeading += (rowStart + _(summaries[item]['TITLE']) + '</td><th></th><th>' + summArray[item][TOTAL_COL_ID] + '</th>' + cells + rowEnd);
+            newHeading += (rowStart + _(summaries[item]['TITLE']) + '</td><td></td><td></td><td>' + summArray[item][TOTAL_COL_ID] + '</td>' + cells + rowEnd);
         }
         // Append all summary rows' html at once for better performance
         tableheading.append($(newHeading));
@@ -907,7 +877,7 @@
 
         // Force table width to match the currently visible columns
         // see https://stackoverflow.com/questions/5109831/how-to-resize-a-jquery-datatable-after-hiding-columns
-        pointsTableRef.width("100%");
+        pointsTableRef.width("99%");
 
         // Finally redraw table
         dtVar.draw();
@@ -988,7 +958,7 @@
         // dynamically generated columns, as these may no longer give correct results
         clearPointsSearch();
         // Nothing much here, just refresh the table
-        pointsTableRef.width('100%');
+        pointsTableRef.width('99%');
         recalculateTable();
     }
 
@@ -1120,7 +1090,7 @@
     function showSisuColumns(dtVar, sisumode) {
         dtVar.columns('.sisu-only').visible(sisumode);
         // force table to have correct width after column visibility changes
-        pointsTableRef.width("100%");
+        pointsTableRef.width("99%");
     }
 
     /**
@@ -1175,7 +1145,7 @@
                 {data: "Email", title: "Email", class: "always-hidden col-1", type: "string", searchable: true},
                 {data: "LastName", title: _("Last name"), class: "student-name stick-on-scroll col-2", type: "html", render: renderParticipantLink},
                 {data: "FirstName", title: _("First name"), class: "student-name stick-on-scroll col-3", type: "html", render: renderParticipantLink},
-                {data: "StudentID", title: _("Student ID"), type: "string", width: "6em", class: "student-id stick-on-scroll col-4", render: renderParticipantLink},
+                {data: "StudentID", title: _("Student ID"), type: "string", class: "student-id stick-on-scroll col-4", render: renderParticipantLink},
                 {data: "Grade", title: _("Grade"), class: "sisu-only col-5", type: "string", defaultContent: ""},
                 {data: "Credits", title: _("Credits"), class: "sisu-only col-6", type: "string", defaultContent: ""},
                 {data: "AssessmentDate", title: _("Assessment date"), class: "sisu-only col-7", type: "string", defaultContent: ""},
@@ -1184,7 +1154,7 @@
                 {data: "Organization", title: _("Organization"), class: "col-10", type: "string"},
                 {data: "Tags", title: _("Tags"), class: "tags col-11", render: function(data) { return userTagsToHTML(data); }, type: "html" },
                 {data: "Count", title: "Count", class: "col-12", visible: false, defaultContent: 0, type: "num"},
-                {data: "Total", title: _("Total"), width: "6em", class: "points total col-13", defaultContent: 0, type: "num"}
+                {data: "Total", title: _("Total"), class: "points total col-13", defaultContent: 0, type: "num"}
             ];
 
             // Store exercises globally
@@ -1392,7 +1362,7 @@
                  */
                 dom: "<'row'<'col-md-4 col-sm-6'l><'col-md-4 col-sm-6'B><'col-md-4 col-sm-12'f>>" +
                         "<'row'<'col-sm-6'i><'col-sm-6 dt-note'>>" +
-                        "<'row'<'col-sm-12'tr>>" +
+                        "<'row'<'#table-points-div.col-sm-12'tr>>" +
                         "<'row'<'col-sm-5'i><'col-sm-7'p>>",
                 /**
                  * Data export buttons
@@ -1470,18 +1440,6 @@
             // Save the jQuery DOM instance for later
             multiSelectSelector = $(".multiselect-container");
 
-            // Make the first columns stick when scrolling table
-            $('#table-points-div').scroll(function(ev) {
-                $('#table-points .stick-on-scroll').css('transform', 'translateX(' + this.scrollLeft + 'px)');
-            });
-            /**
-             * Need new table top coordinate when window resized and elements possibly moved.
-             * This is debounced for more responsive UI while scaling.
-             */
-            $( window ).resize(function() {
-                refreshTableYPositionDebounced();
-            });
-
             /**
              * Event handlers for (de)selecting all summary rows at once
              */
@@ -1556,10 +1514,6 @@
                 }
                 searchForSelectedTags();
             });
-
-            // Initialize data table position for fixing top header (see TODO)
-            // moved to the end of this function as it takes less time that way
-            refreshTableYPosition();
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
             console.error("Loading student data failed.");

--- a/exercise/templates/exercise/staff/results.html
+++ b/exercise/templates/exercise/staff/results.html
@@ -177,7 +177,7 @@
 		</ul>
 
 		<!--Data table-->
-		<div id="table-points-div" class="table-responsive" role="tabpanel" style="padding: 20px 0px 0px 0px;">
+		<div class="table-responsive" role="tabpanel" style="padding: 20px 0px 0px 0px;">
 			<table id="table-points" class="table table-striped table-bordered table-condensed">
 				<thead id="table-heading">
 				</thead>


### PR DESCRIPTION
# Description

**What?**

Fix scrolling and layout issues (e.g. width of sticky columns) on All results page (scrolling and sticky columns don't work perfectly on small screens, but proved too difficult to fix).
Also show tooltips on summary row headers to improve ease of use. Also updated tooltip texts in the JSON-file to use the term "assignment" rather than "exercise", which will be soon changed elsewhere as well. Tooltips on row headers probably don't work on mobile devices.

**Why?**

Previously when scrolling, cells overlapped strangely and sticky cells didn't behave as wanted.

**How?**

CSS-styling; Bootstrap tooltips

Fixes #832
Fixes #845 (duplicate)


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested scrolling vertically and horizontally with different screen sizes. And tested that tooltips work on hover on a PC.
All points page is not very accessible, it has many contrast errors, problems with labels, etc. and these accessibility errors are not fixed in this PR.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
However, the indentation in the JS-file used indentation of 4 spaces, which is why I kept that.

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*