### PR TITLE
Add customizable environment variable setting prefix

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -431,8 +431,11 @@ from r_django_essentials.conf import *
 update_settings_with_file(__name__,
                           environ.get('APLUS_LOCAL_SETTINGS', 'local_settings'),
                           quiet='APLUS_LOCAL_SETTINGS' in environ)
+
 update_settings_from_environment(__name__, 'DJANGO_') # FIXME: deprecated. was used with containers before, so keep it here for now.
-update_settings_from_environment(__name__, 'APLUS_')
+# Load settings from environment variables starting with ENV_SETTINGS_PREFIX (default APLUS_)
+ENV_SETTINGS_PREFIX = environ.get('ENV_SETTINGS_PREFIX', 'APLUS_')
+update_settings_from_environment(__name__, ENV_SETTINGS_PREFIX)
 update_secret_from_file(__name__, environ.get('APLUS_SECRET_KEY_FILE', 'secret_key'))
 
 # Complain if BASE_URL is not set


### PR DESCRIPTION
# Description

**What?**

Add possibility of changing the environment variable prefix from which Django settings are read.

**Why?**

In a Kubernetes environment, k8s-injected environment variables may unintendedly be parsed as settings. Being able to change the default APLUS_ prefix into something else helps, while preserving the ability of changing settings via environment variables.

**How?**

In `settings.py`, read ENV_SETTINGS_PREFIX environment variable to use as a filter for settings to be set from environment. As an example, with environment variables

```
ENV_SETTINGS_PREFIX="TESTING_"
TESTING_DEBUG=False
```

the Django DEBUG setting would be set to `False`.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.