### PR TITLE
Display deviations in student UI

### DIFF
--- a/deviations/tests.py
+++ b/deviations/tests.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from course.models import Course, CourseInstance, CourseModule, \
     LearningObjectCategory
 from deviations.models import DeadlineRuleDeviation
-from exercise.exercise_models import ExerciseWithAttachment
+from exercise.models import ExerciseWithAttachment, Submission
 from userprofile.models import User
 
 
@@ -16,10 +16,14 @@ class DeviationsTest(TestCase):
         self.user.set_password("testPassword")
         self.user.save()
 
+        self.user_2 = User(username="testUser2", first_name="First2", last_name="Last2")
+        self.user_2.set_password("testPassword2")
+        self.user_2.save()
+
         self.course = Course.objects.create(
             name="test course",
             code="123456",
-            url="Course-Url"
+            url="Course-Url",
         )
 
         self.today = timezone.now()
@@ -31,7 +35,7 @@ class DeviationsTest(TestCase):
             starting_time=self.today,
             ending_time=self.tomorrow,
             course=self.course,
-            url="T-00.1000_d1"
+            url="T-00.1000_d1",
         )
 
         self.course_module = CourseModule.objects.create(
@@ -40,13 +44,13 @@ class DeviationsTest(TestCase):
             points_to_pass=15,
             course_instance=self.course_instance,
             opening_time=self.today,
-            closing_time=self.tomorrow
+            closing_time=self.tomorrow,
         )
 
         self.learning_object_category = LearningObjectCategory.objects.create(
             name="test category",
             course_instance=self.course_instance,
-            points_to_pass=5
+            points_to_pass=5,
         )
 
         self.exercise_with_attachment = ExerciseWithAttachment.objects.create(
@@ -55,25 +59,127 @@ class DeviationsTest(TestCase):
             category=self.learning_object_category,
             max_points=50,
             points_to_pass=50,
-            max_submissions=0,
+            max_submissions=1,
             files_to_submit="test1.txt|test2.txt|img.png",
-            content="test_instructions"
+            content="test_instructions",
         )
 
-        self.deadline_rule_deviation = DeadlineRuleDeviation.objects.create(
+        self.exercise_with_attachment_2 = ExerciseWithAttachment.objects.create(
+            name="test exercise 4",
+            course_module=self.course_module,
+            category=self.learning_object_category,
+            max_points=50,
+            points_to_pass=50,
+            max_submissions=1,
+            files_to_submit="test1.txt|test2.txt|img.png",
+            content="test_instructions",
+        )
+
+        self.deadline_rule_deviation_u1_e1 = DeadlineRuleDeviation.objects.create(
             exercise=self.exercise_with_attachment,
             submitter=self.user.userprofile,
-            extra_minutes=1440  # One day
+            extra_minutes=1440, # One day
+        )
+
+        self.deadline_rule_deviation_u1_e2 = DeadlineRuleDeviation.objects.create(
+            exercise=self.exercise_with_attachment_2,
+            submitter=self.user.userprofile,
+            extra_minutes=2880, # Two days
+        )
+
+        self.deadline_rule_deviation_u2_e1 = DeadlineRuleDeviation.objects.create(
+            exercise=self.exercise_with_attachment,
+            submitter=self.user_2.userprofile,
+            extra_minutes=4320, # Three days
         )
 
     def test_deadline_rule_deviation_extra_time(self):
-        self.assertEqual(timedelta(days=1), self.deadline_rule_deviation.get_extra_time())
+        self.assertEqual(timedelta(days=1), self.deadline_rule_deviation_u1_e1.get_extra_time())
 
     def test_deadline_rule_deviation_new_deadline(self):
-        self.assertEqual(self.two_days_from_now, self.deadline_rule_deviation.get_new_deadline())
+        self.assertEqual(self.two_days_from_now, self.deadline_rule_deviation_u1_e1.get_new_deadline())
 
     def test_deadline_rule_deviation_new_deadline_with_normal_deadline(self):
-        self.assertEqual(self.tomorrow, self.deadline_rule_deviation.get_new_deadline(self.today))
+        self.assertEqual(self.tomorrow, self.deadline_rule_deviation_u1_e1.get_new_deadline(self.today))
 
     def test_deadline_rule_deviation_normal_deadline(self):
-        self.assertEqual(self.tomorrow, self.deadline_rule_deviation.get_normal_deadline())
+        self.assertEqual(self.tomorrow, self.deadline_rule_deviation_u1_e1.get_normal_deadline())
+
+    def test_get_max_deviations(self):
+        # Test that the get_max_deviations method returns the correct deviation
+        # when one exercise is passed into the method.
+
+        deviation = DeadlineRuleDeviation.objects.get_max_deviation(
+            self.user.userprofile,
+            self.exercise_with_attachment,
+        )
+        self.assertIsNotNone(deviation)
+        self.assertEqual(deviation.exercise.id, self.exercise_with_attachment.id)
+        self.assertEqual(deviation.extra_minutes, 1440)
+
+        deviation = DeadlineRuleDeviation.objects.get_max_deviation(
+            self.user_2.userprofile,
+            self.exercise_with_attachment,
+        )
+        self.assertIsNotNone(deviation)
+        self.assertEqual(deviation.exercise.id, self.exercise_with_attachment.id)
+        self.assertEqual(deviation.extra_minutes, 4320)
+
+    def test_get_max_deviations_multiple(self):
+        # Test that the get_max_deviations method returns the correct deviation
+        # when multiple exercises are passed into the method.
+
+        deviations = DeadlineRuleDeviation.objects.get_max_deviations(
+            self.user.userprofile,
+            [self.exercise_with_attachment, self.exercise_with_attachment_2],
+        )
+        counter = 0
+        for deviation in deviations:
+            counter += 1
+            if deviation.exercise.id == self.exercise_with_attachment.id:
+                self.assertEqual(deviation.extra_minutes, 1440)
+            elif deviation.exercise.id == self.exercise_with_attachment_2.id:
+                self.assertEqual(deviation.extra_minutes, 2880)
+            else:
+                raise self.failureException('Unexpected exercise returned')
+        self.assertEqual(counter, 2)
+
+        deviations = DeadlineRuleDeviation.objects.get_max_deviations(
+            self.user_2.userprofile,
+            [self.exercise_with_attachment, self.exercise_with_attachment_2],
+        )
+        counter = 0
+        for deviation in deviations:
+            counter += 1
+            if deviation.exercise.id == self.exercise_with_attachment.id:
+                self.assertEqual(deviation.extra_minutes, 4320)
+            else:
+                raise self.failureException('Unexpected exercise returned')
+        self.assertEqual(counter, 1)
+
+    def test_get_max_deviations_group(self):
+        # Test that the get_max_deviations method returns the correct deviation
+        # when there is a group submission with both users. In this case,
+        # user 2's deviation should also be returned for user 1.
+
+        submission = Submission.objects.create(
+            exercise=self.exercise_with_attachment,
+            status=Submission.STATUS.READY,
+        )
+        submission.submitters.add(self.user.userprofile, self.user_2.userprofile)
+
+        deviation = DeadlineRuleDeviation.objects.get_max_deviation(
+            self.user.userprofile,
+            self.exercise_with_attachment,
+        )
+        self.assertIsNotNone(deviation)
+        self.assertEqual(deviation.exercise.id, self.exercise_with_attachment.id)
+        self.assertEqual(deviation.extra_minutes, 4320)
+
+        deviation = DeadlineRuleDeviation.objects.get_max_deviation(
+            self.user_2.userprofile,
+            self.exercise_with_attachment,
+        )
+        self.assertIsNotNone(deviation)
+        self.assertEqual(deviation.exercise.id, self.exercise_with_attachment.id)
+        self.assertEqual(deviation.extra_minutes, 4320)

--- a/exercise/templates/exercise/_exercise_info.html
+++ b/exercise/templates/exercise/_exercise_info.html
@@ -41,7 +41,7 @@
             <dd class="exercise-info-submissions">
             	{{ summary.get_submission_count }}
             	{% if exercise.max_submissions %}
-            	/ {{ exercise|max_submissions:profile }}
+            	/ {{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}
             	{% endif %}
             </dd>
 
@@ -52,6 +52,16 @@
 
             <dt>{% translate "DEADLINE" %}</dt>
             <dd class="exercise-info-deadline">{{ exercise.course_module.closing_time }}</dd>
+
+						{% if cached_points.personal_deadline %}
+						<dt>{% translate "EXTENDED_DEADLINE" %}</dt>
+						<dd class="exercise-info-extended-deadline">
+							{{ cached_points.personal_deadline }}
+							{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}
+                (-{{ exercise.course_module.late_submission_penalty|percent }}%)
+              {% endif %}
+						</dd>
+						{% endif %}
 
             {% if exercise.course_module.late_submissions_allowed %}
             <dt>{% translate "LATE_SUBMISSION_DEADLINE" %}</dt>

--- a/exercise/templates/exercise/_exercise_info.html
+++ b/exercise/templates/exercise/_exercise_info.html
@@ -3,84 +3,84 @@
 {% load exercise %}
 
 <div class="well">
-    {% if exercise.category.confirm_the_level %}
-    <p>{% translate "CURRENT_STATUS" %}</p>
-    <p class="exercise-info-points">
-      {% points_badge summary %}
-    </p>
-    {% else %}
-    <p>{% translate "EARNED_POINTS" %}</p>
-    <p><strong class="h2 exercise-info-points">
-        {% format_points summary.get_points feedback_revealed False %}
-        <small>
-            / {{ exercise.max_points }}
-            {% if summary.get_penalty %}
-            <span class="badge">
-                {% translate "LATE" %} -{{ summary.get_penalty|percent }} %
-            </span>
-            {% endif %}
-        </small>
-    </strong></p>
-    {% points_progress summary %}
-    {% endif %}
+	{% if exercise.category.confirm_the_level %}
+	<p>{% translate "CURRENT_STATUS" %}</p>
+	<p class="exercise-info-points">
+		{% points_badge summary %}
+	</p>
+	{% else %}
+	<p>{% translate "EARNED_POINTS" %}</p>
+	<p><strong class="h2 exercise-info-points">
+		{% format_points summary.get_points feedback_revealed False %}
+		<small>
+			/ {{ exercise.max_points }}
+			{% if summary.get_penalty %}
+			<span class="badge">
+				{% translate "LATE" %} -{{ summary.get_penalty|percent }} %
+			</span>
+			{% endif %}
+		</small>
+	</strong></p>
+	{% points_progress summary %}
+	{% endif %}
 </div>
 
 <div class="panel panel-primary">
-    <div class="panel-heading">
-        <h4 class="panel-title">{% translate "EXERCISE_INFO" %}</h4>
-    </div>
-    <div class="panel-body">
-        <dl>
-            {% if exercise.category.status != "hidden" %}
-              <dt>{% translate "EXERCISE_CATEGORY" %}</dt>
-              <dd class="exercise-info-category">
-              	{{ exercise.category|parse_localization }}
-              </dd>
-            {% endif %}
-            <dt>{% translate "YOUR_SUBMISSIONS" %}</dt>
-            <dd class="exercise-info-submissions">
-            	{{ summary.get_submission_count }}
-            	{% if exercise.max_submissions %}
-            	/ {{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}
-            	{% endif %}
-            </dd>
+	<div class="panel-heading">
+			<h4 class="panel-title">{% translate "EXERCISE_INFO" %}</h4>
+	</div>
+	<div class="panel-body">
+		<dl>
+			{% if exercise.category.status != "hidden" %}
+				<dt>{% translate "EXERCISE_CATEGORY" %}</dt>
+				<dd class="exercise-info-category">
+					{{ exercise.category|parse_localization }}
+				</dd>
+			{% endif %}
+			<dt>{% translate "YOUR_SUBMISSIONS" %}</dt>
+			<dd class="exercise-info-submissions">
+				{{ summary.get_submission_count }}
+				{% if exercise.max_submissions %}
+				/ {{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}
+				{% endif %}
+			</dd>
 
-            {% if exercise.points_to_pass > 0 %}
-            <dt>{% translate "POINTS_REQUIRED_TO_PASS" %}</dt>
-            <dd class="exercise-info-required-points">{{ exercise.points_to_pass }}</dd>
-            {% endif %}
+			{% if exercise.points_to_pass > 0 %}
+			<dt>{% translate "POINTS_REQUIRED_TO_PASS" %}</dt>
+			<dd class="exercise-info-required-points">{{ exercise.points_to_pass }}</dd>
+			{% endif %}
 
-            <dt>{% translate "DEADLINE" %}</dt>
-            <dd class="exercise-info-deadline">{{ exercise.course_module.closing_time }}</dd>
+			<dt>{% translate "DEADLINE" %}</dt>
+			<dd class="exercise-info-deadline">{{ exercise.course_module.closing_time }}</dd>
 
-						{% if cached_points.personal_deadline %}
-						<dt>{% translate "EXTENDED_DEADLINE" %}</dt>
-						<dd class="exercise-info-extended-deadline">
-							{{ cached_points.personal_deadline }}
-							{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}
-                (-{{ exercise.course_module.late_submission_penalty|percent }}%)
-              {% endif %}
-						</dd>
-						{% endif %}
+			{% if cached_points.personal_deadline %}
+			<dt>{% translate "EXTENDED_DEADLINE" %}</dt>
+			<dd class="exercise-info-extended-deadline">
+				{{ cached_points.personal_deadline }}
+				{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}
+					(-{{ exercise.course_module.late_submission_penalty|percent }}%)
+				{% endif %}
+			</dd>
+			{% endif %}
 
-            {% if exercise.course_module.late_submissions_allowed %}
-            <dt>{% translate "LATE_SUBMISSION_DEADLINE" %}</dt>
-            <dd class="exercise-info-late-deadline">
-              {{ exercise.course_module.late_submission_deadline }}
-              {% if module.late_submission_penalty > 0 %}
-                (-{{ exercise.course_module.late_submission_penalty|percent }}%)
-              {% endif %}
-            </dd>
-            {% endif %}
+			{% if exercise.course_module.late_submissions_allowed %}
+			<dt>{% translate "LATE_SUBMISSION_DEADLINE" %}</dt>
+			<dd class="exercise-info-late-deadline">
+				{{ exercise.course_module.late_submission_deadline }}
+				{% if module.late_submission_penalty > 0 %}
+					(-{{ exercise.course_module.late_submission_penalty|percent }}%)
+				{% endif %}
+			</dd>
+			{% endif %}
 
-            {% if exercise.max_group_size > 1 %}
-            <dt>{% translate "GROUP_SIZE" %}</dt>
-            <dd class="exercise-info-group">{{ exercise.min_group_size }}{% if exercise.max_group_size > exercise.min_group_size %}-{{ exercise.max_group_size }}{% endif %}</dd>
-            {% endif %}
+			{% if exercise.max_group_size > 1 %}
+			<dt>{% translate "GROUP_SIZE" %}</dt>
+			<dd class="exercise-info-group">{{ exercise.min_group_size }}{% if exercise.max_group_size > exercise.min_group_size %}-{{ exercise.max_group_size }}{% endif %}</dd>
+			{% endif %}
 
-            <dt>{% translate "TOTAL_NUMBER_OF_SUBMITTERS" %}</dt>
-            <dd class="exercise-info-submitters">{{ exercise.get_total_submitter_count }}</dd>
+			<dt>{% translate "TOTAL_NUMBER_OF_SUBMITTERS" %}</dt>
+			<dd class="exercise-info-submitters">{{ exercise.get_total_submitter_count }}</dd>
 
-        </dl>
-    </div>
+		</dl>
+	</div>
 </div>

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -4,15 +4,15 @@
 
 {% if categories|len_listed > 1 %}
 <p class="filter-categories">
-  <small>{% translate "FILTER_VIEW" %}:</small>
-  {% for entry in categories %}
-  {% if entry|is_listed %}
-  <button class="aplus-button--secondary aplus-button--xs" data-category="{{ entry.id }}">
-    <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
-    {{ entry.name|parse_localization }}
-  </button>
-  {% endif %}
-  {% endfor %}
+	<small>{% translate "FILTER_VIEW" %}:</small>
+	{% for entry in categories %}
+	{% if entry|is_listed %}
+	<button class="aplus-button--secondary aplus-button--xs" data-category="{{ entry.id }}">
+		<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+		{{ entry.name|parse_localization }}
+	</button>
+	{% endif %}
+	{% endfor %}
 </p>
 {% endif %}
 
@@ -29,170 +29,170 @@
 {% module_accessible module as accessible %}
 {% exercise_accessible module as exercise_accessible %}
 <div class="panel panel-primary module-panel{% if not open and after_open %} module-expired{% endif %}">
-  <a class="panel-heading{% if not accessible or not open and after_open %} collapsed{% endif %}"
-    role="button" href="#module{{ module.id }}" data-toggle="collapse"
-    aria-expanded="{% if accessible and not after_open or open %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
-    <h3 class="panel-title">
-      {% points_badge module "pull-right" %}
-      {% if not accessible %}
-      <span class="badge pull-right">
-        {% translate "OPENS ON" %} {{ module.opening_time }}
-      </span>
-      {% elif not after_open %}
-      <span class="badge pull-right">
-        {% translate "EXERCISES_OPEN_ON" %} {{ module.opening_time }}
-      </span>
-      <span class="badge badge-info pull-right">
-        {% translate "OPEN_FOR_READING" %}
-      </span>
-      {% endif %}
-      {% if module.requirements|length > 0 %}
-      <span class="badge pull-right">
-        {% translate "REQUIRES" %}:
-        {% for requirement in module.requirements %}{{ requirement }}{% endfor %}
-      </span>
-      {% endif %}
-      <span class="caret" aria-hidden="true"></span>
-      {{ module.name|parse_localization }}
-    </h3>
-  </a>
-  <div class="collapse{% if accessible and not after_open or open %} in{% endif %}" id="module{{ module.id }}">
-  <div class="panel-body">
-    <p>
-      {{ module.opening_time }} &ndash; {{ module.closing_time }}
+	<a class="panel-heading{% if not accessible or not open and after_open %} collapsed{% endif %}"
+		role="button" href="#module{{ module.id }}" data-toggle="collapse"
+		aria-expanded="{% if accessible and not after_open or open %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
+		<h3 class="panel-title">
+			{% points_badge module "pull-right" %}
+			{% if not accessible %}
+			<span class="badge pull-right">
+				{% translate "OPENS ON" %} {{ module.opening_time }}
+			</span>
+			{% elif not after_open %}
+			<span class="badge pull-right">
+				{% translate "EXERCISES_OPEN_ON" %} {{ module.opening_time }}
+			</span>
+			<span class="badge badge-info pull-right">
+				{% translate "OPEN_FOR_READING" %}
+			</span>
+			{% endif %}
+			{% if module.requirements|length > 0 %}
+			<span class="badge pull-right">
+				{% translate "REQUIRES" %}:
+				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
+			</span>
+			{% endif %}
+			<span class="caret" aria-hidden="true"></span>
+			{{ module.name|parse_localization }}
+		</h3>
+	</a>
+	<div class="collapse{% if accessible and not after_open or open %} in{% endif %}" id="module{{ module.id }}">
+	<div class="panel-body">
+		<p>
+			{{ module.opening_time }} &ndash; {{ module.closing_time }}
 
-      {% if module.late_allowed and module.late_percent > 0 %}
-      <br />
-      <em>
-        {% blocktranslate trimmed with deadline=module.late_time|date:"DATETIME_FORMAT" %}
-          LATE_SUBMISSIONS_ALLOWED_UNTIL -- {{ deadline }}
-        {% endblocktranslate %}
-        {% if module.late_percent != 100 %}
-          {% blocktranslate trimmed with percent=module.late_percent %}
-            LATE_SUBMISSION_POINTS_WORTH -- {{ percent }}
-          {% endblocktranslate %}
-        {% endif %}
-      </em>
-      {% endif %}
+			{% if module.late_allowed and module.late_percent > 0 %}
+			<br />
+			<em>
+				{% blocktranslate trimmed with deadline=module.late_time|date:"DATETIME_FORMAT" %}
+					LATE_SUBMISSIONS_ALLOWED_UNTIL -- {{ deadline }}
+				{% endblocktranslate %}
+				{% if module.late_percent != 100 %}
+					{% blocktranslate trimmed with percent=module.late_percent %}
+						LATE_SUBMISSION_POINTS_WORTH -- {{ percent }}
+					{% endblocktranslate %}
+				{% endif %}
+			</em>
+			{% endif %}
 
-      {% if module.points_to_pass > 0 %}
-        <br />
-        {% blocktranslate trimmed with points=module.points_to_pass %}
-          POINTS_REQUIRED_TO_PASS_MODULE -- {{ points }}
-        {% endblocktranslate %}
-      {% endif %}
-    </p>
+			{% if module.points_to_pass > 0 %}
+				<br />
+				{% blocktranslate trimmed with points=module.points_to_pass %}
+					POINTS_REQUIRED_TO_PASS_MODULE -- {{ points }}
+				{% endblocktranslate %}
+			{% endif %}
+		</p>
 
-    {% points_progress module %}
-    {{ module.introduction|safe }}
-  </div>
-  {% if not exercise_accessible and not is_course_staff %}
-  <div class="alert alert-warning clearfix site-message">
-    {% translate "CHANGES_ARE_POSSIBLE_IN_EXERCISES_BEFORE_MODULE_OPENING" %}
-  </div>
-  {% endif %}
-  {% if module.children|length > 0 %}
-  <table class="table table-striped table-condensed results-table">
-    <tbody>
-      <tr class="category-row">
-        <th>{% translate "EXERCISE" %}</th>
-        <th>{% translate "CATEGORY_capitalized" %}</th>
-        <th>{% translate "SUBMISSIONS" %}</th>
-        <th>{% translate "POINTS" %}</th>
-        {% if is_course_staff %}
-        <th>{% translate "COURSE_STAFF" %}</th>
-        {% endif %}
-      </tr>
-      {% for entry in module.flatted %}
+		{% points_progress module %}
+		{{ module.introduction|safe }}
+	</div>
+	{% if not exercise_accessible and not is_course_staff %}
+	<div class="alert alert-warning clearfix site-message">
+		{% translate "CHANGES_ARE_POSSIBLE_IN_EXERCISES_BEFORE_MODULE_OPENING" %}
+	</div>
+	{% endif %}
+	{% if module.children|length > 0 %}
+	<table class="table table-striped table-condensed results-table">
+		<tbody>
+			<tr class="category-row">
+				<th>{% translate "EXERCISE" %}</th>
+				<th>{% translate "CATEGORY_capitalized" %}</th>
+				<th>{% translate "SUBMISSIONS" %}</th>
+				<th>{% translate "POINTS" %}</th>
+				{% if is_course_staff %}
+				<th>{% translate "COURSE_STAFF" %}</th>
+				{% endif %}
+			</tr>
+			{% for entry in module.flatted %}
 
-      {% if entry.submittable and entry|is_visible %}
-      <tr data-category="{{ entry.category_id }}">
-        <td>
-          {% if exercise_accessible or is_course_staff %}
-          <a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a>
-          {% else %}
-          {{ entry.name|parse_localization }}
-          {% endif %}
-        </td>
-        <td>
-          <small>{{ entry.category|parse_localization }}</small>
-        </td>
-        <td class="submissions-dropdown dropdown">
-          <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button">
-            <span class="badge">
-              {% if entry.notified %}
-              <span class="glyphicon glyphicon-comment{% if entry.unseen %} red{% endif %}"></span>
-              {% endif %}
-              {{ entry.submission_count }}
-              {% if entry.max_submissions > 0 %}
-              / {{ entry.personal_max_submissions|default_if_none:entry.max_submissions }}
-              {% endif %}
-            </span><b class="caret"></b>
-          </a>
-          <ul class="dropdown-menu">
-            {% for submission in entry.submissions %}
-            <li>
-              <a href="{{ submission.url }}" class="page-modal">
-                {{ forloop.revcounter }}.
-                {{ submission.date }}
-                {% points_badge submission %}
-              </a>
-            </li>
-            {% empty %}
-            <li>
-              <a href="#" class="page-modal">{% translate "NO_SUBMISSIONS_YET" %}</a>
-            </li>
-            {% endfor %}
-          </ul>
-        </td>
-        <td>
-          {% points_badge entry %}
-        </td>
-        {% if is_course_staff %}
-        <td>
-          {% if not accessible %}
-          <a href="{{ entry.link }}">
-            <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
-            {% translate "EARLY_ACCESS" %}
-          </a>
-          {% else %}
-          {% exercise_text_stats entry.id %}
-          {% endif %}
-          <a class="aplus-button--secondary aplus-button--xs" role="button" href="{{ entry.submissions_link }}">
-            <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
-            {% translate "VIEW_SUBMISSIONS" %}
-          </a>
-        </td>
-        {% endif %}
-      </tr>
+			{% if entry.submittable and entry|is_visible %}
+			<tr data-category="{{ entry.category_id }}">
+				<td>
+					{% if exercise_accessible or is_course_staff %}
+					<a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a>
+					{% else %}
+					{{ entry.name|parse_localization }}
+					{% endif %}
+				</td>
+				<td>
+					<small>{{ entry.category|parse_localization }}</small>
+				</td>
+				<td class="submissions-dropdown dropdown">
+					<a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button">
+						<span class="badge">
+							{% if entry.notified %}
+							<span class="glyphicon glyphicon-comment{% if entry.unseen %} red{% endif %}"></span>
+							{% endif %}
+							{{ entry.submission_count }}
+							{% if entry.max_submissions > 0 %}
+							/ {{ entry.personal_max_submissions|default_if_none:entry.max_submissions }}
+							{% endif %}
+						</span><b class="caret"></b>
+					</a>
+					<ul class="dropdown-menu">
+						{% for submission in entry.submissions %}
+						<li>
+							<a href="{{ submission.url }}" class="page-modal">
+								{{ forloop.revcounter }}.
+								{{ submission.date }}
+								{% points_badge submission %}
+							</a>
+						</li>
+						{% empty %}
+						<li>
+							<a href="#" class="page-modal">{% translate "NO_SUBMISSIONS_YET" %}</a>
+						</li>
+						{% endfor %}
+					</ul>
+				</td>
+				<td>
+					{% points_badge entry %}
+				</td>
+				{% if is_course_staff %}
+				<td>
+					{% if not accessible %}
+					<a href="{{ entry.link }}">
+						<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+						{% translate "EARLY_ACCESS" %}
+					</a>
+					{% else %}
+					{% exercise_text_stats entry.id %}
+					{% endif %}
+					<a class="aplus-button--secondary aplus-button--xs" role="button" href="{{ entry.submissions_link }}">
+						<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+						{% translate "VIEW_SUBMISSIONS" %}
+					</a>
+				</td>
+				{% endif %}
+			</tr>
 
-      {% elif entry.type == 'exercise' and entry|is_visible %}
-      <tr>
-        <td colspan="4">
-          {% if accessible %}
-          <strong><a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a></strong>
-          {% else %}
-          <strong>{{ entry.name|parse_localization }}</strong>
-          {% endif %}
-        </td>
-        {% if is_course_staff %}
-        <td>
-          {% if not accessible %}
-          <a href="{{ entry.link }}">
-            <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
-            {% translate "EARLY_ACCESS" %}
-          </a>
-          {% endif %}
-        </td>
-        {% endif %}
-      </tr>
-      {% endif %}
+			{% elif entry.type == 'exercise' and entry|is_visible %}
+			<tr>
+				<td colspan="4">
+					{% if accessible %}
+					<strong><a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a></strong>
+					{% else %}
+					<strong>{{ entry.name|parse_localization }}</strong>
+					{% endif %}
+				</td>
+				{% if is_course_staff %}
+				<td>
+					{% if not accessible %}
+					<a href="{{ entry.link }}">
+						<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+						{% translate "EARLY_ACCESS" %}
+					</a>
+					{% endif %}
+				</td>
+				{% endif %}
+			</tr>
+			{% endif %}
 
-      {% endfor %}
-    </tbody>
-  </table>
-  {% endif %}
-  </div>
+			{% endfor %}
+		</tbody>
+	</table>
+	{% endif %}
+	</div>
 </div>
 {% endwith %}
 {% endif %}
@@ -202,38 +202,38 @@
 var aplusPointsTotal = {{ total_json|safe }};
 
 $(function() {
-  var limit = 2;
-  var expired = $(".module-expired");
-  if (expired.length > limit) {
-    expired.slice(0, expired.length - limit).hide();
-    $("#toggle-expired").removeClass("hide")
-    .find("button").on("click", function(event) {
-      event.preventDefault();
-      $(".module-expired:hidden").show();
-      $(this).parent().hide();
-    });
-  }
+	var limit = 2;
+	var expired = $(".module-expired");
+	if (expired.length > limit) {
+		expired.slice(0, expired.length - limit).hide();
+		$("#toggle-expired").removeClass("hide")
+		.find("button").on("click", function(event) {
+			event.preventDefault();
+			$(".module-expired:hidden").show();
+			$(this).parent().hide();
+		});
+	}
 
-  $('.filter-categories button').on("click", function(event) {
-    var button = $(this);
-    var id = button.attr("data-category");
-    if (button.hasClass("active")) {
-      button.removeClass("active")
-      .find("span").removeClass("glyphicon-unchecked").addClass("glyphicon-check");
-      $('.module-panel tr[data-category="' + id + '"]').removeClass("hide");
-    } else {
-      button.addClass("active")
-      .find("span").removeClass("glyphicon-check").addClass("glyphicon-unchecked");
-      $('.module-panel tr[data-category="' + id + '"]').addClass("hide");
-    }
-    $('.module-panel').each(function(index, panel) {
-      var mod = $(panel);
-      if (mod.find("tr:not(.hide)").length > 0) {
-        mod.removeClass("hide");
-      } else {
-        mod.addClass("hide");
-      }
-    });
-  });
+	$('.filter-categories button').on("click", function(event) {
+		var button = $(this);
+		var id = button.attr("data-category");
+		if (button.hasClass("active")) {
+			button.removeClass("active")
+			.find("span").removeClass("glyphicon-unchecked").addClass("glyphicon-check");
+			$('.module-panel tr[data-category="' + id + '"]').removeClass("hide");
+		} else {
+			button.addClass("active")
+			.find("span").removeClass("glyphicon-check").addClass("glyphicon-unchecked");
+			$('.module-panel tr[data-category="' + id + '"]').addClass("hide");
+		}
+		$('.module-panel').each(function(index, panel) {
+			var mod = $(panel);
+			if (mod.find("tr:not(.hide)").length > 0) {
+				mod.removeClass("hide");
+			} else {
+				mod.addClass("hide");
+			}
+		});
+	});
 });
 </script>

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -125,7 +125,7 @@
               {% endif %}
               {{ entry.submission_count }}
               {% if entry.max_submissions > 0 %}
-              / {{ entry.max_submissions }}
+              / {{ entry.personal_max_submissions|default_if_none:entry.max_submissions }}
               {% endif %}
             </span><b class="caret"></b>
           </a>

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -44,7 +44,7 @@
 					<a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button"
 							aria-haspopup="true" aria-expanded="false">
 							{% translate "MY_SUBMISSIONS" %}
-							({{ summary.get_submission_count }}{% if exercise.max_submissions %}/{{ exercise|max_submissions:profile }}{% endif %})
+							({{ summary.get_submission_count }}{% if exercise.max_submissions %}/{{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}{% endif %})
 							<span class="caret"></span>
 					</a>
 					<ul class="dropdown-menu">

--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -71,7 +71,7 @@
 										<span class="badge">
 											{{ summary.get_submission_count }}
 											{% if exercise.max_submissions %}
-												/ {{ exercise|max_submissions:profile }}
+												/ {{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}
 											{% endif %}
 										</span>
 										<b class="caret"></b>
@@ -108,7 +108,15 @@
 												{% endif %}
 												<li>
 													<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-													{% if exercise.is_late_submission_open %}
+													{% if cached_points.personal_deadline %}
+														{% translate "EXTENDED_DEADLINE" %}
+														{{ cached_points.personal_deadline }}
+														{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}
+														({% blocktranslate trimmed with penalty=module.late_submission_penalty|percent deadline=module.closing_time %}
+															PENALTY_AFTER -- {{ penalty }}, {{ deadline }}
+														{% endblocktranslate %})
+														{% endif %}
+													{% elif exercise.is_late_submission_open %}
 														{% translate "LATE_SUBMISSION_DEADLINE" %} {{ module.late_submission_deadline }}
 														{% if module.late_submission_penalty > 0 %}
 														(-{{ module.late_submission_penalty|percent }}%)

--- a/exercise/templates/exercise/staff/inspect_submission.html
+++ b/exercise/templates/exercise/staff/inspect_submission.html
@@ -65,7 +65,7 @@
 				<span class="badge">
 					{{ summary.submission_count }}
 					{% if exercise.max_submissions %}
-					/ {{ exercise|max_submissions:submission.submitters.first }}
+					/ {{ cached_points.personal_max_submissions|default_if_none:exercise.max_submissions }}
 					{% endif %}
 				</span>
 				{% if exercise.max_submissions %}

--- a/exercise/templatetags/exercise.py
+++ b/exercise/templatetags/exercise.py
@@ -123,11 +123,6 @@ def latest_submissions(context):
 
 
 @register.filter
-def max_submissions(exercise, user_profile):
-    return exercise.max_submissions_for_student(user_profile)
-
-
-@register.filter
 def percent(decimal):
     return int(decimal * 100)
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-05 15:45+0200\n"
+"POT-Creation-Date: 2021-11-17 13:26+0200\n"
 "PO-Revision-Date: 2021-05-27 14:47+0300\n"
 "Last-Translator: Ella Anttila <ella.anttila@aalto.fi>\n"
 "Language-Team: English<>\n"
@@ -3111,6 +3111,11 @@ msgstr "Deadline"
 
 #: exercise/templates/exercise/_exercise_info.html
 #: exercise/templates/exercise/exercise_plain.html
+msgid "EXTENDED_DEADLINE"
+msgstr "Extended deadline"
+
+#: exercise/templates/exercise/_exercise_info.html
+#: exercise/templates/exercise/exercise_plain.html
 msgid "LATE_SUBMISSION_DEADLINE"
 msgstr "Late submission deadline"
 
@@ -3380,6 +3385,10 @@ msgid "OPEN_EXERCISE_IN_NEW_TAB"
 msgstr ""
 "Open this assignment in a new tab (recommended for keyboard and assistive "
 "technology users)"
+
+#: exercise/templates/exercise/exercise_plain.html
+msgid "PENALTY_AFTER -- %(penalty)s, %(deadline)s"
+msgstr "-%(penalty)s%% penalty after %(deadline)s"
 
 #: exercise/templates/exercise/exercise_plain.html
 msgid "TO_BE_SUBMITTED_ALONE"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-05 15:45+0200\n"
+"POT-Creation-Date: 2021-11-17 13:26+0200\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Ella Anttila <ella.anttila@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -3114,6 +3114,11 @@ msgstr "Määräaika"
 
 #: exercise/templates/exercise/_exercise_info.html
 #: exercise/templates/exercise/exercise_plain.html
+msgid "EXTENDED_DEADLINE"
+msgstr "Pidennetty määräaika"
+
+#: exercise/templates/exercise/_exercise_info.html
+#: exercise/templates/exercise/exercise_plain.html
 msgid "LATE_SUBMISSION_DEADLINE"
 msgstr "Myöhästyneiden palautuksien määräaika"
 
@@ -3386,6 +3391,10 @@ msgid "OPEN_EXERCISE_IN_NEW_TAB"
 msgstr ""
 "Avaa tämä tehtävä uudessa välilehdessä (suositellaan näppäimistön ja "
 "avustavan teknologian käyttäjille)"
+
+#: exercise/templates/exercise/exercise_plain.html
+msgid "PENALTY_AFTER -- %(penalty)s, %(deadline)s"
+msgstr "-%(penalty)s%% pistevähennys alkaen %(deadline)s"
 
 #: exercise/templates/exercise/exercise_plain.html
 msgid "TO_BE_SUBMITTED_ALONE"


### PR DESCRIPTION
# Description

**What?**

This pull request adds information to the student UI about the deviations granted to the student (max submissions deviations and deadline deviations).

**Why?**

Previously, the deviations were not visible to the student.

**How?**

Max submissions deviations are now counted in places that display a submission counter in the format "X/Y" where X is the current number of submissions and Y is the maximum number of submissions.

Deadline deviations are now displayed in the "exercise info" box on the standalone exercise and submission pages. They are also displayed in the exercise frame header.

This is a re-implementation of the older pull request #398. In that PR, the deviation information was added to the `CachedStudent` cache. However, in the more recent delayed feedback update, the deviation information was added to `CachedPoints` instead. This makes the old PR's `CachedStudent` update obsolete. In addition, the old PR was based on template tags, each of which initialized its own `CachedStudent` instance to fetch the deadline information. This PR initializes a `CachedPoints` instance only once in `ExerciseMixin` and stores it as an attribute of the view. The UI changes (where and how the deviation information is displayed) are very similar to the old PR, though.


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the deviation information was correctly displayed in all the intended places, and that the penalty was displayed next to the deadline deviation when the penalty wasn't cancelled by the deviation.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*