### PR TITLE
CachedPoints duplication and related fixes

### DIFF
--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -134,7 +134,7 @@ class InspectSubmitterView(ExerciseBaseView, BaseRedirectView):
         )
 
         # Find the submitter's best submission using the cache.
-        cache = CachedPoints(self.instance, user, self.content)
+        cache = CachedPoints(self.instance, user, self.content, True)
         ids = cache.submission_ids(exercise_id=self.exercise.id, best=True)
         if not ids:
             raise Http404()
@@ -306,7 +306,7 @@ class NextUnassessedSubmitterView(ExerciseBaseView, BaseRedirectView):
             return self.redirect(self.exercise.get_submission_list_url())
 
         # Find the submitter's best submission using the cache.
-        cache = CachedPoints(self.instance, submitter.user, self.content)
+        cache = CachedPoints(self.instance, submitter.user, self.content, True)
         ids = cache.submission_ids(exercise_id=self.exercise.id, best=True)
         if not ids:
             raise Http404()

--- a/exercise/templates/exercise/_exercise_info.html
+++ b/exercise/templates/exercise/_exercise_info.html
@@ -3,26 +3,26 @@
 {% load exercise %}
 
 <div class="well">
-	{% if exercise.category.confirm_the_level %}
-	<p>{% translate "CURRENT_STATUS" %}</p>
-	<p class="exercise-info-points">
-		{% points_badge summary %}
-	</p>
-	{% else %}
-	<p>{% translate "EARNED_POINTS" %}</p>
-	<p><strong class="h2 exercise-info-points">
-		{% format_points summary.get_points feedback_revealed False %}
-		<small>
-			/ {{ exercise.max_points }}
-			{% if summary.get_penalty %}
-			<span class="badge">
-				{% translate "LATE" %} -{{ summary.get_penalty|percent }} %
-			</span>
-			{% endif %}
-		</small>
-	</strong></p>
-	{% points_progress summary %}
-	{% endif %}
+    {% if exercise.category.confirm_the_level %}
+    <p>{% translate "CURRENT_STATUS" %}</p>
+    <p class="exercise-info-points">
+      {% points_badge summary is_revealed=feedback_revealed %}
+    </p>
+    {% else %}
+    <p>{% translate "EARNED_POINTS" %}</p>
+    <p><strong class="h2 exercise-info-points">
+        {% format_points summary.get_points feedback_revealed False %}
+        <small>
+            / {{ exercise.max_points }}
+            {% if summary.get_penalty %}
+            <span class="badge">
+                {% translate "LATE" %} -{{ summary.get_penalty|percent }} %
+            </span>
+            {% endif %}
+        </small>
+    </strong></p>
+    {% points_progress summary is_revealed=feedback_revealed %}
+    {% endif %}
 </div>
 
 <div class="panel panel-primary">

--- a/exercise/templates/exercise/_submission_list.html
+++ b/exercise/templates/exercise/_submission_list.html
@@ -8,7 +8,7 @@
 	<div class="list-group">
 		{% for submission in submissions %}
 		<a href="{{ submission|url }}" class="list-group-item">
-			{% points_badge submission %}
+			{% points_badge submission is_revealed=feedback_revealed %}
 			{{ submission.exercise }}<br />
 			<small class="text-nowrap">
 				{{ submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -53,7 +53,7 @@
 									<a href="{{ submission|url }}">
 											{{ forloop.revcounter }}.
 											{{ submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}
-											{% points_badge submission %}
+											{% points_badge submission is_revealed=feedback_revealed %}
 									</a>
 							</li>
 							{% empty %}

--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -60,7 +60,7 @@
 										{% if not exercise.category.confirm_the_level %}
 											{% translate "POINTS" %}
 										{% endif %}
-										{% points_badge summary %}
+										{% points_badge summary is_revealed=feedback_revealed %}
 									</span>
 								</a>
 							</li>
@@ -83,7 +83,7 @@
 											<a href="{{ submission|url:'submission-plain' }}">
 												{{ forloop.revcounter }}.
 												{{ submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}
-												{% points_badge submission %}
+												{% points_badge submission is_revealed=feedback_revealed %}
 											</a>
 										</li>
 									{% empty %}

--- a/exercise/templates/exercise/submission_plain.html
+++ b/exercise/templates/exercise/submission_plain.html
@@ -53,8 +53,8 @@
 					{% endif %}
 				</td>
 				<td class="points-badge">
-					<span class="hidden">{% points_badge summary %}</span>
-					{% points_badge submission %}
+					<span class="hidden">{% points_badge summary is_revealed=feedback_revealed %}</span>
+					{% points_badge submission is_revealed=feedback_revealed %}
 				</td>
 				{% if submission.files.exists %}
 				<td>

--- a/exercise/templatetags/exercise.py
+++ b/exercise/templatetags/exercise.py
@@ -145,12 +145,17 @@ def _points_data(
         user: User,
         classes: Optional[str] = None,
         is_staff: bool = False,
+        known_revealed: Optional[bool] = None,
         ) -> Dict[str, Any]:
     reveal_time = None
-    is_revealed = is_staff
+    is_revealed = None
+    if known_revealed is not None:
+        is_revealed = known_revealed
+    elif is_staff:
+        is_revealed = True
     if isinstance(obj, UserExerciseSummary):
         exercise = obj.exercise
-        if not is_staff:
+        if is_revealed is None:
             is_revealed, reveal_time = _reveal_rule(exercise, user)
         data = {
             'points': obj.get_points() if is_revealed else 0,
@@ -170,7 +175,7 @@ def _points_data(
         }
     elif isinstance(obj, Submission):
         exercise = obj.exercise
-        if not is_staff:
+        if is_revealed is None:
             is_revealed, reveal_time = _reveal_rule(exercise, user)
         data = {
             'points': obj.grade if is_revealed else 0,
@@ -246,8 +251,9 @@ def _points_data(
 def points_progress(
         context: Context,
         obj: Union[UserExerciseSummary, Submission, Dict[str, Any]],
+        is_revealed: Optional[bool] = None,
         ) -> Dict[str, Any]:
-    return _points_data(obj, context['request'].user, None, context['is_course_staff'])
+    return _points_data(obj, context['request'].user, None, context['is_course_staff'], is_revealed)
 
 
 @register.inclusion_tag("exercise/_points_badge.html", takes_context=True)
@@ -255,8 +261,9 @@ def points_badge(
         context: Context,
         obj: Union[UserExerciseSummary, Submission, Dict[str, Any]],
         classes: Optional[str] = None,
+        is_revealed: Optional[bool] = None,
         ) -> Dict[str, Any]:
-    return _points_data(obj, context['request'].user, classes, context['is_course_staff'])
+    return _points_data(obj, context['request'].user, classes, context['is_course_staff'], is_revealed)
 
 
 @register.simple_tag


### PR DESCRIPTION
# Description

**What?**

`CachedPoints` was duplicated in the delayed feedback update because that was the easiest way to store revealed and unrevealed exercise results simultaneously. This PR fixes the duplication.

Additionally, the PR contains several related bug fixes:
- `InspectSubmitterView` and `NextUnassessedSubmitterView` used the student version of the cache, which means they would redirect the user to the submitter's last submission if delayed feedback was enabled, even though staff members are supposed to be able to know which submission is the best one.
- The "my submissions" list would evaluate the exercise's reveal rule for each submission separately. This was unnecessary because the result would be the same for each submission. This has been optimized.
- The cache key `best_submission` would reveal the best submission through the student cache before feedback was supposed to be revealed. It is now reverted to the last submission in the student cache when feedback is not revealed.
- Some comments were outdated after the "delayed feedback" and "force exercise points" updates.
- The cache keys `feedback_revealed` and `feedback_reveal_time` were missing from submissions.
- The helper functions `has_more_points` and `is_newer` now accept a submission as the second argument, instead of the current cache entry. Because of this, `submission_date` (exercise key) no longer has to be stored in cache.

**Why?**

The duplicated cache took some extra memory. In addition, it would have to be generated twice since there were two versions of it, so this is also a performance improvement.

**How?**

`CachedPoints` now generates the staff and student cache immediately after one another, using the same query results for both passes. Because of this, the generation time is reduced. After both versions have been generated, they are merged by recursively comparing the values in the caches. When there is a conflicting value (e.g. points are revealed in staff cache but not in student cache), a tuple with both values is stored. This completely eliminates the duplication if a course doesn't use delayed feedback at all, and greatly reduces it when it does since only the differing keys have duplicated values. In the `CachedPoints` initializer, only one set of these duplicate keys is left in the dict, while the other set is removed. This has a small runtime cost (~4-5 ms), but makes it easier to use the cache in views and templates (the caller doesn't have to check which value should be used every time).

The "my submissions" list was optimized by allowing an `is_revealed` argument to be passed to the `points_badge` template tag. If it is provided, the reveal rule will not be evaluated by the template tag.

Fixes #887


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the cache still returns the expected values. In addition, the amount of memory taken by the cache was measured by accessing memcached via telnet.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*