### PR TITLE
Use datetime-local in datetime form fields

### DIFF
--- a/deviations/forms.py
+++ b/deviations/forms.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from exercise.models import BaseExercise
 from userprofile.models import UserProfile
 from course.models import CourseModule
+from lib.widgets import DateTimeLocalInput
 
 
 class DeadlineRuleDeviationForm(forms.Form):
@@ -32,9 +33,9 @@ class DeadlineRuleDeviationForm(forms.Form):
     )
     new_date = forms.DateTimeField(
         required=False,
-        input_formats=['%Y-%m-%d %H:%M'],
         label=_('LABEL_NEW_DEADLINE'),
         help_text=_('DEVIATION_NEW_DEADLINE_DATE_HELPTEXT'),
+        widget=DateTimeLocalInput,
     )
     without_late_penalty = forms.BooleanField(
         required=False,

--- a/edit_course/course_forms.py
+++ b/edit_course/course_forms.py
@@ -7,6 +7,7 @@ from aplus.api import api_reverse
 from course.models import LearningObjectCategory, Course, CourseModule, CourseInstance, UserTag
 from lib.validators import generate_url_key_validator
 from lib.fields import UsersSearchSelectField
+from lib.widgets import DateTimeLocalInput
 from userprofile.models import UserProfile
 
 
@@ -58,6 +59,12 @@ class CourseModuleForm(FieldsetModelForm):
             'late_submission_deadline',
             'late_submission_penalty'
         ]
+        widgets = {
+            'opening_time': DateTimeLocalInput,
+            'reading_opening_time': DateTimeLocalInput,
+            'closing_time': DateTimeLocalInput,
+            'late_submission_deadline': DateTimeLocalInput,
+        }
 
     def get_fieldsets(self):
         return [
@@ -102,6 +109,14 @@ class CourseInstanceForm(forms.ModelForm):
             'assistants',
             'technical_error_emails',
         ]
+        widgets = {
+            'starting_time': DateTimeLocalInput,
+            'ending_time': DateTimeLocalInput,
+            'lifesupport_time': DateTimeLocalInput,
+            'archive_time': DateTimeLocalInput,
+            'enrollment_starting_time': DateTimeLocalInput,
+            'enrollment_ending_time': DateTimeLocalInput,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/edit_course/exercise_forms.py
+++ b/edit_course/exercise_forms.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from course.models import CourseModule, LearningObjectCategory
 from exercise.models import LearningObject, CourseChapter, BaseExercise, \
     LTIExercise, StaticExercise, ExerciseWithAttachment, RevealRule
+from lib.widgets import DateTimeLocalInput
 from .course_forms import FieldsetModelForm
 
 from exercise.exercisecollection_models import ExerciseCollection
@@ -94,6 +95,7 @@ class RevealRuleForm(FieldsetModelForm):
     class Meta:
         model = RevealRule
         fields = ['trigger', 'delay_minutes', 'time', 'currently_revealed']
+        widgets = {'time': DateTimeLocalInput}
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/lib/widgets.py
+++ b/lib/widgets.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, Optional
+
+from django import forms
+
+
+class DateTimeLocalInput(forms.DateTimeInput):
+    """
+    A datetime widget that uses the `datetime-local` input type in HTML.
+
+    The initial value of the HTML input must be formatted `YYYY-MM-DDThh:mm`.
+    This widget ensures proper formatting.
+
+    The submitted form also uses this format, which Django can already handle
+    without custom logic (see `django.utils.dateparse.datetime_re`).
+    """
+    input_type = 'datetime-local'
+
+    def __init__(self, attrs: Optional[Dict[str, Any]] = None) -> None:
+        default_attrs = {'step': 1} # Display seconds in widget
+        if attrs is not None:
+            default_attrs.update(attrs)
+        super().__init__(attrs=default_attrs, format='%Y-%m-%dT%H:%M')

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1427,7 +1427,7 @@ msgstr "New deadline"
 
 #: deviations/forms.py
 msgid "DEVIATION_NEW_DEADLINE_DATE_HELPTEXT"
-msgstr "New submission deadline in the future in format YYYY-MM-DD HH:MM."
+msgstr "New submission deadline."
 
 #: deviations/forms.py deviations/models.py
 msgid "LABEL_WITHOUT_LATE_PENALTY"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1431,7 +1431,7 @@ msgstr "Uusi määräaika"
 
 #: deviations/forms.py
 msgid "DEVIATION_NEW_DEADLINE_DATE_HELPTEXT"
-msgstr "Uusi määräaika formaatissa YYYY-MM-DD HH:MM."
+msgstr "Uusi määräaika."
 
 #: deviations/forms.py deviations/models.py
 msgid "LABEL_WITHOUT_LATE_PENALTY"


### PR DESCRIPTION
# Description

**What?**

This PR adds a datetime picker to all datetime fields in forms.

**Why?**

This was mentioned when discussing the deviation UI with Aalto teachers.

**How?**

A new widget, `DateTimeLocalInput`, has been added. This new widget is otherwise the same as the built-in `DateTimeInput`, except it uses the `datetime-local` HTML input type, which uses a datetime picker provided by the browser. `datetime-local` expects the initial value of the field to be in a specific format, which the widget ensures. `datetime-local` is supported in all major browsers except for IE. If the user's browser doesn't support this widget type, it uses `text` instead (which the A+ forms used before this update anyway).


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [x] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the initial value is populated to the field correctly (in the course configuration form). Tested that the entered value is saved correctly.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*