### PR TITLE
Fix bug that broke SubmissionViewSet

### DIFF
--- a/exercise/viewbase.py
+++ b/exercise/viewbase.py
@@ -178,7 +178,7 @@ class SubmissionBaseMixin(object):
         super().get_resource_objects()
         self.submission = self.get_submission_object()
         if self.submission.is_submitter(self.request.user):
-            self.submitter = self.profile
+            self.submitter = self.request.user.userprofile
         else:
             self.submitter = self.submission.submitters.first()
         self.note("submission", "submitter")


### PR DESCRIPTION
# Description

**What?**

In a previous update, SubmissionBaseMixin was modified to use self.profile. However, self.profile is not assigned in API views, and thus SubmissionViewSet was broken. This fix changes the code so that self.profile is not accessed and the API view now works.

**Why?**

See "What?"

**How?**

See "What?"


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the submission API view now works.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*