### PR TITLE
Fix 404 when clicking "start manual assessment"

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -483,6 +483,7 @@ class CachedPoints(ContentMixin, CachedAbstract):
             exercise_id: Optional[int] = None,
             filter_for_assistant: bool = False,
             best: bool = True,
+            fallback_to_last: bool = False,
             raise_404=True,
             ) -> List[int]:
         exercises = self.search_exercises(
@@ -499,6 +500,10 @@ class CachedPoints(ContentMixin, CachedAbstract):
                 sid = entry.get('best_submission', None)
                 if not sid is None:
                     submissions.append(sid)
+                elif fallback_to_last:
+                    entry_submissions = entry.get('submissions', [])
+                    if entry_submissions:
+                        submissions.append(entry_submissions[0]['id']) # Last submission is first in the cache
         else:
             for entry in exercises:
                 submissions.extend(s['id'] for s in entry.get('submissions', []))

--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -135,7 +135,7 @@ class InspectSubmitterView(ExerciseBaseView, BaseRedirectView):
 
         # Find the submitter's best submission using the cache.
         cache = CachedPoints(self.instance, user, self.content, True)
-        ids = cache.submission_ids(exercise_id=self.exercise.id, best=True)
+        ids = cache.submission_ids(exercise_id=self.exercise.id, best=True, fallback_to_last=True)
         if not ids:
             raise Http404()
         del kwargs['user_id']
@@ -308,7 +308,7 @@ class NextUnassessedSubmitterView(ExerciseBaseView, BaseRedirectView):
 
         # Find the submitter's best submission using the cache.
         cache = CachedPoints(self.instance, submitter.user, self.content, True)
-        ids = cache.submission_ids(exercise_id=self.exercise.id, best=True)
+        ids = cache.submission_ids(exercise_id=self.exercise.id, best=True, fallback_to_last=True)
         if not ids:
             raise Http404()
         url = reverse(


### PR DESCRIPTION
# Description

**What?**

The "start manual assessment" button, as well as the "inspect" button in the submission list when grouped by submitter, would cause a 404 error if none of the chosen user's submissions were marked as `best_submission` in the points cache. This PR fixes the bug.

**Why?**

Shouldn't return 404 when there actually are submissions.

**How?**

The two views in question used the method `CachedPoints.submission_ids` to get the best submission of the chosen user. This method returned an empty list when called with `best=True` and none of the submissions were considered "best" by the points cache's logic. A new optional parameter, `fallback_to_last` has been added to the method. It ensures that *some* submission is returned even when there is no "best" submission.


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually by setting a user's all submissions to the WAITING state, and pressing the "start manual assessment" and "inspect" buttons in the grouped submission list. A 404 error was no longer given, and instead the user's last submission was opened.

The unit tests were already broken by a previous commit: https://github.com/apluslms/a-plus/runs/4690502793?check_suite_focus=true

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*