### PR TITLE
Fix get-token 500 error and PR #937 issue 

### DIFF
--- a/authorization/api/views.py
+++ b/authorization/api/views.py
@@ -58,7 +58,7 @@ class RemoteAuthenticationView(RemoteAuthenticator, APIView):
             payload = request.auth
 
         if not isinstance(payload, Payload):
-            return Response("Missing payload", status=500)
+            return Response("Missing payload", status=400)
 
         if permissions is None:
             if hasattr(request.user, "permissions"):

--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -1,12 +1,13 @@
-from bs4 import BeautifulSoup
 import logging
 import posixpath
 import re
-import requests
-from requests.models import Response
 import time
 from typing import Optional
 from urllib.parse import urlparse, urljoin
+
+from bs4 import BeautifulSoup
+import requests
+from requests.models import Response
 
 from aplus_auth.payload import Permission, Permissions
 from django.conf import settings


### PR DESCRIPTION
# Description

**What?**

No more 500 error on loading get-token page, and fixes the import grouping for remote_page.py.

**Why?**

500 isn't correct behaviour.

**How?**

Return 400 Bad Request instead, as it makes most sense.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature