### PR TITLE
Allow INITIALIZED and WAITING submissions to be the best submission in CachedPoints

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -335,7 +335,7 @@ class CachedPoints(ContentMixin, CachedAbstract):
                         'best_submission': submission.id,
                         'points': submission.grade,
                         'formatted_points': format_points(submission.grade, True, False),
-                        'passed': (ready and submission.grade >= entry['points_to_pass']),
+                        'passed': (not unofficial and submission.grade >= entry['points_to_pass']),
                         'graded': True,
                         'unofficial': False,
                         'forced_points': True,
@@ -343,7 +343,7 @@ class CachedPoints(ContentMixin, CachedAbstract):
                     final_submission = submission
                 if not entry.get('forced_points', False):
                     if (
-                        ready and (
+                        not unofficial and (
                             entry['unofficial'] or
                             is_better_than(submission, final_submission)
                         )
@@ -356,14 +356,14 @@ class CachedPoints(ContentMixin, CachedAbstract):
                             'best_submission': submission.id,
                             'points': submission.grade,
                             'formatted_points': format_points(submission.grade, True, False),
-                            'passed': (ready and submission.grade >= entry['points_to_pass']),
-                            'graded': ready, # != unofficial
+                            'passed': (not unofficial and submission.grade >= entry['points_to_pass']),
+                            'graded': not unofficial,
                             'unofficial': unofficial,
                         })
                         final_submission = submission
                 # Update last_submission to be the last submission, or the last
                 # official submission if there are any official submissions.
-                # Note that the submissions are ordered by descendng time.
+                # Note that the submissions are ordered by descending time.
                 if last_submission is None or (
                     last_submission.status == Submission.STATUS.UNOFFICIAL
                     and not unofficial

--- a/exercise/tests.py
+++ b/exercise/tests.py
@@ -587,15 +587,22 @@ class ExerciseTest(TestCase):
         self.learning_object_category.accept_unofficial_submits = True
         self.learning_object_category.save()
 
+        self.submission_when_late_allowed.set_error()
+        self.late_late_submission_when_late_allowed.set_error()
+        self.submission_when_late_allowed.save()
+        self.late_late_submission_when_late_allowed.save()
+
         self.late_submission_when_late_allowed.set_points(10, 10)
         self.late_submission_when_late_allowed.set_ready()
         self.late_submission_when_late_allowed.save()
         self.assertEqual(self.late_submission_when_late_allowed.grade, 100)
         self.assertEqual(self.late_submission_when_late_allowed.status, Submission.STATUS.UNOFFICIAL)
         summary = UserExerciseSummary(self.base_exercise_with_late_submission_allowed, self.user)
-        self.assertEqual(summary.get_submission_count(), 3)
+        self.assertEqual(summary.get_submission_count(), 1)
         self.assertEqual(summary.get_points(), 0) # unofficial points are not shown here
         self.assertFalse(summary.is_graded())
+        # 3 submissions:
+        # initialized, unofficial, initialized
         self.assertTrue(summary.is_unofficial())
 
         self.submission_when_late_allowed.set_points(5, 10)
@@ -604,6 +611,7 @@ class ExerciseTest(TestCase):
         self.assertEqual(self.submission_when_late_allowed.grade, 50)
         self.assertEqual(self.submission_when_late_allowed.status, Submission.STATUS.READY)
         summary = UserExerciseSummary(self.base_exercise_with_late_submission_allowed, self.user)
+        self.assertEqual(summary.get_submission_count(), 2)
         self.assertEqual(summary.get_points(), 50)
         self.assertTrue(summary.is_graded())
         self.assertFalse(summary.is_unofficial())
@@ -618,6 +626,7 @@ class ExerciseTest(TestCase):
         sub.set_points(10, 10)
         sub.save()
         summary = UserExerciseSummary(self.base_exercise_with_late_submission_allowed, self.user)
+        self.assertEqual(summary.get_submission_count(), 3)
         self.assertEqual(summary.get_points(), 50)
         self.assertTrue(summary.is_graded())
         self.assertFalse(summary.is_unofficial())

--- a/exercise/tests_cache.py
+++ b/exercise/tests_cache.py
@@ -141,10 +141,13 @@ class CachedPointsTest(CourseTestCase):
 
     def test_accumulation(self):
         self.submission2.set_points(2,2)
+        self.submission2.set_error()
         self.submission2.save()
         c = CachedContent(self.instance)
         p = CachedPoints(self.instance, self.student, c)
         entry,tree,_,_ = p.find(self.exercise)
+        # 2 submissions:
+        # ready 50, initialized 100
         self.assertTrue(entry['graded'])
         self.assertTrue(entry['passed'])
         self.assertEqual(entry['points'], 50)
@@ -164,7 +167,7 @@ class CachedPointsTest(CourseTestCase):
         self.submission2.save()
         p = CachedPoints(self.instance, self.student, c)
         total = p.total()
-        self.assertEqual(total['submission_count'], 2)
+        self.assertEqual(total['submission_count'], 3)
         self.assertEqual(total['points'], 100)
         self.assertEqual(total['points_by_difficulty'].get('',0), 100)
 


### PR DESCRIPTION
# Description

**What?**

This PR changes CachedPoints to allow INITIALIZED and WAITING submissions to be the best submission, instead of just READY.

**Why?**

The same change was already done to UserExerciseSummary in https://github.com/apluslms/a-plus/commit/87dae322fd9777f707db2d0279ccfd1258bf0587, which changed how points are displayed on chapter pages. After this PR, the same change is visible on the course results page (front page).

![image](https://user-images.githubusercontent.com/28843787/148075073-d80a880d-ab26-46c1-b330-6588480ed0c1.png)

In the above image, the exercise's grading mode is LAST, which causes the 2nd submission to be the "best" submission. Before this PR, the exercise's points would be shown as 10/10, because the 2nd submission's state is WAITING.

**How?**

In all points in the CachedPoints code where submissions were restricted to READY only, all states except UNOFFICIAL are now allowed (ERROR and REJECTED were already filtered out before the main submission loop).


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the front page's points now correspond to the chapter pages.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*