### PR TITLE
Catch ValueError in get-token payload parsing

### DIFF
--- a/authorization/api/views.py
+++ b/authorization/api/views.py
@@ -85,7 +85,10 @@ class RemoteAuthenticationView(RemoteAuthenticator, APIView):
         payload = request.auth
         if not isinstance(payload, Payload):
             data = dict(request.data)
-            payload = Payload(**data)
+            try:
+                payload = Payload(**data)
+            except ValueError as e:
+                return Response(str(e), status=400)
             payload.iss = f"user:{request.user.username}"
             try:
                 # request.auth has already been authorized but the payload in


### PR DESCRIPTION
# Description

**What?**

Fix crash when get-token payload has invalid dates.

**Why?**

Crash bad.

**How?**

Catch exception.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Checked that it doesn't crash anymore and works otherwise.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
