### PR TITLE
Exclude WAITING submissions from all results table

### DIFF
--- a/exercise/api/csv/views.py
+++ b/exercise/api/csv/views.py
@@ -322,7 +322,8 @@ class CourseResultsDataViewSet(NestedViewSetMixin,
         points = CachedPoints(self.instance, request.user, self.content, self.is_course_staff)
         revealed_ids = get_revealed_exercise_ids(search_args, points)
         exclude_list = [Submission.STATUS.ERROR, Submission.STATUS.REJECTED]
-        if(request.GET.get('show_unofficial') != 'true'):
+        show_unofficial = request.GET.get('show_unofficial') == 'true'
+        if not show_unofficial:
             exclude_list.append(Submission.STATUS.UNOFFICIAL)
         aggr = (
             Submission.objects
@@ -330,7 +331,7 @@ class CourseResultsDataViewSet(NestedViewSetMixin,
             .exclude(status__in=(exclude_list))
             .values('submitters__user_id', 'exercise_id')
             .annotate(count=Count('id'))
-            .annotate_submitter_points('total', revealed_ids)
+            .annotate_submitter_points('total', revealed_ids, show_unofficial)
             .order_by()
         )
         data,fields = aggregate_points(

--- a/exercise/exercise_summary.py
+++ b/exercise/exercise_summary.py
@@ -56,7 +56,7 @@ class UserExerciseSummary(object):
                         self.forced_points = True
                     if not self.forced_points:
                         if (
-                            s.status != Submission.STATUS.UNOFFICIAL and (
+                            s.status == Submission.STATUS.READY and (
                                 self.best_submission is None
                                 or self.unofficial
                                 or self._is_better(s, self.best_submission)


### PR DESCRIPTION
# Description

**What?**

This PR changes the all results table to ignore submissions in the states `WAITING` and `INITIALIZED` when determining a student's final points in an exercise, and reverts a previous change (87dae322fd9777f707db2d0279ccfd1258bf0587), which changed the chapter pages to **not** ignore submissions in those states when determining the students final points.

**Why?**

In a previous commit (87dae322fd9777f707db2d0279ccfd1258bf0587), `UserExerciseSummary` was changed to include submissions in states `WAITING` and `INITIALIZED`, to match the behaviour of the all results table (which uses `CourseResultsDataViewSet`). It was later decided that this should be the other way around: the all results table should ignore submissions in the aforementioned states, like `UserExerciseSummary` and `CachedPoints` did.

**How?**

The `annotate_submitter_points` has been updated to only consider submissions in the state `READY`, unless the `include_unofficial` parameter is `True`, in which case submissions in states `READY` and `UNOFFICIAL` are considered.

The previous change to `UserExerciseSummary` has been reverted.

The `test_annotate_submitter_points` method has also been expanded to cover more situations:
- all submissions are in a state that is not included in the calculation
- `include_unofficial` is `True`
- `revealed_ids` is an empty tuple (no exercises have been revealed)


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that submissions in states `WAITING` and `INITIALIZED` are now ignored in the following points calculations:
- user results page (uses `CachedPoints`)
- chapter page (uses `UserExerciseSummary`)
- all results page (uses `CourseResultsDataViewSet`)

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*