### PR TITLE
Permission fixes for GraderUser

### DIFF
--- a/authorization/object_permissions.py
+++ b/authorization/object_permissions.py
@@ -163,6 +163,7 @@ class ObjectPermissions:
     def __init__(self):
         self.courses: ObjectPermissionList["Course"] = ObjectPermissionList()
         self.instances: ObjectPermissionList["CourseInstance"] = ObjectPermissionList()
+        self.exercises: ObjectPermissionList["BaseExercise"] = ObjectPermissionList()
         self.submissions: ObjectPermissionList["Submission"] = ObjectPermissionList()
 
     @staticmethod
@@ -174,6 +175,7 @@ class ObjectPermissions:
         perms = ObjectPermissions()
         perms.courses = ObjectPermissionList.from_payload(user, payload, payload.permissions.courses)
         perms.instances = ObjectPermissionList.from_payload(user, payload, payload.permissions.instances)
+        perms.exercises = ObjectPermissionList.from_payload(user, payload, payload.permissions.exercises)
         perms.submissions = ObjectPermissionList.from_payload(user, payload, payload.permissions.submissions)
         return perms
 
@@ -182,6 +184,7 @@ class ObjectPermissions:
         for target, source in [
                     (permissions.courses, self.courses),
                     (permissions.instances, self.instances),
+                    (permissions.exercises, self.exercises),
                     (permissions.submissions, self.submissions),
                 ]:
             for permission, obj in source.instances:

--- a/course/permissions.py
+++ b/course/permissions.py
@@ -17,7 +17,7 @@ from authorization.permissions import (
 from exercise.cache.points import CachedPoints
 from exercise.models import BaseExercise
 from exercise.submission_models import Submission
-from userprofile.models import UserProfile
+from userprofile.models import GraderUser, UserProfile
 from .models import (
     Course,
     CourseModule,
@@ -130,6 +130,9 @@ class CourseVisiblePermissionBase(ObjectVisibleBasePermission):
         """
         # NOTE: course is actually course instance
 
+        if isinstance(request.user, GraderUser):
+            return False
+
         # Course is always visible to staff members
         if view.is_course_staff:
             return True
@@ -236,6 +239,8 @@ class CourseModulePermissionBase(MessageMixin, Permission):
         return True
 
     def has_object_permission(self, request: HttpRequest, view: Any, module: CourseModule) -> bool:
+        if isinstance(request.user, GraderUser):
+            return False
 
         if not isinstance(module, CourseModule):
             return True

--- a/exercise/permissions.py
+++ b/exercise/permissions.py
@@ -105,6 +105,9 @@ class SubmissionVisiblePermissionBase(ObjectVisibleBasePermission):
     obj_var = 'submission'
 
     def is_object_visible(self, request, view, submission):
+        if isinstance(request.user, GraderUser):
+            return False
+
         if not isinstance(request.user, User) or not (view.is_teacher or
                 (view.is_assistant and submission.exercise.allow_assistant_viewing) or
                 submission.is_submitter(request.user)):

--- a/lib/api/authentication/grader.py
+++ b/lib/api/authentication/grader.py
@@ -54,6 +54,9 @@ class GraderAuthentication(ServiceAuthentication[GraderUser], BaseAuthentication
             perm_dict: Dict[str, Any] = {"exercise_id": exercise.id, "user_id": user_id}
             payload.permissions.submissions.add(Permission.CREATE, **perm_dict)
             permissions.submissions.add_create(**perm_dict)
+
+            payload.permissions.exercises.add(Permission.READ, id=exercise.id)
+            permissions.exercises.add(Permission.READ, {"id": exercise.id})
         else:
             raise AuthenticationFailed("Authentication token is invalid.")
 


### PR DESCRIPTION
# Description

**What?**

Fixes GraderUser permissions related to Jutut access.

**Why?**

Jutut either couldn't access exercises or it crashed A+.

**How?**

Check that the user is not a GraderUser in normal permissions, and add exercise read permission to exercise tokens.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
