### PR TITLE
Fix "show all submissions" button appear condition on inspect submission page

### DIFF
--- a/exercise/templates/exercise/staff/_submissions_table_compact.html
+++ b/exercise/templates/exercise/staff/_submissions_table_compact.html
@@ -72,7 +72,7 @@
 			</td>
 		</tr>
 		{% endfor %}
-		{% if summary.submission_count > 1 %}
+		{% if summary.submission_count > highest_visible_index or lowest_visible_index > 1 %}
 		<tr>
 			<td colspan="5">
 				<button class="aplus-button--secondary aplus-button--xs" data-toggle="visibility" data-target=".submissions-toggle">


### PR DESCRIPTION
# Description

**What?**

In the A+ inspect submission page, the submission list has a button "Show all submissions" under it.
The button is now hidden if all submissions are already shown.

**Why?**

The button was displayed even when all submissions were already displayed, and that is misleading or confusing for the teacher.

**How?**

Fixed the if-condition in the Django HTML template.

Fixes issue [EDIT-770](https://jira.aalto.fi/projects/EDIT/issues/EDIT-770) in JIRA.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

I tested that the button is correctly shown/hidden depending on if there are hidden submissions or not.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature