### PR TITLE
Use type variable in JWT decorator

### DIFF
--- a/authorization/object_permissions.py
+++ b/authorization/object_permissions.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Generic, Itera
 
 from aplus_auth import settings as auth_settings
 from aplus_auth.payload import Payload, Permission, PermissionItem, PermissionItemList, Permissions
+from django.db import models
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import AuthenticationFailed
@@ -21,17 +22,18 @@ logger = logging.getLogger('aplus.authentication')
 _jwt_accessible_managers: Dict[str, JWTAccessible] = {}
 
 
+TModel = TypeVar("TModel", bound=models.Model)
 @overload
-def register_jwt_accessible_class(type_id: str) -> Callable[[Type[Any]], Type[Any]]: ...
+def register_jwt_accessible_class(type_id: str) -> Callable[[Type[TModel]], Type[TModel]]: ...
 @overload
-def register_jwt_accessible_class(cls: Type[Any], type_id: str) -> Type[Any]: ...
+def register_jwt_accessible_class(cls: Type[TModel], type_id: str) -> Type[TModel]: ...
 def register_jwt_accessible_class(cls, type_id = None): # type: ignore
     """
     a decorator to register a model to be accessible through JWT
 
     cls.objects must inherit JWTAccessible
     """
-    def wrapper(cls: Type[Any]) -> Type[Any]:
+    def wrapper(cls: Type[TModel]) -> Type[TModel]:
         global _jwt_accessible_managers
         if not isinstance(cls.objects, JWTAccessible):
             raise TypeError(f"{cls} does not have a JWTAccessible manager")


### PR DESCRIPTION
# Description

**What?**

This PR fixes the type hinting of the `register_jwt_accessible_class` decorator.

**Why?**

IDE type checking and autocompletion was broken for all classes that the `register_jwt_accessible_class` decorator was applied to.

**How?**

The type hinting of the `register_jwt_accessible_class` decorator has been changed to use type variables instead of relying on `Type[Any]`, to signify that the input and output types of the decorator are the same.


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the type errors when using e.g. `BaseExercise.objects` are now resolved and that the autocompletion for objects of that class works again.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*