### PR TITLE
Fix inspect page "show all submissions" button more

### DIFF
--- a/exercise/templates/exercise/staff/_submissions_table_compact.html
+++ b/exercise/templates/exercise/staff/_submissions_table_compact.html
@@ -80,7 +80,7 @@
 			</td>
 		</tr>
 		{% endfor %}
-		{% if summary.submission_count > highest_visible_index or lowest_visible_index > 1 %}
+		{% if submissions|length > highest_visible_index or lowest_visible_index > 1 %}
 		<tr>
 			<td colspan="5">
 				<button class="aplus-button--secondary aplus-button--xs" data-toggle="visibility" data-target=".submissions-toggle">


### PR DESCRIPTION
# Description

**What?**

In the A+ inspect submission page, the submission list has a button "Show all submissions" under it.
The button now correctly counts and behaves with submissions that have ERROR or REJECTED status.

**Why?**

The button's render logic did not correctly count submissions with ERROR or REJECTED statuses.

**How?**

Fixed the if-condition in the Django HTML template.

Related JIRA issue: [EDIT-770](https://jira.aalto.fi/projects/EDIT/issues/EDIT-770)

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

I tested that the button is correctly shown/hidden now.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature