### PR TITLE
Replace inspect page submitted file dropdown with tabs

### DIFF
--- a/exercise/static/exercise/assessment.js
+++ b/exercise/static/exercise/assessment.js
@@ -19,46 +19,35 @@ $(function () {
     label1.after(feedbackToggleButton.clone().text(label2.text())).after(' | ');
     label2.before(feedbackToggleButton.clone().text(label1.text())).before(' | ');
 
-    // Change the displayed file with the dropdown menu
+    // Load the submitted files
     const loadedFiles = new Set();
-    const fileSelect = $('#submitted-file-select');
-    function updateFile() {
-      $('.submitted-file').each(function () {
-        const element = $(this);
-        const fileId = element.data('id');
-        const fileViewable = element.data('viewable');
-        const fileUrl = element.data('url');
-        if (fileId == fileSelect.val()) {
-          element.removeClass('hidden');
-          // Load the file when selected from the menu
-          if (fileUrl && fileViewable && !loadedFiles.has(fileId)) {
-            loadedFiles.add(fileId);
-            $.get(fileUrl, function (data) {
-              const text = $("<pre/>").text(data);
-              element.find('.submitted-file-data').html(text);
-              const downloadButton = {
-                action: function() {
-                  window.location.href = fileUrl + '?download=yes';
-                },
-                icon: 'download-alt',
-                text: _('Download'),
-              };
-              text.highlightCode({extraButtons: [downloadButton]});
-            })
-            .fail(function () {
-              element.find('.submitted-file-error').removeClass('hidden');
-            })
-            .always(function () {
-              element.find('.submitted-file-progress').addClass('hidden');
-            });
-          }
-        } else {
-          element.addClass('hidden');
-        }
-      });
-    }
-    updateFile();
-    fileSelect.on('change', updateFile);
+    $('.submitted-file').each(function () {
+      const element = $(this);
+      const fileId = element.attr('id');
+      const fileViewable = element.data('viewable');
+      const fileUrl = element.data('url');
+      if (fileUrl && fileViewable && !loadedFiles.has(fileId)) {
+        loadedFiles.add(fileId);
+        $.get(fileUrl, function (data) {
+          const text = $("<pre/>").text(data);
+          element.find('.submitted-file-data').html(text);
+          const downloadButton = {
+            action: function() {
+              window.location.href = fileUrl + '?download=yes';
+            },
+            icon: 'download-alt',
+            text: _('Download'),
+          };
+          text.highlightCode({extraButtons: [downloadButton]});
+        })
+        .fail(function () {
+          element.find('.submitted-file-error').removeClass('hidden');
+        })
+        .always(function () {
+          element.find('.submitted-file-progress').addClass('hidden');
+        });
+      }
+    });
 
     // The "sticky" feature is enabled if ResizeObserver is available and there
     // are submitted files (= there are two columns)

--- a/exercise/static/exercise/assessment.js
+++ b/exercise/static/exercise/assessment.js
@@ -23,7 +23,7 @@ $(function () {
     const loadedFiles = new Set();
     $('.submitted-file').each(function () {
       const element = $(this);
-      const fileId = element.attr('id');
+      const fileId = element.data('id');
       const fileViewable = element.data('viewable');
       const fileUrl = element.data('url');
       if (fileUrl && fileViewable && !loadedFiles.has(fileId)) {

--- a/exercise/templates/exercise/staff/_assessment_panel.html
+++ b/exercise/templates/exercise/staff/_assessment_panel.html
@@ -84,38 +84,41 @@
 			{# Body: left column (submitted files) #}
 			{% if has_files %}
 			<div class="col-sm-6">
-				<div class="form-group">
-					<select id="submitted-file-select" class="form-control" autocomplete="off">
-						{% for file in submission.files.all %}
-						<option value="{{ file.id }}" {% if forloop.first %}selected{% endif %}>{{ file.filename }}</option>
-						{% endfor %}
-					</select>
-				</div>
+				<ul class="nav nav-tabs" role="tablist">
+					{% for file in submission.files.all %}
+					<li class="nav-item {% if forloop.first %}active{% endif %}" role="presentation">
+						<a class="nav-link" href="#{{ file.id }}" role="tab" data-toggle="tab">{{ file.filename }}</a>
+					</li>
+					{% endfor %}
+				</ul>
 
-				{% for file in submission.files.all %}
-				<div
-					class="submitted-file {% if not forloop.first %}hidden{% endif %}"
-					data-id="{{ file.id }}"
-					{% if not file.is_passed %}data-viewable="true"{% endif %}
-					{% if file.exists %}data-url="{{ file.get_absolute_url }}"{% endif %}
-				>
-					{% if file.exists %}
-						{% if not file.is_passed %}
-						<div class="submitted-file-progress">
-							<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%">
-								{% translate "LOADING" %}
+				<div class="tab-content">
+					{% for file in submission.files.all %}
+					<div
+						id="{{ file.id }}"
+						role="tabpanel"
+						class="submitted-file tab-pane {% if forloop.first %}active{% endif %}"
+						{% if not file.is_passed %}data-viewable="true"{% endif %}
+						{% if file.exists %}data-url="{{ file.get_absolute_url }}"{% endif %}
+					>
+						{% if file.exists %}
+							{% if not file.is_passed %}
+							<div class="submitted-file-progress">
+								<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%">
+									{% translate "LOADING" %}
+								</div>
 							</div>
-						</div>
-						<div class="submitted-file-data"></div>
-						{% else %}
-							{% include "exercise/_file_link.html" %}
+							<div class="submitted-file-data"></div>
+							{% else %}
+								{% include "exercise/_file_link.html" %}
+							{% endif %}
 						{% endif %}
-					{% endif %}
-					<div class="alert alert-danger submitted-file-error {% if file.exists %}hidden{% endif %}">
-						{% translate "FILE_NOT_FOUND" %}
+						<div class="alert alert-danger submitted-file-error {% if file.exists %}hidden{% endif %}">
+							{% translate "FILE_NOT_FOUND" %}
+						</div>
 					</div>
+					{% endfor %}
 				</div>
-				{% endfor %}
 			</div>
 			{% endif %}
 

--- a/exercise/templates/exercise/staff/_assessment_panel.html
+++ b/exercise/templates/exercise/staff/_assessment_panel.html
@@ -87,7 +87,7 @@
 				<ul class="nav nav-tabs" role="tablist">
 					{% for file in submission.files.all %}
 					<li class="nav-item {% if forloop.first %}active{% endif %}" role="presentation">
-						<a class="nav-link" href="#{{ file.id }}" role="tab" data-toggle="tab">{{ file.filename }}</a>
+						<a class="nav-link" href="#file-{{ file.id }}" role="tab" aria-controls="file-{{ file.id }}" data-toggle="tab">{{ file.filename }}</a>
 					</li>
 					{% endfor %}
 				</ul>
@@ -95,7 +95,8 @@
 				<div class="tab-content">
 					{% for file in submission.files.all %}
 					<div
-						id="{{ file.id }}"
+						id="file-{{ file.id }}"
+						data-id="{{ file.id }}"
 						role="tabpanel"
 						class="submitted-file tab-pane {% if forloop.first %}active{% endif %}"
 						{% if not file.is_passed %}data-viewable="true"{% endif %}


### PR DESCRIPTION
# Description

**What?**

Replace the dropdown menu that is used to select submitted files for viewing on the inspect page with tabs, which have the file names as titles.

**Why?**

This was requested by a teacher to reduce the amount of needed clicks to switch between files.

**How?**

Modify the related HTML and JavaScript to replace the dropdown with bootstrap nav tabs.

Fixes #920


# Testing


**What type of test did you run?**

- [x] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the switching between files works correctly and that a large amount of tabs starts stacking vertically.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature