### PR TITLE
Remove duplicate HTML attribute id="exercise"

### DIFF
--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -175,6 +175,8 @@ class RemotePage:
 
     def element_or_body(self, search_attributes):
         element = self.select_element_or_body(search_attributes)
+        if element.get('id') == 'exercise':
+            del element['id']
         return str(element) if element else ""
 
     def clean_element_or_body(self, search_attributes):


### PR DESCRIPTION
# Description

**What?**

Remove the HTML attribute ``id="exercise"`` when chapters and exercises are rendered in the A+ frontend.

**Why?**

HTML id attributes must be unique. However, the ``id="exercise"`` was used multiple times.

**How?**

The ``id="exercise"`` is now removed in ``remote_page.py`` when A-plus retrieves chapter and exercise HTML from the backend.

Fixes #940


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Checked that the duplicate ``id="exercise"`` no longer exists.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
