### PR TITLE
Fix rendering of binary files in submitted file views

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -4,6 +4,7 @@ import os
 import json
 from typing import IO, Dict, Iterable, List, Tuple, TYPE_CHECKING
 
+from binaryornot.check import is_binary
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db import models, DatabaseError
@@ -642,7 +643,7 @@ class SubmittedFile(UrlMixin, models.Model):
         return guess_type(self.file_object.path)[0]
 
     def is_passed(self):
-        return self.get_mime() in SubmittedFile.PASS_MIME
+        return is_binary(self.file_object.path)
 
 
     ABSOLUTE_URL_NAME = "submission-file"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ markdown ~= 3.3.4
 aplus-auth ~= 0.2.0
 celery >= 5.2.1, < 6
 redis >= 4
+binaryornot ~= 0.4.4


### PR DESCRIPTION
# Description

**What?**

A+ no longer tries to render some binary files in plain text in the submitted file views.

**Why?**

A teacher noticed that this problem was causing performance issues, when large binary files were being loaded for preview.

**How?**

Binary files are now detected using a library called ``binaryornot`` instead of using ``mimetypes``. The library inspects the file contents and based on that guesses whether the file is binary or not.

Fixes #965


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Checked that binary files are no longer rendered with a preview in any of the submitted file views.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
