### PR TITLE
Fix active elements label for attribute missing suffix

### DIFF
--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -234,7 +234,7 @@
 
       var label = $("<label>");
       label.attr("class", "control-label");
-      label.attr("for", id + "_input");
+      label.attr("for", id + "_input_id");
       label.html(title);
 
       var form_field;


### PR DESCRIPTION
# Description

**What?**

This change adds the missing suffix to ``<label for="">`` attribute in active elements.

**Why?**

In active element exercises, the ``<label for="">`` attribute did not match the id of the input element and thus, clicking the label did not activate the text input like it should.

**How?**

Add the missing suffix to ``chapter.js``.

Fixes #823


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Checked that clicking on the label activates the text input like it should.
Also made sure that there are no duplicate ids in the HTML.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.


# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature