### PR TITLE
Improve sitemaps with dynamic priorities

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -158,6 +158,12 @@ INSTALLED_APPS = (
     'aplus_auth',
 )
 
+# Sitemap settings
+##########################################################################
+
+# A course is considered recent or upcoming if it was/is open within this delta (in days) from now.
+SITEMAP_DELTA_DAYS_RECENT_OR_UPCOMING = 180
+
 # Different login options (may override in local_settings.py)
 ##########################################################################
 

--- a/course/sitemaps.py
+++ b/course/sitemaps.py
@@ -2,6 +2,7 @@ from django.contrib import sitemaps
 from django.urls.base import reverse
 from django.utils import timezone
 
+from lib.sitemaps import AplusSitemap
 from .models import CourseInstance, CourseModule
 
 
@@ -19,31 +20,27 @@ class CourseStaticViewSitemap(sitemaps.Sitemap):
         return reverse(item)
 
 
-class InstanceSitemap(sitemaps.Sitemap):
-    priority = 1.0
+class InstanceSitemap(AplusSitemap):
     changefreq = 'daily'
+    base_priority = 0.4
 
     def items(self):
         return CourseInstance.objects.filter(
             view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            visible_to_students=True,
         )
 
-    def location(self, item):
-        return item.get_display_url()
 
-
-class ModuleSitemap(sitemaps.Sitemap):
-    priority = 0.2
+class ModuleSitemap(AplusSitemap):
     changefreq = 'daily'
+    base_priority = 0.2
 
     def items(self):
         return CourseModule.objects.filter(
             course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            course_instance__visible_to_students=True,
             opening_time__lte=timezone.now(),
         )
-
-    def location(self, item):
-        return item.get_display_url()
 
 
 all_sitemaps = {

--- a/exercise/sitemaps.py
+++ b/exercise/sitemaps.py
@@ -1,50 +1,47 @@
-from django.contrib import sitemaps
 from django.urls.base import reverse
 from django.utils import timezone
 
 from course.models import CourseInstance
+from lib.sitemaps import AplusSitemap
 from .models import BaseExercise, CourseChapter, LearningObject
 
 
-class BaseExerciseSitemap(sitemaps.Sitemap):
-    priority = 0.2
+class BaseExerciseSitemap(AplusSitemap):
     changefreq = 'daily'
+    base_priority = 0.5
 
     def items(self):
         return BaseExercise.objects.filter(
             course_module__course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            course_module__course_instance__visible_to_students=True,
             course_module__opening_time__lte=timezone.now(),
-            status__in=[LearningObject.STATUS.READY, LearningObject.STATUS.UNLISTED],
+            status=LearningObject.STATUS.READY,
             audience=LearningObject.AUDIENCE.COURSE_AUDIENCE,
+            parent__isnull=True,
         )
 
-    def location(self, item):
-        return item.get_display_url()
 
-
-class CourseChapterSitemap(sitemaps.Sitemap):
-    priority = 1.0
+class CourseChapterSitemap(AplusSitemap):
     changefreq = 'daily'
 
     def items(self):
         return CourseChapter.objects.filter(
             course_module__course_instance__view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            course_module__course_instance__visible_to_students=True,
             course_module__opening_time__lte=timezone.now(),
             status__in=[LearningObject.STATUS.READY, LearningObject.STATUS.UNLISTED],
             audience=LearningObject.AUDIENCE.COURSE_AUDIENCE,
         )
 
-    def location(self, item):
-        return item.get_display_url()
 
-
-class TableOfContentsSitemap(sitemaps.Sitemap):
-    priority = 0.2
+class TableOfContentsSitemap(AplusSitemap):
     changefreq = 'monthly'
+    base_priority = 0.2
 
     def items(self):
         return CourseInstance.objects.filter(
             view_content_to=CourseInstance.VIEW_ACCESS.PUBLIC,
+            visible_to_students=True,
         )
 
     def location(self, item):

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -30,6 +30,12 @@
 {% endblock %}
 {% endblock %}
 
+{% block meta %}
+{% if exercise.parent and exercise.status == exercise.STATUS.UNLISTED %}
+<meta name="robots" content="noindex">
+{% endif %}
+{% endblock %}
+
 {% block columns %}
 <div class="{% if exercise.use_wide_column %}col-lg-12{% else %}col-lg-9{% endif %} exercise-column">
 

--- a/lib/sitemaps.py
+++ b/lib/sitemaps.py
@@ -1,0 +1,45 @@
+import datetime
+
+from django.conf import settings
+from django.contrib import sitemaps
+from django.utils import timezone
+
+from course.models import CourseInstance, CourseModule
+from exercise.models import BaseExercise, CourseChapter
+
+
+class AplusSitemap(sitemaps.Sitemap):
+    # The base priority for pages from old courses.
+    # Pages of recent or upcoming courses have the base priority multiplied.
+    base_priority = 0.5
+
+    def is_recent_or_upcoming(self, item):
+        """
+        Return a boolean value indicating if the given item is open now
+        or if either the item's start date or end date is within a certain time delta from now.
+        """
+        if isinstance(item, CourseInstance):
+            start_date = item.starting_time
+            end_date = item.ending_time
+        elif isinstance(item, CourseModule):
+            start_date = item.opening_time
+            end_date = item.closing_time
+        elif isinstance(item, (BaseExercise, CourseChapter)):
+            start_date = item.course_module.opening_time
+            end_date = item.course_module.closing_time
+        else:
+            return False
+        now = timezone.now()
+        delta = datetime.timedelta(settings.SITEMAP_DELTA_DAYS_RECENT_OR_UPCOMING)
+        is_recent_or_upcoming = (
+            item.is_open(now)
+            or now - delta <= start_date <= now + delta
+            or now - delta <= end_date <= now + delta
+        )
+        return is_recent_or_upcoming
+
+    def location(self, item):
+        return item.get_display_url()
+
+    def priority(self, item):
+        return min(1.0, 2 * self.base_priority) if self.is_recent_or_upcoming(item) else self.base_priority

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,6 +66,10 @@
 	{# Put all additional scripts inside this block. #}
 	{% endblock %}
 
+	{% block meta %}
+	{# Put all additional meta data inside this block. #}
+	{% endblock %}
+
 	<!-- Some favicons courtesy of http://realfavicongenerator.net/ -->
 	<link rel="apple-touch-icon" sizes="57x57" href="{{ STATIC_URL }}favicons/apple-touch-icon-57x57.png">
 	<link rel="apple-touch-icon" sizes="114x114" href="{{ STATIC_URL }}favicons/apple-touch-icon-114x114.png">


### PR DESCRIPTION
# Description

**What?**

* Improve A+ Google search sitemaps with dynamic priorities, where old pages have lower priority than newer ones
* Assign zero priority to standalone exercise pages for exercises that are included in a course chapter. This is to hide the standalone exercise pages from Google search.

**Why?**

These improvements were suggested by a teacher.

**How?**

Edited the ``sitemap.py`` files. See the code.

Fixes #975


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the code does not produce errors by loading ``sitemap.xml`` in the browser.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.


# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
