### PR TITLE
Show hidden modules and exercises to teachers on "Your points" page

### DIFF
--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -24,7 +24,7 @@
 </p>
 
 {% for module in modules %}
-{% if module|is_visible %}
+{% if module|is_visible or is_teacher %}
 {% with open=module|exercises_open:now after_open=module|has_opened:now %}
 {% module_accessible module as accessible %}
 {% exercise_accessible module as exercise_accessible %}
@@ -51,6 +51,9 @@
 				{% translate "REQUIRES" %}:
 				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
 			</span>
+			{% endif %}
+			{% if not module|is_visible and is_teacher %}
+			<span class="label label-danger pull-right">{% translate "HIDDEN_capitalized" %}</span>
 			{% endif %}
 			<span class="caret" aria-hidden="true"></span>
 			{{ module.name|parse_localization }}
@@ -100,12 +103,12 @@
 				<th>{% translate "SUBMISSIONS" %}</th>
 				<th>{% translate "POINTS" %}</th>
 				{% if is_course_staff %}
-				<th colspan="2">{% translate "COURSE_STAFF" %}</th>
+				<th colspan="3">{% translate "COURSE_STAFF" %}</th>
 				{% endif %}
 			</tr>
 			{% for entry in module.flatted %}
 
-			{% if entry.submittable and entry|is_visible %}
+			{% if entry.submittable and entry|is_visible or entry.submittable and is_teacher %}
 			<tr data-category="{{ entry.category_id }}">
 				<td>
 					{% if exercise_accessible or is_course_staff %}
@@ -172,10 +175,15 @@
 						{% translate "VIEW_SUBMISSIONS" %}
 					</a>
 				</td>
+				<td>
+					{% if not entry|is_visible and is_teacher %}
+					<span class="label label-danger">{% translate "HIDDEN_capitalized" %}</span>
+					{% endif %}
+				</td>
 				{% endif %}
 			</tr>
 
-			{% elif entry.type == 'exercise' and entry|is_visible %}
+			{% elif entry.type == 'exercise' and entry|is_visible or entry.type == 'exercise' and is_teacher %}
 			<tr>
 				<td colspan="5">
 					{% if accessible %}
@@ -191,6 +199,11 @@
 						<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
 						{% translate "EARLY_ACCESS" %}
 					</a>
+					{% endif %}
+				</td>
+				<td>
+					{% if not entry|is_visible and is_teacher %}
+					<span class="label label-danger">{% translate "HIDDEN_capitalized" %}</span>
 					{% endif %}
 				</td>
 				{% endif %}


### PR DESCRIPTION
# Description

**What?**

Show hidden modules and exercises to teachers on "Your points" results page with a "hidden" label.

**Why?**

Teachers have requested easier access to hidden modules and exercises, such as enrollment questionnaires.

**How?**

Hidden modules are now shown to teachers and marked with a "hidden" label.

Fixes apluslms/a-plus-rst-tools#111
Fixes #449
Fixes #1012

# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Checked that everything works and looks good.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
