### PR TITLE
Add button to regenerate the API access token

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5505,6 +5505,14 @@ msgid "COPY"
 msgstr "Copy"
 
 #: userprofile/templates/userprofile/profile.html
+msgid "REGENERATE_API_ACCESS_TOKEN"
+msgstr "Generate a new API Access Token"
+
+#: userprofile/templates/userprofile/profile.html
+msgid "REGENERATE"
+msgstr "Regenerate"
+
+#: userprofile/templates/userprofile/profile.html
 msgid "AUTOMATIC_REDIRECTIONS"
 msgstr "Automatic redirections"
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -5524,6 +5524,14 @@ msgid "COPY"
 msgstr "Kopioi"
 
 #: userprofile/templates/userprofile/profile.html
+msgid "REGENERATE_API_ACCESS_TOKEN"
+msgstr "Generoi uusi API-käyttöoikeustietue"
+
+#: userprofile/templates/userprofile/profile.html
+msgid "REGENERATE"
+msgstr "Uudelleengeneroi"
+
+#: userprofile/templates/userprofile/profile.html
 msgid "AUTOMATIC_REDIRECTIONS"
 msgstr "Automaattiset uudelleenohjaukset"
 

--- a/userprofile/models.py
+++ b/userprofile/models.py
@@ -145,6 +145,13 @@ class UserProfile(models.Model):
         kwargs = dict(user_id=self.user.id, **instance.get_url_kwargs())
         return reverse('user-results', kwargs=kwargs)
 
+    def regenerate_api_token(self):
+        # FIXME: implement support for more than 1 token
+        token, created = Token.objects.get_or_create(user=self.user)
+        if not created:
+            token.delete()
+            Token.objects.create(user=self.user)
+
 
 def create_user_profile(sender, instance, created, **kwargs):
     """

--- a/userprofile/templates/userprofile/profile.html
+++ b/userprofile/templates/userprofile/profile.html
@@ -9,22 +9,22 @@
 
 {% block js-translations %}
 <link
-    data-translation
+	data-translation
 	rel="prefetch"
-    as="fetch"
-    crossorigin="anonymous"
-    type="application/json, */*;"
-    hreflang="fi"
-    href="{{ STATIC_URL }}js-translations/profile.fi.json"
+	as="fetch"
+	crossorigin="anonymous"
+	type="application/json, */*;"
+	hreflang="fi"
+	href="{{ STATIC_URL }}js-translations/profile.fi.json"
 >
 <link
-    data-translation
+	data-translation
 	rel="prefetch"
-    as="fetch"
-    crossorigin="anonymous"
-    type="application/json, */*;"
-    hreflang="fi"
-    href="{{ STATIC_URL }}js-translations/copy-to-clipboard.fi.json"
+	as="fetch"
+	crossorigin="anonymous"
+	type="application/json, */*;"
+	hreflang="fi"
+	href="{{ STATIC_URL }}js-translations/copy-to-clipboard.fi.json"
 >
 {% endblock %}
 
@@ -79,8 +79,18 @@
 				<button data-toggle="tooltip" data-placement="bottom"
 					title="{% translate 'COPY_API_ACCESS_TOKEN' %}" aria-label="{% translate 'COPY_API_ACCESS_TOKEN' %}"
 					class="aplus-button--secondary aplus-button--md js-copy" type="button"><span
-						class="glyphicon glyphicon-copy"></span><span class="">{% translate "COPY" %}</span></button>
+						class="glyphicon glyphicon-copy" aria-hidden="true"></span><span class="">{% translate "COPY" %}</span></button>
 			</span>
+		</div>
+		<div>
+			<form action="{% url 'regenerate-access-token' %}" method="post" class="form">{% csrf_token %}
+				<div class="form-group">
+					<button type="submit" data-toggle="tooltip" data-placement="bottom"
+						title="{% translate 'REGENERATE_API_ACCESS_TOKEN' %}" aria-label="{% translate 'REGENERATE_API_ACCESS_TOKEN' %}"
+						class="aplus-button--secondary aplus-button--md"><span
+							class="glyphicon glyphicon-refresh" aria-hidden="true"></span><span class="">{% translate "REGENERATE" %}</span></button>
+				</div>
+			</form>
 		</div>
 		<br>
 		<div>

--- a/userprofile/urls.py
+++ b/userprofile/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     url(r'^accounts/$', views.ProfileView.as_view(),
         name="profile"),
     url(r'^setlang', views.set_user_language, name="set-user-language"),
+    url(r'^regentoken/$', views.regenerate_access_token, name="regenerate-access-token"),
     url(r'^teachers/$', views.TeacherListView.as_view(), name="teachers"),
 ]

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 from urllib.parse import unquote
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
 from django.core.cache import cache
 from django.core.cache.utils import make_template_fragment_key
@@ -18,6 +19,7 @@ from django.utils.translation import (
 )
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext
+from django.views.decorators.http import require_POST
 
 from authorization.permissions import ACCESS
 from course.models import CourseInstance
@@ -73,7 +75,7 @@ class CustomLoginView(LoginView):
 
 
 def set_user_language(request):
-    """"Overrides set_language function from  django.views.i18n."""
+    """Overrides set_language function from django.views.i18n."""
     LANGUAGE_PARAMETER = 'language'
 
     next = remove_query_param_from_url(request.POST.get('next', request.GET.get('next')), 'hl')
@@ -109,6 +111,14 @@ def set_user_language(request):
                     domain=settings.LANGUAGE_COOKIE_DOMAIN,
                 )
     return response
+
+
+@login_required
+@require_POST
+def regenerate_access_token(request):
+    """Regenerates the API access token."""
+    request.user.userprofile.regenerate_api_token()
+    return HttpResponseRedirect(reverse('profile'))
 
 
 def try_get_template(name):


### PR DESCRIPTION
# Description

**What?**

Previously, it was not possible for the user to regenerate a new API token in the user interface.
The user profile view now has a button for regenerating one.

**Why?**

This makes it easier to generate a new API token.

**How?**

A button was added to the userprofile page for regenerating the token.

Fixes #1022


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that regenerating the API token works.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface?

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
