### PR TITLE
Fix duplicate check in exercises other than quiz or file submit

### DIFF
--- a/exercise/static/exercise/duplicate_check.js
+++ b/exercise/static/exercise/duplicate_check.js
@@ -60,7 +60,7 @@ function duplicateCheck(exercise, form_element, submitCallback) {
       }
     };
     readNextFile();
-  } else if (exercise.quiz) {
+  } else {
     const hash = md5(hashThis);
     openDuplicateModalOrSubmit(exercise, hashes, hash, submitCallback);
   }


### PR DESCRIPTION
# Description

**What?**

There was a bug where the exercise submit button did not do anything in exercises that were neither questionnaires or file submission exercises. This was due to a bug in the recently added duplicate submission checking feature.

This PR fixes the bug by removing the false expectation that the exercise has either files to submit or is a questionnaire.
Now the duplicate submission checking feature works on other types of exercises too, such as custom JavaScript exercises.

**Why?**

This was pointed out by a teacher in an internal ticket:
https://rt.cs.aalto.fi/Ticket/Display.html?id=21819

Fixes #1064