### PR TITLE
Submitters aren't lost when saving deviations

### DIFF
--- a/deviations/templates/deviations/add_dl.html
+++ b/deviations/templates/deviations/add_dl.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block columns %}
+
 <div class="col-md-12">
 	<form method="post" class="well form-horizontal">
 		{% csrf_token %}
@@ -20,10 +21,27 @@
 		{{ form|bootstrap_horizontal }}
 		<div class="form-group">
 			<div class="col-sm-10 col-sm-offset-2">
-				<button type="submit" class="aplus-button--default aplus-button--md">{% translate "SAVE" %}</button>
+				<button id="save-button" type="submit" class="aplus-button--default aplus-button--md">{% translate "SAVE" %}</button>
 				<a href="{{ instance|url:'deviations-list-dl' }}" class="aplus-button--secondary aplus-button--md" role="button">{% translate "CANCEL" %}</a>
 			</div>
 		</div>
 	</form>
 </div>
+<script>
+	$( document ).ready(function() {
+		let cachedHtml = localStorage.getItem("submitters") ? localStorage.getItem("submitters") : "";
+
+		//append the cached html to the submitters. If no cached data empty string is pushed resulting in no change
+		$("#id_submitter_wrapper > ul").append(cachedHtml)
+		localStorage.setItem("submitters", "");
+
+		//bind an event to the save button which stores the most recent values of the input to localStorage
+		$('#save-button').click(
+			function () {
+				//cache the list of submitters
+				localStorage.setItem("submitters", $("#id_submitter_wrapper > ul").html());
+			}
+		);
+	});
+</script>
 {% endblock %}


### PR DESCRIPTION
The list of submitters are cached in localStorage whenever the
save button is clicked. On page load, the localStorage is loaded,
and the list of submitters are added to the form.

Fixes #998

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

I tested different situations, such as refreshing the page, making sure a selected submitter was present after a save, and that no submitter was present after a page. I also made sure that users could still be deleted and wouldn't appear after a save.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [X] Other documentation (mention below which documentation).
I added comments as this was quite a small change
# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature


