### PR TITLE
_course_cards.html doesn't hide label when condensed

### DIFF
--- a/course/templates/course/_course_cards.html
+++ b/course/templates/course/_course_cards.html
@@ -26,7 +26,7 @@
 					</p>
 					<p class="card-text">
 						{{ instance.course.code }}
-						{% if not instance.visible_to_students and not condensed %}
+						{% if not instance.visible_to_students %}
    							<span class="label label-danger">{% translate "HIDDEN_FROM_STUDENTS" %}</span>
 						{% endif %}
 						<br />


### PR DESCRIPTION
Before, when the _course_cards.html was created by a parent and condensed was set to true, the hidden label would not be visible. Now condensed cards also show the label. This was done through removing the "and not condensed" condition from the card template

# Description

**What?**

The archive now shows the red "Hidden from students" label on course cards

**Why?**

It is useful for those with the permissions to see hidden courses (such as admins) to know that their courses are hidden

**How?**

Before, condensed cards would hide the label. I removed the condensed check (and not condensed) to prevent this from happening.

Fixes #727 

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

I added a course instance which was hidden, and ensured that this had the "Hidden From Students" label on it, and courses which weren't hidden didn't have this label (from the root account). I also ensured that this change did not make hidden instances visible to students.

**Did you test the changes in**

- [ ] Chrome
- [X ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

