### PR TITLE
Metadata values added to the modal in the submission inspection

### DIFF
--- a/exercise/templates/exercise/staff/_submission_data_modal.html
+++ b/exercise/templates/exercise/staff/_submission_data_modal.html
@@ -32,6 +32,16 @@
 					<dt>{% translate "NO_VALUES" %}</dt>
 					{% endfor %}
 				</dl>
+
+				<h4>{% translate "LABEL_META_DATA"|capfirst %}</h4>
+				<dl>
+					{% for key, value in submission.meta_data.items %}
+						<dt>{{ key }}</dt>
+						<dd>{{ value }}</dd>
+					{% empty %}
+						<dt>{% translate "NO_VALUES" %}</dt>
+					{% endfor %}
+				</dl>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
# Description

When inspecting a submission and opening the submission details modal, this modal did not have the meta_data field of the Submission model.

**Why?**
This can help admins and teachers debug issues

**How?**

In the modal template, we iterate over the key value pairs of the meta_data dictionary and display the keys and values.

Fixes #614 

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Made sure that the correct metadata values were displayed for the corresponding labels, ensured that the fallback (No values to display) works when the metadata is empty.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**


# Programming style
- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?


# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
