### PR TITLE
Clicking the label in a SearchSelectField focuses input

### DIFF
--- a/assets/js/ajax_search_select.js
+++ b/assets/js/ajax_search_select.js
@@ -140,6 +140,9 @@ $(function() {
         self.paste($(this).data("field"));
       });
 
+      //access the inner id of the hidden select, and set it as the input's id, so that
+      //the label refers to the input and clicking the label focuses the input
+      this.element.find('input')[0].id = this.inner_element[0].id
       this.inner_element.removeAttr('required');
     },
 


### PR DESCRIPTION


# Description

**What?**

This PR edits the ajax_search_select.js by adding the id the label refers to (<label for="id".../>) to the input of the field (<input id="id".../>) 

**Why?**

Before, when the label of a SearchSelectField was clicked, the input wouldn't be focused, although other types of fields had this behavior, which is bad user experience.

**How?**

We access the hidden select's id through the inner_element attribute. We then find the child input of the element and set it's id to the hidden select's id.

Fixes #934 

# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

Double clicking the label and ensuring that this focused the input, analyzing the DOM and ensuring that only the input was changed and that the input had a new id and nothing else

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.


# Style 

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature


