### PR TITLE
Added support for MathJax 3.x

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -503,7 +503,7 @@ $(function() {
                         modal.trigger("opened.aplus.modal");
                         // render math in the modal
                         if (typeof window.MathJax !== "undefined") {
-                            window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, modal.get(0)]);
+                          modal.aplusTypesetMath();
                         }
                     }
                 }).fail(function() {
@@ -520,6 +520,30 @@ $(function() {
             }
         });
     };
+})(jQuery, window);
+
+
+(function($, window) {
+  "use strict";
+
+  const pluginName = "aplusTypesetMath";
+  $.fn[pluginName] = function() {
+    if (typeof window.MathJax === "undefined") {
+      return;
+    }
+    switch (window.MathJax.version[0]) {
+      case "2":
+        window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, this.get()]);
+        break;
+      case "3":
+        window.MathJax.typesetPromise(this.get()).catch((err) =>
+          console.error(err)
+        );
+        break;
+      default:
+        console.error("Unsupported version of MathJax, use 2.x or 3.x!");
+    }
+  };
 })(jQuery, window);
 
 /**

--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -104,10 +104,7 @@
     },
 
     renderMath: function() {
-      if (typeof window.MathJax === "undefined") {
-        return;
-      }
-      window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, this.modalElement.get(0)]);
+      this.modalElement.aplusTypesetMath();
     },
   });
 
@@ -859,10 +856,7 @@
     },
 
     renderMath: function() {
-      if (typeof window.MathJax === "undefined") {
-        return;
-      }
-      window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub, this.element.get(0)]);
+      this.element.aplusTypesetMath();
     },
   });
 


### PR DESCRIPTION
This commit does not break the support for MathJax 2.x. Rather than unconditionally using the 2.x API (Hub.Queue([])) we instead check the version of MathJax and either use the old Hub.Queue implementation or the new promise based implementation of 3.x (MathJax.typesetPromise()). This conditional typesetting is defined once as a jQuery plugin in assets/js/aplus.js. This plugin expects the HTML element which should be typeset.

Fixes #871

# Description

**What?**

Added support for MathJax 3.x without breaking compatibility 2.x.

**Why?**
According to the MathJax documentation, 2.x will only be maintained and there will be no further development. 

"MathJax v2 will continue to be maintained as we work to move more features into version 3, but MathJax v2 likely will not see much further development, just maintenance, once MathJax v3 is fully converted."
https://docs.mathjax.org/en/v3.2-latest/upgrading/v2.html


**How?**

Added a jQuery plugin in assets/js/aplus.js which typesets conditionally based on the version of MathJax which was loaded in the html of the build.

Fixes #871 


# Testing





**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

I edited an HTML file which used MathJax in aplus-manual (_build/programming_exercises/hello_world.html) and changed the version of MathJax to 3.2.2 by editing the src attribute of the script tag which loads MathJax. This allowed me to test whether a 3.x version of MathJax worked. I also changed the script tag back to 2.7.7 to ensure that 2.x version of MathJax still work with the new changes.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?


# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
