### PR TITLE
Added tooltips to show model solutions buttons

### DIFF
--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -151,7 +151,7 @@
 							open it due to personal extensions. However, this saves some database queries.
 							{% endcomment %}
 							{% if exercise.model_answers %}
-								<a class="aplus-button--secondary aplus-button--xs page-modal" role="button" href="{{ exercise|url:'exercise-model' }}">
+								<a class="aplus-button--secondary aplus-button--md page-modal" role="button" href="{{ exercise|url:'exercise-model' }}">
 									<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
 									{% translate "SHOW_MODEL_ANSWER" %}
 								</a>
@@ -159,14 +159,14 @@
 						{% endif %}
 						{% if is_course_staff or is_student %}
 							{% if exercise.templates %}
-								<a class="aplus-button--secondary aplus-button--xs page-modal" role="button" href="{{ exercise|url:'exercise-template' }}">
+								<a class="aplus-button--secondary aplus-button--md page-modal" role="button" href="{{ exercise|url:'exercise-template' }}">
 									<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
 									{% translate "SHOW_EXERCISE_TEMPLATE" %}
 								</a>
 							{% endif %}
 						{% endif %}
 						{% if is_course_staff %}
-							<a class="aplus-button--secondary aplus-button--xs page-modal" role="button" href="{{ exercise|url:'submission-list' }}">
+							<a class="aplus-button--secondary aplus-button--md page-modal" role="button" href="{{ exercise|url:'submission-list' }}">
 								<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
 								{% translate "VIEW_ALL_SUBMISSIONS" %}
 							</a>


### PR DESCRIPTION
Added a bootstrap tooltip to the "Show model solutions" button. The tooltips are only shown once to the user through the use of localStorage. This is to prevent the tooltips from becoming annoying, and there is no reason to draw attention to the tooltips more than once.

Fixes #856

# Description

**What?**

The first time the client comes across a "show model solutions" button, this button has a tooltip bringing the users attention to it.

**Why?**

There were reports that users didn't notice the model solutions button. By adding the tooltip users should notice this button better. By only showing this button once we also avoid this from becoming annoying and distracting.

**How?**

We first check if the user has seen the model solutions tooltips before. This can be checked from the user's localStorage, based on the value of model-solutions-tooltip-shown. If this isn't true, we register an event listener for all ajax requests to finish. This means that all exercises have loaded. We then check if any of these exercises have the "Show model solutions" button in them. If this is the case, we enable the tooltips on these buttons, and set the value of model-solutions-tooltip-shown to true. 

Fixes #856 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

I tested multiple cases. The 6.3 module has multiple model solutions buttons, so I ensured that these have tooltips on first load. After a refresh, I ensured that no tooltips were visible, and that the localStorage had model-solutions-tooltip-shown set to true. I also ensured that model-solutions-tooltip-shown was not set to true in module 6.1, which has no "Show model solutions" buttons.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
