### PR TITLE
Anchor links work even when page height changes

### DIFF
--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -66,6 +66,27 @@
         this.dom_element.dispatchEvent(
           new CustomEvent("aplus:exercise-ready", {bubbles: true, detail: {type: type}}));
       }
+
+      this.consecutiveScrollEvents = 0;
+
+      // Only register the events related to anchor links when there's a hash
+      // (e.g., #chapter-exercise-3)
+      const hash = window.location.hash;
+      if (hash) {
+        const hashScrollListener = () => {
+          this.consecutiveScrollEvents++;
+          // If there are 3 consecutive scroll events, then the user tried to manually scroll
+          // and we should stop focusing on the exercise which was referred to by the hash.
+          if (3 < this.consecutiveScrollEvents) {
+            window.removeEventListener("scroll", hashScrollListener);
+          } else {
+            // Otherwise, keep focusing on the referenced exercise.
+            location.hash = hash;
+          }
+        };
+
+        window.addEventListener("scroll", hashScrollListener);
+      }
     },
 
     nextExercise: function() {
@@ -75,6 +96,10 @@
       }
       this.dom_element.dispatchEvent(
         new CustomEvent("aplus:chapter-ready", {bubbles: true}));
+
+      // Loading an exercise triggers a scroll event, but it isn't manual so
+      // consecutiveScrollEvents is reset.
+      this.consecutiveScrollEvents = 0;
     },
 
     readMessages: function() {

--- a/exercise/templates/exercise/exercise.html
+++ b/exercise/templates/exercise/exercise.html
@@ -11,13 +11,13 @@
 
 {% block js-translations %}
 <link
-    data-translation
-    rel="preload"
-    as="fetch"
-    crossorigin="anonymous"
-    type="application/json"
-    hreflang="fi"
-    href="{{ STATIC_URL }}js-translations/exercise.fi.json"
+	data-translation
+	rel="preload"
+	as="fetch"
+	crossorigin="anonymous"
+	type="application/json"
+	hreflang="fi"
+	href="{{ STATIC_URL }}js-translations/exercise.fi.json"
 >
 {% endblock %}
 
@@ -28,32 +28,32 @@
 {% endif %}
 
 <div
-    id="exercise-page-content"
-    {% if exercise.is_submittable %}
-        data-aplus-chapter="{{ exercise|url }}"
-        data-aplus-group="{{ exercise.min_group_size }}-{{ exercise.max_group_size }}"
-        {% if summary.get_submission_count > 0 %}
-            data-aplus-group-fixed="{{ summary.get_group_id }}"
-        {% endif %}
-    {% endif %}
+	id="exercise-page-content"
+	{% if exercise.is_submittable %}
+		data-aplus-chapter="{{ exercise|url }}"
+		data-aplus-group="{{ exercise.min_group_size }}-{{ exercise.max_group_size }}"
+		{% if summary.get_submission_count > 0 %}
+			data-aplus-group-fixed="{{ summary.get_group_id }}"
+		{% endif %}
+	{% endif %}
 >
-  {% if latest_enrollment_submission_data %}
-    {{ latest_enrollment_submission_data|json_script:"enroll-submission-data" }}
-  {% endif %}
-  <div class="overlay-parent">
-    {% if issues and not submission_allowed %}
-        {% include 'exercise/_warnings_overlay.html' %}
-    {% endif %}
-    <div {% if disable_submit %}data-aplus-disable-submit="true"{% endif %}>
-      {{ page.content|safe }}
-    </div>
-  </div>
+	{% if latest_enrollment_submission_data %}
+		{{ latest_enrollment_submission_data|json_script:"enroll-submission-data" }}
+	{% endif %}
+	<div class="overlay-parent">
+		{% if issues and not submission_allowed %}
+			{% include 'exercise/_warnings_overlay.html' %}
+		{% endif %}
+		<div {% if disable_submit %}data-aplus-disable-submit="true"{% endif %}>
+			{{ page.content|safe }}
+		</div>
+	</div>
 </div>
 
 <div id="submit-progress" class="hide progress">
-  <div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;">
-    {% translate "POSTING_SUBMISSION" %}
-  </div>
+	<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;">
+		{% translate "POSTING_SUBMISSION" %}
+	</div>
 </div>
 
 {% include "exercise/_exercise_wait.html" %}
@@ -61,10 +61,10 @@
 {% include "exercise/_duplicate_submission_modal.html" %}
 
 <div id="loading-indicator" class="hide progress"
-  data-msg-load="{% translate 'LOADING_EXERCISE' %}"
-  data-msg-submit="{% translate 'POSTING_SUBMISSION' %}"
-  data-msg-error="{% translate 'EXERCISE_ERROR_COMMUNICATION' %}">
-  <div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;"></div>
+	data-msg-load="{% translate 'LOADING_EXERCISE' %}"
+	data-msg-submit="{% translate 'POSTING_SUBMISSION' %}"
+	data-msg-error="{% translate 'EXERCISE_ERROR_COMMUNICATION' %}">
+	<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;"></div>
 </div>
 {% endblock %}
 
@@ -79,27 +79,27 @@
 <script src="{% static 'exercise/duplicate_check.js' %}"></script>
 <script src="{% static 'exercise/chapter.js' %}"></script>
 <script
-    src="{% static 'exercise/language_link.js' %}"
-    data-set-lang="{{ instance|url:'set-enrollment-language' }}"></script>
+	src="{% static 'exercise/language_link.js' %}"
+	data-set-lang="{{ instance|url:'set-enrollment-language' }}"></script>
 <script>
 // Visualize loading in case of slow POST operations.
 /*$(function() {
-    var forms = $("#exercise-page-content").find("form:not([data-aplus-exercise] form)");
-    forms.on("submit", function(event) {
-        $("#submit-progress").removeClass("hide");
-    });
+	var forms = $("#exercise-page-content").find("form:not([data-aplus-exercise] form)");
+	forms.on("submit", function(event) {
+		$("#submit-progress").removeClass("hide");
+	});
 });*/
 
 // Add an Ajax exercise event listener to refresh the info column.
 window.addEventListener("message", function (event) {
-    if (event.data.type === "a-plus-refresh-stats") {
-        $("#submit-progress").addClass("hide");
-        var $stats = $("#exercise-info"),
-            url = $stats.data("url");
-        $stats.load(url, function() {
-            $stats.find('[data-toggle="tooltip"]').tooltip();
-        });
-    }
+	if (event.data.type === "a-plus-refresh-stats") {
+		$("#submit-progress").addClass("hide");
+		var $stats = $("#exercise-info"),
+			url = $stats.data("url");
+		$stats.load(url, function() {
+			$stats.find('[data-toggle="tooltip"]').tooltip();
+		});
+	}
 });
 </script>
 {{ page.head|safe }}


### PR DESCRIPTION
By using an ajaxComplete exercises maintain position on the exercise even as content loads. The scroll listener allows the user to scroll freely and prevent the repeated focusing on the exercise as content loads.

Fixes #1028


# Description

**What?**

This change ensures that when the user clicks on a anchor link referencing an exercise (such as #chapter-exercise-1) the focus remains on the referenced exercise even when content loads and the page height changes.

*No user scrolling*
![no_scroll](https://user-images.githubusercontent.com/46625399/191065272-c984a674-8a78-4c3b-8167-7b0e126761d4.gif)


*With user scrolling (focusing on the exercise disables as soon as scrolling is detected)*
![scroll](https://user-images.githubusercontent.com/46625399/191064866-8665bfd6-18e8-4606-a260-690efb833a1b.gif)

**Why?**

Before, when a user clicked on an anchor link and content above loaded, the page would scroll and the exercise which was referenced by the link would move down either off screen or out of focus of the user which can cause confusion.

**How?**

As exercises load, the ajaxComplete listener is triggered. Whenever ajaxComplete triggers,  we set the users scroll position to the new position of the referenced exercise. We also created a scroll listener, which prevents repeated focusing on the referenced exercise if the user scrolls manually. We detect manual scrolling if there are 3 consecutive scroll events with no ajaxComplete events in between, as exercises loading triggers the scroll event.

Fixes #1028 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

I tested the O1 course locally, which had issues with focusing on exercises. I ensured that on both Firefox and Chrome that with no scrolling, clicking on a link with a chapter exercise anchor reference resulted in the browser constantly focusing the correct referenced exercise. I also ensured that the moment the user tries to scroll that the browser stops trying to maintain focus on the exercise. 

**Did you test the changes in**

- [X] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?


# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
