### PR TITLE
Add caching to /courses/<course_id>/exercises/

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -1319,11 +1319,15 @@ class CourseModule(UrlMixin, models.Model):
         if errors:
             raise ValidationError(errors)
 
-    def is_open(self, when=None):
+    @staticmethod
+    def check_is_open(reading_opening_time, opening_time, closing_time, when=None):
         when = when or timezone.now()
-        if self.reading_opening_time:
-            return self.reading_opening_time <= when <= self.closing_time
-        return self.opening_time <= when <= self.closing_time
+        if reading_opening_time:
+            return reading_opening_time <= when <= closing_time
+        return opening_time <= when <= closing_time
+
+    def is_open(self, when=None):
+        return self.check_is_open(self.reading_opening_time, self.opening_time, self.closing_time, when=when)
 
     def is_after_open(self, when=None):
         """


### PR DESCRIPTION
Fixes #1084 

# Description
This change adds caching to the CourseExercisesViewSet endpoint. The outputs of the endpoint (with caching) are shown below.

/api/v2/courses/1/exercises/
https://gist.github.com/EerikSaksi/fef85032e20e45b09f98f2851cc780b5

/api/v2/courses/1/exercises/1/
https://gist.github.com/EerikSaksi/caaeca53237b08f0acf8c16ee316582e

/api/v2/courses/1/exercises/123456/
https://gist.github.com/EerikSaksi/63378e65211c39f89cc2c4aaa400d924


**Why?**
It is inefficient to fetch the exercises for every user from the database separately. This change saves the exercises in memory to make this endpoint more efficient, and to reduce load on the database.

**How?**
Below are details of all the changes this request introduces, as well as possible improvements which could be considered before this is merged.


***exercise/content/cache.py***
_generate_data now returns a new variable, exercises. exercises is generated from the modules variable. Although this works this could possibly be done better. This implementation even requires a temporary modification of the modules variable (adding is_open to every module which is then removed once exercises is generated). It might be better to not derive exercises from modules for maintainability and for readability, but this was an easy way to do it as modules was well structured and easy to use.

***course/api/views.py***
In this file we modify CourseExercisesViewSet to instead use the cache, rather than the database. We also add support for fetching just one module's exercises with the retrieve function.

***course/api/full_serializers.py***
Here we modify CourseModuleSerializer to process the dictionary data and ModuleExerciseSerializer to serializer the exercises of each module. This works, but there might be a better way to do this which makes better use of existing serializers.




Fixes #1084 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

I ran diff on the output of the old and new API output. The only difference I found was that the order of some of the exercises were different. The output using the caching seems to order the exercises correclyt (5.1.1, 5.1.2 ... 5.1.9).

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
