### PR TITLE
Fix chapter exercise feedback modal missing focus after duplicate check

### DIFF
--- a/exercise/static/exercise/duplicate_check.js
+++ b/exercise/static/exercise/duplicate_check.js
@@ -6,9 +6,10 @@ function openDuplicateModalOrSubmit(exercise, hashes, hash, submitCallback) {
     // Unbind previous event handlers and bind a new one
     $("#duplicate-submission-modal-button").off('click');
     $("#duplicate-submission-modal-button").click(function() {
+      $("#duplicate-submission-modal").modal('hide');
       submitCallback(exercise, hash);
     });
-    $("#duplicate-submission-modal").modal()
+    $("#duplicate-submission-modal").modal('show');
   } else {
     submitCallback(exercise, hash);
   }


### PR DESCRIPTION
# Description

**What?**

Fix the bug where after submitting to a chapter exercise, the feedback modal was not scrollable if duplicate submission confirmation modal appeared first.

**Why?**

This was an annoying bug that prevented from scrolling the exercise feedback.

**How?**

The duplicate submission modal is now hidden before the exercise feedback modal is opened, which causes the exercise feedback modal to have focus as it should.

Fixes #1093

# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the modals have correctly working focus now.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.


# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
