### PR TITLE
Fix duplicate submission check crashing with optional files

### DIFF
--- a/exercise/static/exercise/duplicate_check.js
+++ b/exercise/static/exercise/duplicate_check.js
@@ -43,7 +43,13 @@ function duplicateCheck(exercise, form_element, submitCallback) {
 
     let index = 0;
     function readNextFile() {
-      const file = inputFileElements[index++].files[0];
+      let file;
+      const fileList = inputFileElements[index++].files;
+      if (fileList.length > 0) {
+        file = fileList[0];
+      } else {
+        file = new File([""], "filename");
+      }
       reader.readAsText(file);
     };
     reader.onload = function() {


### PR DESCRIPTION
# Description

**What?**

Fix duplicate submission check JavaScript crashing when the exercise submission form included optional file upload fields and the user did not select any file.

**Why?**

The code should not crash when optional files are not selected.

**How?**

Optional files that aren't selected are now treated as empty files by the duplicate submission check code.

Fixes #1095


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the code now works as intended.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
