### PR TITLE
Use A+ as an LTI 1.3 tool

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -139,6 +139,7 @@ INSTALLED_APPS = (
     'bootstrapform',
     'rest_framework',
     'rest_framework.authtoken',
+    'pylti1p3.contrib.django.lti1p3_tool_config',
 
     # First party applications
     'inheritance',
@@ -155,6 +156,7 @@ INSTALLED_APPS = (
     'diploma',
     'apps',
     'redirect_old_urls',
+    'lti_tool',
 
     'js_jquery_toggle',
     'django_colortag',

--- a/aplus/urls.py
+++ b/aplus/urls.py
@@ -18,6 +18,7 @@ import diploma.urls
 import apps.urls
 import api.urls_v2
 import redirect_old_urls.urls
+import lti_tool.urls
 
 
 admin.autodiscover()
@@ -44,6 +45,7 @@ urlpatterns = [
     url(r'^', include(deviations.urls)),
     url(r'^', include(edit_course.urls)),
     url(r'^', include(notification.urls)),
+    url(r'^', include(lti_tool.urls)),
     url(r'^', include(exercise.urls)),
     url(r'^', include(course.urls)),
     path('sitemap.xml', sitemap, { 'sitemaps': all_sitemaps },

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -32,6 +32,7 @@
 
 {% block content %}
 <div data-taggings="{{ get_taggings|join:' ' }}" class="row">
+	{% block course_sidebar %}
 	<button
 		class="hidden hidden-xs course-sidebar-expander"
 		title="{% translate 'OPEN_SIDEBAR' %}"
@@ -72,6 +73,7 @@
 		</div>
 		{% endcomment %}
 	</div>
+	{% endblock course_sidebar %}
 	<div class="col-sm-10" id="course-content">
 		{% if instance.is_past and instance.has_enrollment_closed %}
 			<div class="alert sticky-alert alert-default">

--- a/exercise/protocol/aplus.py
+++ b/exercise/protocol/aplus.py
@@ -9,6 +9,8 @@ from lib.email_messages import email_course_error
 from lib.remote_page import RemotePage, RemotePageException
 from .exercise_page import ExercisePage
 
+from lti_tool.utils import send_lti_points
+
 
 if TYPE_CHECKING:
     from exercise.models import LearningObject
@@ -111,6 +113,8 @@ def load_feedback_page(request, url, exercise, submission, no_penalties=False):
                 exercise.service_url)
             page.errors.append(_('ASSESSMENT_SERVICE_ERROR_RESPONDED_ERROR'))
         submission.save()
+        if page.is_graded and page.is_sane() and submission.lti_launch_id:
+            send_lti_points(request, submission)
 
     return page
 

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -238,6 +238,9 @@ class SubmissionManager(JWTAccessible["Submission"], models.Manager):
             meta_data_dict['lang'] = get_language()
 
         try:
+            meta_data_dict['lti-launch-id'] = request.session.get("lti-launch-id")
+            meta_data_dict['lti-session-id'] = request.COOKIES.get('lti1p3-session-id')
+
             new_submission = Submission.objects.create(
                 exercise=exercise,
                 submission_data=submission_data_list,
@@ -626,6 +629,13 @@ class Submission(UrlMixin, models.Model):
         """Is this submission late or unofficial so that it could be approved?"""
         return (self.late_penalty_applied is not None
             or self.status == self.STATUS.UNOFFICIAL)
+
+    @property
+    def lti_launch_id(self):
+        try:
+            return self.meta_data.get('lti-launch-id')
+        except AttributeError:
+            return None
 
     ABSOLUTE_URL_NAME = "submission"
 

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -42,7 +42,7 @@
 	{% if exercise.is_submittable %}
 	<ul class="nav nav-tabs">
 			<li class="menu-exercise">
-					<a href="{{ current.link }}">
+					<a href="{{ exercise|url:exercise_url_name }}">
 							{% translate "EXERCISE_DESCRIPTION" %}
 					</a>
 			</li>
@@ -56,7 +56,7 @@
 					<ul class="dropdown-menu">
 							{% for submission in submissions %}
 							<li>
-									<a href="{{ submission|url }}" data-hash="{{ submission.meta_data.hash }}">
+									<a href="{{ submission|url:submission_url_name }}" data-hash="{{ submission.meta_data.hash }}">
 											{{ forloop.revcounter }}.
 											{{ submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}
 											{% points_badge submission is_revealed=feedback_revealed %}

--- a/exercise/templates/exercise/submission.html
+++ b/exercise/templates/exercise/submission.html
@@ -48,8 +48,10 @@
 		{% translate "NO_GRADER_FEEDBACK_FOR_SUBMISSION" %}
 	</div>
 	{% endif %}
-	{% include "exercise/_exercise_wait.html" %}
+{% endblock %}
 
+{% block exercise_wait %}
+	{% include "exercise/_exercise_wait.html" %}
 {% endblock %}
 
 {% block scripts %}

--- a/exercise/viewbase.py
+++ b/exercise/viewbase.py
@@ -100,6 +100,8 @@ class ExerciseMixin(ExerciseRevealRuleMixin, ExerciseBaseMixin, CourseModuleMixi
     exercise_permission_classes = ExerciseBaseMixin.exercise_permission_classes + (
         BaseExerciseAssistantPermission,
     )
+    submission_url_name = 'submission'
+    exercise_url_name = 'exercise'
 
     def get_exercise_object(self):
         try:
@@ -120,7 +122,7 @@ class ExerciseMixin(ExerciseRevealRuleMixin, ExerciseBaseMixin, CourseModuleMixi
         self.current = cur
         self.next = nex
         self.breadcrumb = tree[1:-1]
-        self.note("now", "previous", "current", "next", "breadcrumb")
+        self.note("now", "previous", "current", "next", "breadcrumb", "submission_url_name", "exercise_url_name")
 
     def get_summary_submissions(self, user: Optional[User] = None) -> None:
         self.summary = UserExerciseSummary(

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -198,7 +198,9 @@ class ExerciseView(BaseRedirectMixin, ExerciseBaseView, EnrollableViewMixin):
 
                 # Redirect non AJAX normally to submission page.
                 if not request.is_ajax() and "__r" not in request.GET:
-                    return self.redirect(new_submission.get_absolute_url() +
+                    # LTI based views require redirection to LTI specific views
+                    redirect_view = kwargs.get('redirect_view')
+                    return self.redirect(new_submission.get_absolute_url(view_override=redirect_view) +
                         ("?wait=1" if page.is_wait else ""))
 
                 # "grade" returns the submission feedback page. If feedback is

--- a/lib/models.py
+++ b/lib/models.py
@@ -10,7 +10,9 @@ class UrlMixin(object):
     def get_display_url(self):
         return self.get_absolute_url()
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, view_override=None):
+        if view_override:
+            return self.get_url(view_override)
         if not hasattr(self, 'ABSOLUTE_URL_NAME'):
             raise NotImplementedError("Model %r doesn't have absolute url" % self)
         return self.get_url(self.ABSOLUTE_URL_NAME)

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-24 18:19+0200\n"
+"POT-Creation-Date: 2022-12-13 12:10+0200\n"
 "PO-Revision-Date: 2021-05-27 14:47+0300\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: English<>\n"
@@ -1071,6 +1071,7 @@ msgstr "Pagination"
 #: exercise/templates/exercise/_children.html
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "EARLY_ACCESS"
 msgstr "Early access"
 
@@ -1202,12 +1203,14 @@ msgstr "There are currently no ongoing courses."
 
 #: course/templates/course/module.html
 #: exercise/templates/exercise/_user_results.html
+#: lti_tool/templates/lti_tool/lti_module.html
 #, python-format
 msgid "LATE_SUBMISSIONS_ALLOWED_UNTIL -- %(deadline)s"
 msgstr "Late submissions are allowed until %(deadline)s. "
 
 #: course/templates/course/module.html
 #: exercise/templates/exercise/_user_results.html
+#: lti_tool/templates/lti_tool/lti_module.html
 #, python-format
 msgid "LATE_SUBMISSION_POINTS_WORTH -- %(percent)s"
 msgstr "However, points are only worth %(percent)s%%. "
@@ -3817,6 +3820,7 @@ msgstr "Total number of submitters"
 
 #: exercise/templates/exercise/_exercise_wait.html
 #: exercise/templates/exercise/exercise.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
 "There was a problem loading the assignment. Try loading the page again "
@@ -3825,12 +3829,14 @@ msgstr ""
 "staff."
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "EXERCISE_ERROR_GRADING_TIMEOUT"
 msgstr ""
 "Unfortunately grading takes longer than expected. Return later to see the "
 "result."
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "GRADING_SUBMISSION"
 msgstr "Grading submission..."
 
@@ -4001,6 +4007,7 @@ msgstr "Open for reading"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "REQUIRES"
 msgstr "Requires"
 
@@ -4038,6 +4045,7 @@ msgid "INSPECT"
 msgstr "Inspect"
 
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "OPENS"
 msgstr "Opens"
 
@@ -5182,6 +5190,36 @@ msgstr "Connecting to the course service failed with {code}!"
 #: lib/validators.py
 msgid "URL_KEY_MAY_CONSIST_OF"
 msgstr "URL keys may consist of alphanumeric characters, hyphen and period."
+
+#: lti_tool/templates/lti_tool/course_list.html
+msgid "LTI_SELECT_COURSE"
+msgstr "Select course"
+
+#: lti_tool/templates/lti_tool/course_list.html
+msgid "LTI_USE_WHOLE_COURSE"
+msgstr "Use the whole course"
+
+#: lti_tool/templates/lti_tool/course_list.html
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_SELECT_SPECIFIC_CONTENT"
+msgstr "Select specific content"
+
+#: lti_tool/templates/lti_tool/exercise_list.html
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_GO_BACK"
+msgstr "Go back"
+
+#: lti_tool/templates/lti_tool/exercise_list.html
+msgid "LTI_SELECT_CHAPTER_OR_EXERCISE"
+msgstr "Select chapter or exercise"
+
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_SELECT_MODULE"
+msgstr "Select module"
+
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_USE_WHOLE_MODULE"
+msgstr "Use the whole module"
 
 #: news/forms.py
 msgid "SEND_EMAIL_TO_STUDENTS"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-24 18:19+0200\n"
+"POT-Creation-Date: 2022-12-13 12:10+0200\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -1078,6 +1078,7 @@ msgstr "Sivuilla siirtyminen"
 #: exercise/templates/exercise/_children.html
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "EARLY_ACCESS"
 msgstr "Aikainen pääsy"
 
@@ -1210,12 +1211,14 @@ msgstr "Tällä hetkellä ei ole meneillään olevia kursseja."
 
 #: course/templates/course/module.html
 #: exercise/templates/exercise/_user_results.html
+#: lti_tool/templates/lti_tool/lti_module.html
 #, python-format
 msgid "LATE_SUBMISSIONS_ALLOWED_UNTIL -- %(deadline)s"
 msgstr "Myöhästyneitä palautuksia vastaanotetaan %(deadline)s asti."
 
 #: course/templates/course/module.html
 #: exercise/templates/exercise/_user_results.html
+#: lti_tool/templates/lti_tool/lti_module.html
 #, python-format
 msgid "LATE_SUBMISSION_POINTS_WORTH -- %(percent)s"
 msgstr "Pisteiden arvo on %(percent)s%% ajoissa palautetusta."
@@ -3826,6 +3829,7 @@ msgstr "Palauttaneita opiskelijoita yhteensä"
 
 #: exercise/templates/exercise/_exercise_wait.html
 #: exercise/templates/exercise/exercise.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
 "Tehtävän lataaminen epäonnistui. Yritä uudelleen myöhemmin. "
@@ -3834,12 +3838,14 @@ msgstr ""
 "kurssihenkilökuntaan."
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "EXERCISE_ERROR_GRADING_TIMEOUT"
 msgstr ""
 "Valitettavasti arvostelu kestää odotettua kauemmin. Palaa myöhemmin "
 "katsomaan palautetta."
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: lti_tool/templates/lti_tool/_lti_exercise_wait.html
 msgid "GRADING_SUBMISSION"
 msgstr "Palautusta arvostellaan..."
 
@@ -4013,6 +4019,7 @@ msgstr "Lukumateriaali avoinna"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "REQUIRES"
 msgstr "Vaaditaan"
 
@@ -4050,6 +4057,7 @@ msgid "INSPECT"
 msgstr "Tutki"
 
 #: exercise/templates/exercise/_user_toc.html
+#: lti_tool/templates/lti_tool/lti_course.html
 msgid "OPENS"
 msgstr "Avautuu"
 
@@ -5205,6 +5213,36 @@ msgstr "Yhteys kurssipalveluun epäonnistui virheellä {code}!"
 msgid "URL_KEY_MAY_CONSIST_OF"
 msgstr ""
 "URL-avaimet voivat sisältää kirjaimia, numeroita, yhdysmerkin ja pisteen."
+
+#: lti_tool/templates/lti_tool/course_list.html
+msgid "LTI_SELECT_COURSE"
+msgstr "Valitse kurssi"
+
+#: lti_tool/templates/lti_tool/course_list.html
+msgid "LTI_USE_WHOLE_COURSE"
+msgstr "Valitse koko kurssi"
+
+#: lti_tool/templates/lti_tool/course_list.html
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_SELECT_SPECIFIC_CONTENT"
+msgstr "Valitse tarkempaa sisältöä"
+
+#: lti_tool/templates/lti_tool/exercise_list.html
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_GO_BACK"
+msgstr "Takaisin"
+
+#: lti_tool/templates/lti_tool/exercise_list.html
+msgid "LTI_SELECT_CHAPTER_OR_EXERCISE"
+msgstr "Valitse luku tai tehtävä"
+
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_SELECT_MODULE"
+msgstr "Valitse moduuli"
+
+#: lti_tool/templates/lti_tool/module_list.html
+msgid "LTI_USE_WHOLE_MODULE"
+msgstr "Valitse koko moduuli"
 
 #: news/forms.py
 msgid "SEND_EMAIL_TO_STUDENTS"

--- a/lti_tool/templates/lti_tool/_lti_exercise_wait.html
+++ b/lti_tool/templates/lti_tool/_lti_exercise_wait.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load course %}
+{% if page.is_wait %}
+<div class="exercise-wait hide progress"
+	data-poll-url="{{ submission|url:'lti-submission-poll' }}"
+	data-msg-error="{% translate 'EXERCISE_ERROR_COMMUNICATION' %}"
+	data-msg-timeout="{% translate 'EXERCISE_ERROR_GRADING_TIMEOUT' %}">
+	<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;">
+		{% translate "GRADING_SUBMISSION" %}
+	</div>
+</div>
+{% endif %}

--- a/lti_tool/templates/lti_tool/course_list.html
+++ b/lti_tool/templates/lti_tool/course_list.html
@@ -1,0 +1,55 @@
+{% extends "lti_tool/lti_base.html" %}
+
+{% load i18n %}
+{% load base %}
+{% load course %}
+{% load static %}
+
+{% block content %}
+<h2 id="heading">{% translate "LTI_SELECT_COURSE" %}</h2>
+<section aria-labelledby="heading" class="frontpage frontpage-section">
+	<div class="cards">
+		{% for instance in instances %}
+		{% with instance_url=instance|url:"lti-select-course" %}
+			<div class="frontpage card">
+				<div>
+					<div class="card-body">
+						<h3 lang="{{ instance.language }}">
+							{{ instance.course.name|parse_localization }}<br />
+						</h3>
+						<p class="card-subtitle" lang="{{ instance.language }}">
+							{{ instance.instance_name|parse_localization }}
+						</p>
+						<p class="card-text">
+							{{ instance.course.code }}
+							<br />
+							{{ instance.starting_time|date:"SHORT_DATE_FORMAT" }} &ndash;
+							{{ instance.ending_time|date:"SHORT_DATE_FORMAT" }}
+							<br />
+						</p>
+						<p class="card-text">
+							<form style="display: inline-block" method="POST" action="{{ instance_url }}">
+								{% csrf_token %}
+								<button
+									class="aplus-button--secondary aplus-button--xs"
+									type="submit"
+								>
+									{% translate "LTI_USE_WHOLE_COURSE" %}
+								</button>
+							</form>
+							<a
+								style="display: inline-block"
+								class="aplus-button--secondary aplus-button--xs"
+								href="{{ instance_url }}"
+							>
+								{% translate "LTI_SELECT_SPECIFIC_CONTENT" %}
+							</a>
+						</p>
+					</div>
+				</div>
+			</div>
+		{% endwith %}
+		{% endfor %}
+	</div>
+</section>
+{% endblock %}

--- a/lti_tool/templates/lti_tool/exercise_list.html
+++ b/lti_tool/templates/lti_tool/exercise_list.html
@@ -1,0 +1,39 @@
+{% extends "lti_tool/lti_base.html" %}
+
+{% load i18n %}
+{% load course %}
+{% load exercise %}
+
+{% block content %}
+<a class="aplus-button--secondary aplus-button--xs" href="..">{% translate "LTI_GO_BACK" %}</a>
+<h2 id="heading">{% translate "LTI_SELECT_CHAPTER_OR_EXERCISE" %}</h2>
+<section aria-labelledby="heading">
+	<h3>{{ instance|parse_localization }}</h3>
+	<h4>{{ module|parse_localization }}</h4>
+
+	{% for entry in flat_module %}
+
+	{% if entry.type == 'level' %}
+		{% if entry.down %}
+		<ul class="toc">
+		{% elif entry.up %}
+		</ul>
+		{% endif %}
+	{% else %}
+	<li>
+		<form style="display: inline-block" method="POST" action="{{ entry.link }}">
+			{% csrf_token %}
+			<button
+				class="aplus-button--secondary aplus-button--xs"
+				type="submit"
+			>
+				{{ entry.name|parse_localization }}
+			</button>
+		</form>
+	</li>
+	{% endif %}
+	{% endfor %}
+</section>
+
+
+{% endblock %}

--- a/lti_tool/templates/lti_tool/lti_base.html
+++ b/lti_tool/templates/lti_tool/lti_base.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+
+{% block header %}{% endblock %}
+{% block footer %}{% endblock %}

--- a/lti_tool/templates/lti_tool/lti_course.html
+++ b/lti_tool/templates/lti_tool/lti_course.html
@@ -1,0 +1,73 @@
+{% extends "course/course_base.html" %}
+{% load i18n %}
+{% load course %}
+{% load exercise %}
+{% load news %}
+{% load apps %}
+
+{% block view_tag %}home{% endblock %}
+{% block siblings %}{% endblock %}
+{% block header %}{% endblock %}
+{% block footer %}{% endblock %}
+{% block breadcrumb %}{% endblock %}
+{% block course_sidebar %}{% endblock %}
+{% block sidecontent %}{% endblock %}
+
+{% block coursecontent %}
+
+<div class="index">
+	{{ instance.description|safe }}
+	{% if instance.index_mode == instance.INDEX_TYPE.LAST %}
+	{% user_last %}
+	{% endif %}
+</div>
+
+<ul class="toc">
+	{% for module in content.data.modules %}
+	{% if module|is_listed %}
+	{% module_accessible module as accessible %}
+	{% exercise_accessible module as exercise_accessible %}
+	<li>
+		{% if accessible %}
+		<h3>
+			<a href="{{ module.link }}" class="{% if module|is_in_maintenance %}maintenance{% endif %}">{{ module.name|parse_localization }}</a>
+		</h3>
+		<h4>
+			{% if module.requirements|length > 0 %}
+			<span class="label label-info">
+				{% translate "REQUIRES" %}:
+				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
+			</span>
+			{% endif %}
+			<small>{{ module.opening_time }} &ndash; {{ module.closing_time }}</small>
+		</h4>
+		{% else %}
+		<h3>
+			{{ module.name|parse_localization }}
+			{% if is_course_staff %}
+			<a href="{{ module.link }}">
+				<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+				{% translate "EARLY_ACCESS" %}
+			</a>
+			{% endif %}
+		</h3>
+		<h4>
+			{% if module.requirements|length > 0 %}
+			<span class="label label-info">
+				{% translate "REQUIRES" %}:
+				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
+			</span>
+			{% endif %}
+			<span class="label label-info">{% translate "OPENS" %} {{ module.opening_time }}</span> <small>&ndash; {{ module.closing_time }}</small>
+		</h4>
+		{% endif %}
+		{% include "exercise/_children.html" with children=module.children accessible=accessible exercise_accessible=exercise_accessible %}
+	</li>
+	{% endif %}
+	{% endfor %}
+</ul>
+
+<div class="index">
+	{{ instance.footer|safe }}
+</div>
+{% endblock %}

--- a/lti_tool/templates/lti_tool/lti_exercise.html
+++ b/lti_tool/templates/lti_tool/lti_exercise.html
@@ -1,0 +1,11 @@
+{% extends "exercise/exercise.html" %}
+
+{% block header %}{% endblock %}
+{% block course_sidebar %}
+<div class="col-sm-1"></div>
+{% endblock %}
+{% block breadcrumb %}{% endblock %}
+{% block breadcrumblist %}{% endblock %}
+{% block siblings %}{% endblock %}
+{% block siblings_bottom %}{% endblock %}
+{% block footer %}{% endblock %}

--- a/lti_tool/templates/lti_tool/lti_module.html
+++ b/lti_tool/templates/lti_tool/lti_module.html
@@ -1,0 +1,45 @@
+{% extends "course/course_base.html" %}
+{% load i18n %}
+{% load course %}
+{% load apps %}
+
+{% block title %}{{ current.name|parse_localization }} | {{ block.super }}{% endblock %}
+
+{% block siblings %}{% endblock %}
+{% block header %}{% endblock %}
+{% block footer %}{% endblock %}
+{% block breadcrumb %}{% endblock %}
+{% block course_sidebar %}{% endblock %}
+{% block sidecontent %}{% endblock %}
+
+{% block coursecontent %}
+	<p>
+		<span class="small">
+			{{ current.opening_time }}
+			&ndash; {{ current.closing_time }}
+		</span>
+		{% if current.late_allowed %}
+		<br />
+		<span class="dates">
+			<em>
+				{% blocktranslate trimmed with deadline=current.late_time|date:"DATETIME_FORMAT" %}
+					LATE_SUBMISSIONS_ALLOWED_UNTIL -- {{ deadline }}
+				{% endblocktranslate %}
+				{% if current.late_percent != 100 %}
+				{% blocktranslate trimmed with percent=current.late_percent %}
+					LATE_SUBMISSION_POINTS_WORTH -- {{ percent }}
+				{% endblocktranslate %}
+				{% endif %}
+			</em>
+		</span>
+		{% endif %}
+	</p>
+
+	{% if module.introduction %}
+	<p>
+		{{ module.introduction|safe }}
+	</p>
+	{% endif %}
+
+	{% include "exercise/_children.html" with children=children accessible=True exercise_accessible=current|exercises_submittable:now %}
+{% endblock %}

--- a/lti_tool/templates/lti_tool/lti_submission.html
+++ b/lti_tool/templates/lti_tool/lti_submission.html
@@ -1,0 +1,20 @@
+{% extends "exercise/submission.html" %}
+
+{% block header %}{% endblock %}
+{% block course_sidebar %}
+<div class="col-sm-1"></div>
+{% endblock %}
+{% block breadcrumb %}{% endblock %}
+{% block breadcrumblist %}{% endblock %}
+{% block siblings %}{% endblock %}
+{% block siblings_bottom %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block exercise_wait %}
+{% include "lti_tool/_lti_exercise_wait.html" %}
+{% endblock %}
+
+{% block exerciseinfo %}
+{{ block.super }}
+{% include 'exercise/_submission_info.html' %}
+{% endblock %}

--- a/lti_tool/templates/lti_tool/module_list.html
+++ b/lti_tool/templates/lti_tool/module_list.html
@@ -1,0 +1,38 @@
+{% extends "lti_tool/lti_base.html" %}
+
+{% load i18n %}
+{% load course %}
+{% load exercise %}
+
+{% block content %}
+
+<a class="aplus-button--secondary aplus-button--xs" href="../..">{% translate "LTI_GO_BACK" %}</a>
+<h2 id="heading">{% translate "LTI_SELECT_MODULE" %}</h2>
+<section aria-labelledby="heading">
+	<h3>{{ instance|parse_localization }}</h3>
+	<ul class="toc">
+		{% for module in modules %}
+		{% with module_url=module|url:"lti-select-module" %}
+		<li>
+			<h4>{{ module|parse_localization }}</h4>
+			<form style="display: inline-block" method="POST" action="{{ module_url }}">
+				{% csrf_token %}
+				<button
+					class="aplus-button--secondary aplus-button--xs"
+					type="submit"
+				>
+					{% translate "LTI_USE_WHOLE_MODULE" %}
+				</button>
+			</form>
+			<a
+				class="aplus-button--secondary aplus-button--xs"
+				href="{{ module_url }}"
+			>
+				{% translate "LTI_SELECT_SPECIFIC_CONTENT" %}
+			</a>
+		</li>
+		{% endwith %}
+		{% endfor %}
+	</ul>
+</section>
+{% endblock %}

--- a/lti_tool/urls.py
+++ b/lti_tool/urls.py
@@ -1,0 +1,59 @@
+from django.conf.urls import url
+from django.views.decorators.csrf import csrf_exempt
+
+from . import views
+from exercise.views import SubmissionPollView
+from course.urls import INSTANCE_URL_PREFIX, MODULE_URL_PREFIX
+from exercise.urls import EXERCISE_URL_PREFIX, SUBMISSION_URL_PREFIX
+
+INSTANCE_URL_FILL = INSTANCE_URL_PREFIX[1:]
+MODULE_URL_FILL = MODULE_URL_PREFIX[1:]
+EXERCISE_URL_FILL = EXERCISE_URL_PREFIX[1:]
+SUBMISSION_URL_FILL = SUBMISSION_URL_PREFIX[1:]
+
+LTI_PREFIX = r'lti/'
+LTI_SELECT_CONTENT_PREFIX = LTI_PREFIX + "select-content/"
+LTI_INSTANCE_URL_PREFIX = LTI_PREFIX + INSTANCE_URL_FILL
+LTI_EDIT_URL_PREFIX = LTI_INSTANCE_URL_PREFIX + r'teachers/'
+LTI_USER_URL_PREFIX = LTI_INSTANCE_URL_PREFIX + r'user/'
+LTI_MODULE_URL_PREFIX = LTI_PREFIX + MODULE_URL_FILL
+
+LTI_EXERCISE_URL_PREFIX = LTI_PREFIX + EXERCISE_URL_FILL
+LTI_SUBMISSION_URL_PREFIX = LTI_PREFIX + SUBMISSION_URL_FILL
+
+urlpatterns = [
+    url(LTI_PREFIX + r'login/$',
+        views.lti_login),
+    url(LTI_SELECT_CONTENT_PREFIX + '$',
+        views.LtiSelectContentView.as_view(),
+        name="lti-select-content"),
+    # csrf_exempt these for now, as proper csrf handling
+    # for these views proved too difficult so far
+    url(LTI_SELECT_CONTENT_PREFIX + INSTANCE_URL_FILL +  '$',
+        csrf_exempt(views.LtiSelectCourseView.as_view()),
+        name="lti-select-course"),
+    url(LTI_SELECT_CONTENT_PREFIX + MODULE_URL_FILL  + '$',
+        csrf_exempt(views.LtiSelectModuleView.as_view()),
+        name="lti-select-module"),
+    url(LTI_SELECT_CONTENT_PREFIX + EXERCISE_URL_FILL + '$',
+        csrf_exempt(views.LtiSelectExerciseView.as_view()),
+        name="lti-select-exercise"),
+    url(LTI_PREFIX + r'launch/$',
+        csrf_exempt(views.LtiLaunchView.as_view()),
+        name="lti-launch"),
+    url(LTI_SUBMISSION_URL_PREFIX + r'$',
+        views.LtiSubmissionView.as_view(),
+        name="lti-submission"),
+    url(LTI_SUBMISSION_URL_PREFIX + r'poll/$',
+        SubmissionPollView.as_view(),
+        name="lti-submission-poll"),
+    url(LTI_EXERCISE_URL_PREFIX + r'$',
+        views.LtiExerciseView.as_view(),
+        name="lti-exercise"),
+    url(LTI_MODULE_URL_PREFIX + r'$',
+        views.LtiModuleView.as_view(),
+        name="lti-module"),
+    url(LTI_INSTANCE_URL_PREFIX + r'$',
+        views.LtiInstanceView.as_view(),
+        name="lti-course"),
+]

--- a/lti_tool/utils.py
+++ b/lti_tool/utils.py
@@ -1,0 +1,74 @@
+import logging
+from datetime import datetime
+from django.conf import settings
+from django.contrib.auth.models import User
+from pylti1p3.grade import Grade
+from pylti1p3.contrib.django import DjangoMessageLaunch, DjangoCacheDataStorage, DjangoDbToolConf
+from pylti1p3.lineitem import LineItem
+from pylti1p3.exception import LtiServiceException
+
+logger = logging.getLogger('aplus.lti_tool')
+
+def get_launch_url(request):
+    target_link_uri = request.POST.get('target_link_uri', request.GET.get('target_link_uri'))
+    if not target_link_uri:
+        logger.error('Missing "target_link_uri" param')
+        raise Exception('Missing "target_link_uri" param')
+    return target_link_uri
+
+def get_tool_conf():
+    # Cannot default to DjangoDbToolConf() in settings.py due to models not being initialized yet
+    if hasattr(settings, "LTI_TOOL_CONF"):
+        return settings.LTI_TOOL_CONF
+    else:
+        return DjangoDbToolConf()
+
+def get_launch_data_storage():
+    return DjangoCacheDataStorage()
+
+def send_lti_points(request, submission):
+    from exercise.exercise_summary import UserExerciseSummary
+    exercise = submission.exercise
+    request.COOKIES['lti1p3-session-id'] = submission.meta_data.get('lti-session-id')
+    launch = DjangoMessageLaunch.from_cache(
+        submission.lti_launch_id,
+        request,
+        get_tool_conf(),
+        launch_data_storage=get_launch_data_storage()
+    )
+
+    try:
+        username = launch.get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/ext']['user_username']
+    except (KeyError, TypeError):
+        username = launch.get_launch_data()['email']
+
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        logger.warn(f"Tried to send LTI points for a non-existing user '{username}'")
+        return
+
+    # Moodle does not have gradebook entries for teachers - don't send result if submitter is a teacher
+    is_course_teacher = exercise.course_instance.is_teacher(user)
+    if not is_course_teacher:
+        summary = UserExerciseSummary(exercise, user)
+        best_submission = summary.best_submission
+        ags = launch.get_ags()
+        grade = Grade()
+        (grade.set_score_given(best_submission.grade)
+            .set_timestamp(best_submission.submission_time.strftime('%Y-%m-%dT%H:%M:%S+0000'))
+            .set_score_maximum(exercise.max_points)
+            .set_activity_progress('Completed')
+            .set_grading_progress('FullyGraded')
+            .set_user_id(launch.get_launch_data().get('sub')))
+        line_item = LineItem()
+        line_item.set_tag(str(submission.exercise.id))
+        try:
+            ags.put_grade(grade, line_item)
+        except LtiServiceException as e:
+            # At least Moodle sends a 409 when trying to save
+            # a grade with same timestamp as an existing grade
+            if e.response.status_code == 409:
+                logger.info("Grade for submission has already been saved through LTI; continuing")
+            else:
+                raise e

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -1,0 +1,325 @@
+import logging
+from django.http import HttpResponse
+from django.views.decorators.clickjacking import xframe_options_exempt
+from django.views.decorators.csrf import csrf_exempt
+from django.shortcuts import redirect, get_object_or_404
+from django.contrib.auth.models import User
+from django.contrib.auth import login
+from django.urls import reverse
+from pylti1p3.contrib.django import DjangoOIDCLogin, DjangoMessageLaunch
+from pylti1p3.deep_link_resource import DeepLinkResource
+from pylti1p3.lineitem import LineItem
+from pylti1p3.exception import LtiException
+
+from course.views import InstanceView, ModuleView
+from course.models import CourseInstance, Enrollment, CourseModule
+from course.viewbase import CourseInstanceBaseView, CourseModuleBaseView
+from exercise.viewbase import ExerciseBaseView
+from exercise.models import LearningObject, BaseExercise
+from exercise.views import ExerciseView, SubmissionView
+from userprofile.models import UserProfile
+from lib.viewbase import BaseTemplateView, BaseRedirectView, BaseMixin
+from authorization.permissions import ACCESS
+from .utils import get_tool_conf, get_launch_data_storage, get_launch_url
+
+logger = logging.getLogger('aplus.lti_tool')
+
+# CSRF exempts due to difficulty in proper implementation. To re-review later.
+@csrf_exempt
+@xframe_options_exempt
+def lti_login(request):
+    tool_conf = get_tool_conf()
+    launch_data_storage = get_launch_data_storage()
+
+    oidc_login = DjangoOIDCLogin(request, tool_conf, launch_data_storage=launch_data_storage)
+    target_link_uri = get_launch_url(request)
+    return oidc_login.enable_check_cookies().redirect(target_link_uri)
+
+
+class LtiLaunchView(BaseRedirectView):
+
+    access_mode = ACCESS.ANONYMOUS
+
+    @xframe_options_exempt
+    def post(self, request, *args, **kwargs):
+        tool_conf = get_tool_conf()
+        launch_data_storage = get_launch_data_storage()
+        message_launch = DjangoMessageLaunch(self.request, tool_conf, launch_data_storage=launch_data_storage)
+        self.message_launch_data = message_launch.get_launch_data()
+
+        # Get or create user
+        try:
+            # Moodle sends username in this parameter
+            username = self.message_launch_data['https://purl.imsglobal.org/spec/lti/claim/ext']['user_username']
+        except (KeyError, TypeError):
+            # Email always received, use as fallback
+            username = self.message_launch_data['email']
+        try:
+            self.user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            self.user = User.objects.create(
+                username=username,
+                email=self.message_launch_data["email"],
+                first_name=self.message_launch_data["given_name"],
+                last_name=self.message_launch_data["family_name"]
+            )
+            profile = self.user.userprofile
+            profile.language = self.message_launch_data["https://purl.imsglobal.org/spec/lti/claim/launch_presentation"]["locale"]
+            profile.student_id = self.message_launch_data["https://purl.imsglobal.org/spec/lti/claim/lis"]["person_sourcedid"]
+            profile.save()
+
+            self.profile = profile
+        login(self.request, self.user)
+        self.request.session["lti-launch-id"] = message_launch.get_launch_id()
+
+        if message_launch.is_resource_launch():
+            launch_params = self.message_launch_data["https://purl.imsglobal.org/spec/lti/claim/custom"]
+            instance = get_object_or_404(CourseInstance,
+                course__url=launch_params["course_slug"],
+                url=launch_params["instance_slug"]
+            )
+            roles = self.message_launch_data["https://purl.imsglobal.org/spec/lti/claim/roles"]
+            is_course_teacher = instance.is_course_staff(self.user)
+            if "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner" in roles and not is_course_teacher:
+                enrolment_success = instance.enroll_student(self.user)
+
+            if "exercise_path" in launch_params:
+                url_params = {
+                    k: launch_params[k] for k in ["exercise_path", "module_slug", "course_slug", "instance_slug"]
+                }
+                return redirect("lti-exercise", **url_params)
+            elif "module_slug" in launch_params:
+                url_params = {
+                    k: launch_params[k] for k in ["module_slug", "course_slug", "instance_slug"]
+                }
+                return redirect("lti-module", **url_params)
+            elif "course_slug" in launch_params and "instance_slug" in launch_params:
+                url_params = {
+                    k: launch_params[k] for k in ["course_slug", "instance_slug"]
+                }
+                return redirect("lti-course", **url_params)
+            else:
+                raise LtiException("Invalid parameters for an LTI launch")
+        elif message_launch.is_deep_link_launch():
+            return redirect("lti-select-content")
+        else:
+            raise LtiException("Invalid LTI launch type")
+
+
+class LtiSessionMixin(BaseMixin):
+
+    @csrf_exempt
+    @xframe_options_exempt
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
+
+    def parse_lti_session_params(self):
+        launch_id = self.request.session.get("lti-launch-id", None)
+        tool_conf = get_tool_conf()
+        if launch_id:
+            self.message_launch = DjangoMessageLaunch.from_cache(
+                launch_id,
+                self.request,
+                tool_conf,
+                launch_data_storage=get_launch_data_storage()
+            )
+            self.message_launch_data = self.message_launch.get_launch_data()
+
+
+class LtiInstanceView(LtiSessionMixin, InstanceView):
+
+    access_mode = ACCESS.ENROLLED
+    template_name = "lti_tool/lti_course.html"
+
+    def get(self, request, *args, **kwargs):
+        # Edit links to point to LTI views
+        module_model_objs = CourseModule.objects.filter(course_instance=self.instance)
+        learningobjects = LearningObject.objects.filter(course_module__course_instance=self.instance)
+        for module in self.content.data['modules']:
+            module_model_obj = next((x for x in module_model_objs if x.id == module['id']), None)
+            module.update({'link': module_model_obj.get_url("lti-module")})
+            for exercise in module['children']:
+                lo_model_obj = next((x for x in learningobjects if x.id == exercise['id']), None)
+                exercise.update({'link': lo_model_obj.get_url("lti-exercise")})
+        return super().get(request, *args, **kwargs)
+
+
+class LtiModuleView(LtiSessionMixin, ModuleView):
+
+    access_mode = ACCESS.ENROLLED
+    template_name = "lti_tool/lti_module.html"
+
+    def get(self, request, *args, **kwargs):
+        learningobjects = LearningObject.objects.filter(course_module=self.module)
+        learningobjects_dict = { obj.id: obj for obj in learningobjects }
+        # Can't use self.children for iteration, so this instead
+        flat_module = self.content.flat_module(self.module)
+        exercises = [entry for entry in flat_module if entry['type'] == 'exercise']
+        for exercise in exercises:
+            learningobj = learningobjects_dict[exercise['id']]
+            exercise['link'] = learningobj.get_url('lti-exercise')
+        return super().get(request, *args, **kwargs)
+
+
+class LtiExerciseView(LtiSessionMixin, ExerciseView):
+
+    access_mode = ACCESS.ENROLLED
+    template_name = "lti_tool/lti_exercise.html"
+    post_url_name = "lti-exercise"
+    submission_url_name = "lti-submission"
+    exercise_url_name = "lti-exercise"
+
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs, redirect_view='lti-submission')
+
+
+class LtiSubmissionView(LtiSessionMixin, SubmissionView):
+
+    access_mode = ACCESS.ENROLLED
+    template_name = "lti_tool/lti_submission.html"
+    submission_url_name = "lti-submission"
+    exercise_url_name = 'lti-exercise'
+
+
+class LtiSelectContentMixin(LtiSessionMixin):
+
+    access_mode = ACCESS.TEACHER
+
+    def get_resource_objects(self):
+        super().get_resource_objects()
+        self.is_teacher = Enrollment.objects.filter(
+            user_profile=self.request.user.userprofile,
+            role=Enrollment.ENROLLMENT_ROLE.TEACHER,
+            status=Enrollment.ENROLLMENT_STATUS.ACTIVE,
+        ).exists()
+
+    def get_common_objects(self):
+        super().get_common_objects()
+        self.parse_lti_session_params()
+        self.teacher_enrollments = Enrollment.objects.select_related("course_instance").filter(
+            user_profile=self.request.user.userprofile,
+            role=Enrollment.ENROLLMENT_ROLE.TEACHER,
+            status=Enrollment.ENROLLMENT_STATUS.ACTIVE,
+        )
+
+
+class LtiSelectContentView(LtiSelectContentMixin, BaseTemplateView):
+
+    template_name = "lti_tool/course_list.html"
+
+    def get_common_objects(self):
+        super().get_common_objects()
+        self.instances = [e.course_instance for e in self.teacher_enrollments]
+        self.note("instances")
+
+
+class LtiSelectCourseView(LtiSelectContentMixin, CourseInstanceBaseView):
+
+    template_name = "lti_tool/module_list.html"
+
+    def post(self, request, *args, **kwargs):
+        # Create gradebook items
+        ags = self.message_launch.get_ags()
+        lineitems = ags.get_lineitems()
+        exercises = BaseExercise.objects.filter(course_module__course_instance=self.instance)
+        for e in exercises:
+            lineitem_exists = bool([li for li in lineitems if li['tag'] == str(e.id)])
+            if e.max_points > 0 and not lineitem_exists:
+                li = LineItem()
+                li.set_tag(str(e.id)).set_score_maximum(e.max_points).set_label(str(e))
+                ags.find_or_create_lineitem(li)
+
+        # Send activity settings
+        deep_link = self.message_launch.get_deep_link()
+        resource = DeepLinkResource()
+        (resource.set_url(request.build_absolute_uri(reverse('lti-launch')))
+            .set_custom_params({
+                "course_slug": kwargs['course_slug'],
+                "instance_slug": kwargs['instance_slug']
+            })
+            .set_title("{}: {}".format(self.course.name, self.instance.instance_name)))
+        return HttpResponse(deep_link.output_response_form([resource]))
+
+    # Get list of modules in course
+    def get(self, request, *args, **kwargs):
+        self.modules = list(self.instance.course_modules.all())
+        self.note("modules")
+        return super().get(request, *args, **kwargs)
+
+
+class LtiSelectModuleView(LtiSelectContentMixin, CourseModuleBaseView):
+
+    template_name = "lti_tool/exercise_list.html"
+
+    def post(self, request, *args, **kwargs):
+        # Create gradebook items
+        ags = self.message_launch.get_ags()
+        lineitems = ags.get_lineitems()
+        exercises = BaseExercise.objects.filter(course_module=self.module)
+        for e in exercises:
+            lineitem_exists = bool([li for li in lineitems if li['tag'] == str(e.id)])
+            if e.max_points > 0 and not lineitem_exists:
+                li = LineItem()
+                li.set_tag(str(e.id)).set_score_maximum(e.max_points).set_label(str(e))
+                ags.find_or_create_lineitem(li)
+
+        # Send activity settings
+        deep_link = self.message_launch.get_deep_link()
+        resource = DeepLinkResource()
+        (resource.set_url(request.build_absolute_uri(reverse('lti-launch')))
+            .set_custom_params({
+                "course_slug": kwargs['course_slug'],
+                "instance_slug": kwargs['instance_slug'],
+                "module_slug": kwargs['module_slug']
+            })
+            .set_title(str(self.module)))
+        return HttpResponse(deep_link.output_response_form([resource]))
+
+    # Get list of exercises in module
+    def get(self, request, *args, **kwargs):
+        self.learningobjects = LearningObject.objects.filter(course_module=self.module)
+        self.learningobjects_dict = { obj.id: obj for obj in self.learningobjects }
+        self.flat_module = self.content.flat_module(self.module)
+        exercises = [entry for entry in self.content.flat_module(self.module) if entry['type'] == 'exercise']
+        for exercise in exercises:
+            learningobj = self.learningobjects_dict[exercise['id']]
+            exercise['link'] = learningobj.get_url('lti-select-exercise')
+        self.note("learningobjects", "flat_module")
+        return super().get(request, *args, **kwargs)
+
+
+class LtiSelectExerciseView(LtiSelectContentMixin, ExerciseBaseView):
+
+    def post(self, request, *args, **kwargs):
+        # Create gradebook items
+        ags = self.message_launch.get_ags()
+        children = self.exercise.children.all()
+        if len(children) > 0:
+            for e in children:
+                if e.max_points > 0:
+                    li = LineItem()
+                    li.set_tag(str(e.id)).set_score_maximum(e.max_points).set_label(str(e))
+                    ags.find_or_create_lineitem(li)
+        else:
+            try:
+                if self.exercise.max_points > 0:
+                    li = LineItem()
+                    (li.set_tag(str(self.exercise.id))
+                        .set_score_maximum(self.exercise.max_points)
+                        .set_label(str(self.exercise)))
+                    ags.find_or_create_lineitem(li)
+            except AttributeError as e:
+                logger.info("Importing LTI exercise with no max_points attribute")
+
+        # Send activity settings
+        deep_link = self.message_launch.get_deep_link()
+        resource = DeepLinkResource()
+        (resource.set_url(request.build_absolute_uri(reverse('lti-launch')))
+            .set_custom_params({
+                "course_slug": kwargs['course_slug'],
+                "instance_slug": kwargs['instance_slug'],
+                "module_slug": kwargs['module_slug'],
+                "exercise_path": kwargs['exercise_path']
+            })
+            .set_title(str(self.exercise)))
+        return HttpResponse(deep_link.output_response_form([resource]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ redis >= 4
 binaryornot ~= 0.4.4
 django-model-utils ~= 4.2.0
 format_cef ~= 0.0.4
+PyLTI1p3 ~= 2.0.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,6 +94,7 @@
 	data-view-tag="{% block view_tag %}{% endblock %}">
 	<a href="#content" class="skip-link">{% translate "SKIP_MAIN_NAVIGATION" %}</a>
 	<div class="page-wrap">
+		{% block header %}
 		<header>
 			<nav class="topbar navbar navbar-inverse navbar-static-top" aria-label="{% translate 'MAIN' %}">
 				<div class="container-fluid">
@@ -211,6 +212,7 @@
 				</div>
 			</nav>
 		</header>
+		{% endblock header %}
 
 		{% block container_opening_tag %}
 		<main class="site-content container-fluid" id="content">


### PR DESCRIPTION
# Description
This PR adds functionality to A+ that enables it to be used as an LTI 1.3 tool in Moodle and possibly other LTI platforms.

**Why?**
Historically, the [A+ Astra moodle plugin](https://github.com/apluslms/moodle-mod_astra) that enables A+ exercises to be used in Moodle, required updates whenever the deployed Moodle version changed. By using the LTI standard to add the functionality instead, we ensure compatibility through version updates.

**How?**
The PR adds LTI protocol specific urls, views, and templates that allow embedding A+ material in an LTI context, and allow users to submit exercises to be graded in A+, with grading results being sent back to the Moodle gradebook. LTI deep linking is also supported, allowing teachers to select content via a UI.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested in Moodle:
* Adding A+ as an LTI tool via Moodle's admin user interface
* Selecting content to embed in an activity as a teacher
* Browsing embedded material as student and teacher
* Submitting exercises as student and teacher
* Verifying that grades are recorded in Moodle's gradebook
  * Teacher grades are not sent to Moodle, though

**Did you test the changes in**

- [X] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

Mostly Firefox; Chrome only occasionally during development.

**Think of what is affected by these changes and could become broken**

Most of the functionality is standalone and should not affect main A+ functionality. Some templates have been modified, mainly adding overwritable blocks, which shouldn't break things. Some code was added to submitting exercise solutions and receiving grades, but the additions are only used in LTI contexts.

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

Documentation regarding the local development setup should be added later.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

**Known issues**

ACOS exercises do not have their grading results sent to Moodle - this still requires extra thought.