### PR TITLE
Implement way of sending Acos grading results to LTI platform

### DIFF
--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -52,6 +52,12 @@ def _post_async_submission(request, exercise, submission, errors=None):
         submission.feedback = form.cleaned_data["feedback"]
         submission.grading_data = post_data
 
+        # Acos-submissions initialize this as an empty string for some reason; fix here
+        if submission.meta_data == "":
+            submission.meta_data = {}
+        if form.cleaned_data["lti_launch_id"]:
+            submission.meta_data["lti-launch-id"] = form.cleaned_data["lti_launch_id"]
+
         if form.cleaned_data["error"]:
             submission.set_error()
         else:

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -955,7 +955,7 @@ class BaseExercise(LearningObject):
             )
             return self._build_service_url(
                 language, students,
-                ordinal, url_name, submission_url
+                ordinal, url_name, submission_url, lti_launch_id=request.session.get("lti-launch-id")
             )
         return super().get_load_url(language, request, students, url_name, ordinal)
 
@@ -994,12 +994,12 @@ class BaseExercise(LearningObject):
         """
         pass
 
-    def _build_service_url(self, language, students, ordinal_number, url_name, submission_url):
+    def _build_service_url(self, language, students, ordinal_number, url_name, submission_url, lti_launch_id=None):
         """
         Generates complete URL with added parameters to the exercise service.
         """
         uid_str = '-'.join(sorted(str(profile.user.id) for profile in students)) if students else ''
-        return update_url_params(self.get_service_url(language), {
+        params = {
             "max_points": self.max_points,
             "max_submissions": self.max_submissions,
             "submission_url": build_aplus_url(submission_url),
@@ -1007,7 +1007,10 @@ class BaseExercise(LearningObject):
             "uid": uid_str,
             "ordinal_number": ordinal_number,
             "lang": language,
-        })
+        }
+        if lti_launch_id:
+            params["lti_launch_id"] = lti_launch_id
+        return update_url_params(self.get_service_url(language), params)
 
     @property
     def can_regrade(self):

--- a/exercise/forms.py
+++ b/exercise/forms.py
@@ -20,6 +20,7 @@ class SubmissionCallbackForm(forms.Form):
     feedback = forms.CharField(required=False)
     notify = forms.CharField(required=False)
     grading_payload = forms.CharField(required=False)
+    lti_launch_id = forms.CharField(required=False)
     error = forms.BooleanField(required=False)
 
     def clean(self):


### PR DESCRIPTION
# Description

This, combined with https://github.com/acos-server/acos-aplus/pull/8, fixes an issue where A+ was unable to send points from ACOS back to the LTI platform when A+ was used as an LTI tool.

Fixes #1154


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.