### PR TITLE
Improve access denied messages and 403 page

### DIFF
--- a/authorization/permissions.py
+++ b/authorization/permissions.py
@@ -114,6 +114,7 @@ class AccessModePermission(MessageMixin, Permission):
         if access_mode == ACCESS.ANONYMOUS:
             return True
         if not request.user.is_authenticated:
+            self.error_msg(_('ACCESS_ERROR_ONLY_AUTHENTICATED'))
             return False
 
         if access_mode >= ACCESS.SUPERUSER:

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 16:41+0200\n"
+"POT-Creation-Date: 2023-05-10 14:22+0300\n"
 "PO-Revision-Date: 2021-05-27 14:47+0300\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: English<>\n"
@@ -201,6 +201,10 @@ msgid "ACCESS_PERMISSION_DENIED_MSG"
 msgstr "Unfortunately you are not permitted to see this content."
 
 #: authorization/permissions.py
+msgid "ACCESS_ERROR_ONLY_AUTHENTICATED"
+msgstr "Please login."
+
+#: authorization/permissions.py
 msgid "ACCESS_ERROR_ONLY_TEACHERS"
 msgstr "Only course teachers shall pass."
 
@@ -372,7 +376,8 @@ msgstr "anonymized ID"
 msgid "LABEL_ROLE"
 msgstr "role"
 
-#: course/models.py exercise/exercise_models.py exercise/submission_models.py
+#: course/models.py exercise/admin.py exercise/exercise_models.py
+#: exercise/submission_models.py
 msgid "LABEL_STATUS"
 msgstr "status"
 
@@ -2922,6 +2927,10 @@ msgstr "Submitters"
 msgid "LABEL_SUBMITTERS"
 msgstr "Submitters"
 
+#: exercise/admin.py exercise/submission_models.py notification/models.py
+msgid "LABEL_SUBMISSION"
+msgstr "submission"
+
 #: exercise/api/views.py exercise/views.py
 msgid "ERROR_SUBMISSION_SAVING_FAILED"
 msgstr ""
@@ -3717,10 +3726,6 @@ msgstr "submission draft"
 #: exercise/submission_models.py
 msgid "MODEL_NAME_SUBMISSION_DRAFT_PLURAL"
 msgstr "submission drafts"
-
-#: exercise/submission_models.py notification/models.py
-msgid "LABEL_SUBMISSION"
-msgstr "submission"
 
 #: exercise/submission_models.py
 msgid "LABEL_PARAM_NAME"
@@ -5037,8 +5042,8 @@ msgstr ""
 msgid "EXTERNAL_SERVICE_SENT_ACCESS_TOKEN_COURSE_STAFF -- %(brand)s"
 msgstr ""
 "Moreover, we send this service a so-called <a href=\"https://en.wikipedia."
-"org/wiki/Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class="
-"\"alert-link\">access token</a>, which gives the service access to the "
+"org/wiki/Access_token\" rel=\"noopener nofollow\" target=\"_blank\" "
+"class=\"alert-link\">access token</a>, which gives the service access to the "
 "%(brand)s API at your privilege level. If you don't want that to happen, "
 "please contact %(brand)s administration."
 
@@ -5047,8 +5052,8 @@ msgstr ""
 msgid "EXTERNAL_SERVICE_SENT_ACCESS_TOKEN_STUDENT -- %(brand)s"
 msgstr ""
 "Moreover, we send this service a so-called <a href=\"https://en.wikipedia."
-"org/wiki/Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class="
-"\"alert-link\">access token</a>, which gives the service access to the "
+"org/wiki/Access_token\" rel=\"noopener nofollow\" target=\"_blank\" "
+"class=\"alert-link\">access token</a>, which gives the service access to the "
 "%(brand)s API at your privilege level. This means that the service can, for "
 "example, access your student ID number and your progress in the course, and "
 "submit solutions to assignments. The course staff has enabled this feature "
@@ -5058,8 +5063,8 @@ msgstr ""
 #, python-format
 msgid "EXTERNAL_SERVICE_PRIVACY_HOSTED_INTERNALLY -- %(brand)s, %(url)s"
 msgstr ""
-"This service is hosted by us (%(brand)s administrators) and thus our <a href="
-"\"%(url)s\" target=\"_blank\">privacy notice</a> covers it too."
+"This service is hosted by us (%(brand)s administrators) and thus our <a "
+"href=\"%(url)s\" target=\"_blank\">privacy notice</a> covers it too."
 
 #: external_services/templates/external_services/_privacy.html
 #, python-format
@@ -5073,21 +5078,22 @@ msgid "EXTERNAL_SERVICE_PRIVACY_HOSTED_IN_EEA"
 msgstr ""
 "This service is hosted within the European Economics Area and is thus "
 "subject to <a href=\"https://ec.europa.eu/info/law/law-topic/data-protection/"
-"reform_en\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link"
-"\">the European Union's General Data Protection Regulation</a>."
+"reform_en\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-"
+"link\">the European Union's General Data Protection Regulation</a>."
 
 #: external_services/templates/external_services/_privacy.html
 msgid "EXTERNAL_SERVICE_PRIVACY_PRIVACYSHIELD"
 msgstr ""
 "This service is hosted outside of the European Economics Area and is thus "
 "not covered by <a href=\"https://ec.europa.eu/info/law/law-topic/data-"
-"protection/reform_en\" rel=\"noopener nofollow\" target=\"_blank\" class="
-"\"alert-link\">the European Union's General Data Protection Regulation</a> "
-"(GDPR). The service used to be certified under <a href=\"https://www."
-"privacyshield.gov/Individuals-in-Europe\" rel=\"noopener nofollow\" target="
-"\"_blank\" class=\"alert-link\">the EU-U.S. Privacy Shield</a>, but the "
-"European Court of Justice has declared the EU-U.S. Privacy Shield invalid. "
-"We are investigating how this affects the use of the service."
+"protection/reform_en\" rel=\"noopener nofollow\" target=\"_blank\" "
+"class=\"alert-link\">the European Union's General Data Protection "
+"Regulation</a> (GDPR). The service used to be certified under <a "
+"href=\"https://www.privacyshield.gov/Individuals-in-Europe\" rel=\"noopener "
+"nofollow\" target=\"_blank\" class=\"alert-link\">the EU-U.S. Privacy "
+"Shield</a>, but the European Court of Justice has declared the EU-U.S. "
+"Privacy Shield invalid. We are investigating how this affects the use of the "
+"service."
 
 #: external_services/templates/external_services/_privacy.html
 msgid "EXTERNAL_SERVICE_PRIVACY_GLOBAL"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 16:41+0200\n"
+"POT-Creation-Date: 2023-05-10 14:22+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -202,6 +202,10 @@ msgid "ACCESS_PERMISSION_DENIED_MSG"
 msgstr "Valitettavasti sinulla ei ole oikeutta nähdä tätä sisältöä."
 
 #: authorization/permissions.py
+msgid "ACCESS_ERROR_ONLY_AUTHENTICATED"
+msgstr "Kirjaudu sisään."
+
+#: authorization/permissions.py
 msgid "ACCESS_ERROR_ONLY_TEACHERS"
 msgstr "Vain opettajille."
 
@@ -373,7 +377,8 @@ msgstr "anonymisoitu ID"
 msgid "LABEL_ROLE"
 msgstr "rooli"
 
-#: course/models.py exercise/exercise_models.py exercise/submission_models.py
+#: course/models.py exercise/admin.py exercise/exercise_models.py
+#: exercise/submission_models.py
 msgid "LABEL_STATUS"
 msgstr "tila"
 
@@ -1174,8 +1179,8 @@ msgstr "[henkilökunnalla ei ole]"
 #, python-format
 msgid "GROUP_PERSONAL_JOIN_CODE -- %(code)s"
 msgstr ""
-"Henkilökohtainen ryhmään <strong>liittymiskoodisi</strong> on <strong>"
-"%(code)s</strong>. "
+"Henkilökohtainen ryhmään <strong>liittymiskoodisi</strong> on "
+"<strong>%(code)s</strong>. "
 
 #: course/templates/course/groups.html
 msgid "GROUP_CREATION_INSTRUCTIONS"
@@ -2532,7 +2537,8 @@ msgstr "Tuo sisältöasetukset URL-osoitteesta"
 #: edit_course/templates/edit_course/edit_content.html
 msgid "APPLY_CHANGES_TOOLTIP"
 msgstr ""
-"Vertaa uusia sisältöasetuksia aikaisempiin, ja päivittää vain muuttuneet osat."
+"Vertaa uusia sisältöasetuksia aikaisempiin, ja päivittää vain muuttuneet "
+"osat."
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "APPLY_CHANGES"
@@ -2934,6 +2940,10 @@ msgstr "Opiskelijat"
 #: exercise/admin.py exercise/forms.py exercise/submission_models.py
 msgid "LABEL_SUBMITTERS"
 msgstr "Palauttajat"
+
+#: exercise/admin.py exercise/submission_models.py notification/models.py
+msgid "LABEL_SUBMISSION"
+msgstr "palautus"
 
 #: exercise/api/views.py exercise/views.py
 msgid "ERROR_SUBMISSION_SAVING_FAILED"
@@ -3725,10 +3735,6 @@ msgstr "palautusluonnos"
 msgid "MODEL_NAME_SUBMISSION_DRAFT_PLURAL"
 msgstr "palautusluonnokset"
 
-#: exercise/submission_models.py notification/models.py
-msgid "LABEL_SUBMISSION"
-msgstr "palautus"
-
 #: exercise/submission_models.py
 msgid "LABEL_PARAM_NAME"
 msgstr "parametrin nimi"
@@ -3985,8 +3991,8 @@ msgstr "Palauttajia: %(number)s <small>%(percentage)s%%</small>"
 #, python-format
 msgid "USER_LAST_VISITED -- %(name)s, %(link)s"
 msgstr ""
-"Olet ollut oppimateriaalissa viimeksi kohdassa <a href=\"%(link)s\">"
-"%(name)s</a>"
+"Olet ollut oppimateriaalissa viimeksi kohdassa <a "
+"href=\"%(link)s\">%(name)s</a>"
 
 #: exercise/templates/exercise/_user_last.html
 #, python-format
@@ -5056,29 +5062,30 @@ msgstr ""
 msgid "EXTERNAL_SERVICE_SENT_ACCESS_TOKEN_COURSE_STAFF -- %(brand)s"
 msgstr ""
 "Lisäksi palvelulle lähetetään <a href=\"https://en.wikipedia.org/wiki/"
-"Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link"
-"\">käyttöoikeustietue</a>, joka mahdollistaa palvelun pääsyn %(brand)s:n API:"
-"in sinun oikeuksillasi. Mikäli näin ei pitäisi tapahtua, niin ota yhteyttä "
-"%(brand)s:n ylläpitoon."
+"Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-"
+"link\">käyttöoikeustietue</a>, joka mahdollistaa palvelun pääsyn %(brand)s:n "
+"API:in sinun oikeuksillasi. Mikäli näin ei pitäisi tapahtua, niin ota "
+"yhteyttä %(brand)s:n ylläpitoon."
 
 #: external_services/templates/external_services/_privacy.html
 #, python-format
 msgid "EXTERNAL_SERVICE_SENT_ACCESS_TOKEN_STUDENT -- %(brand)s"
 msgstr ""
 "Lisäksi palvelulle lähetetään <a href=\"https://en.wikipedia.org/wiki/"
-"Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link"
-"\">käyttöoikeustietue</a>, joka mahdollistaa palvelun pääsyn %(brand)s:n API:"
-"in sinun oikeuksillasi. Tämä tarkoittaa sitä, että palvelu voi mm. selvittää "
-"opiskelijanumerosi, nähdä kurssisuorituksiasi ja palauttaa tehtäviä "
-"puolestasi. Kurssin henkilökunta on mahdollistanut tämän ja luottaa palvelun "
-"toimivan etujesi mukaisesti."
+"Access_token\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-"
+"link\">käyttöoikeustietue</a>, joka mahdollistaa palvelun pääsyn %(brand)s:n "
+"API:in sinun oikeuksillasi. Tämä tarkoittaa sitä, että palvelu voi mm. "
+"selvittää opiskelijanumerosi, nähdä kurssisuorituksiasi ja palauttaa "
+"tehtäviä puolestasi. Kurssin henkilökunta on mahdollistanut tämän ja luottaa "
+"palvelun toimivan etujesi mukaisesti."
 
 #: external_services/templates/external_services/_privacy.html
 #, python-format
 msgid "EXTERNAL_SERVICE_PRIVACY_HOSTED_INTERNALLY -- %(brand)s, %(url)s"
 msgstr ""
-"Tämä palvelu on meidän ylläpitämämme (%(brand)s), joten meidän <a href="
-"\"%(url)s\" target=\"_blank\">tietosuojailmoituksemme</a> kattaa myös sen. "
+"Tämä palvelu on meidän ylläpitämämme (%(brand)s), joten meidän <a "
+"href=\"%(url)s\" target=\"_blank\">tietosuojailmoituksemme</a> kattaa myös "
+"sen. "
 
 #: external_services/templates/external_services/_privacy.html
 #, python-format
@@ -5090,9 +5097,9 @@ msgstr ""
 #: external_services/templates/external_services/_privacy.html
 msgid "EXTERNAL_SERVICE_PRIVACY_HOSTED_IN_EEA"
 msgstr ""
-"Tämä palvelu sijaitsee Euroopan talousalueella, joten sitä koskee <a href="
-"\"https://ec.europa.eu/info/law/law-topic/data-protection/reform_fi\" rel="
-"\"noopener nofollow\" target=\"_blank\" class=\"alert-link\">Euroopan "
+"Tämä palvelu sijaitsee Euroopan talousalueella, joten sitä koskee <a "
+"href=\"https://ec.europa.eu/info/law/law-topic/data-protection/reform_fi\" "
+"rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link\">Euroopan "
 "unionin yleinen tietosuoja-asetus</a>."
 
 #: external_services/templates/external_services/_privacy.html
@@ -5100,12 +5107,12 @@ msgid "EXTERNAL_SERVICE_PRIVACY_PRIVACYSHIELD"
 msgstr ""
 "Tämä palvelu sijaitsee Euroopan talousalueen ulkopuolella, joten sitä ei "
 "koske <a href=\"https://ec.europa.eu/info/law/law-topic/data-protection/"
-"reform_fi\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link"
-"\">Euroopan unionin yleinen tietosuoja-asetus</a> (GDPR). Palvelu oli "
-"aiemmin <a href=\"https://www.privacyshield.gov/Individuals-in-Europe\" rel="
-"\"noopener nofollow\" target=\"_blank\" class=\"alert-link\">EU-U.S. Privacy "
-"Shield</a> -sertifioitu, mutta Euroopan unionin tuomioistuin on kumonnut "
-"päätöksen EU-U.S. Privacy Shield -järjestelyn tietosuojan tason "
+"reform_fi\" rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-"
+"link\">Euroopan unionin yleinen tietosuoja-asetus</a> (GDPR). Palvelu oli "
+"aiemmin <a href=\"https://www.privacyshield.gov/Individuals-in-Europe\" "
+"rel=\"noopener nofollow\" target=\"_blank\" class=\"alert-link\">EU-U.S. "
+"Privacy Shield</a> -sertifioitu, mutta Euroopan unionin tuomioistuin on "
+"kumonnut päätöksen EU-U.S. Privacy Shield -järjestelyn tietosuojan tason "
 "riittävyydestä. Selvitämme edelleen, kuinka uusi päätös vaikuttaa palvelun "
 "käyttöön. "
 
@@ -5127,8 +5134,8 @@ msgstr ""
 #, python-format
 msgid "EXTERNAL_SERVICE_LOOK_WITHOUT_SENDING_DATA -- %(url)s"
 msgstr ""
-"Voit vierailla palvelussa lähettämättä tietoja: <a href=\"%(url)s\" rel="
-"\"noopener nofollow\" target=\"_blank\">palvelun etusivu</a>."
+"Voit vierailla palvelussa lähettämättä tietoja: <a href=\"%(url)s\" "
+"rel=\"noopener nofollow\" target=\"_blank\">palvelun etusivu</a>."
 
 #: external_services/templates/external_services/edit_menu.html
 msgid "ADD_MENU_ITEM"

--- a/selenium_test/test/locators.py
+++ b/selenium_test/test/locators.py
@@ -1,7 +1,11 @@
 from selenium.webdriver.common.by import By
 
 class CommonLocators:
-    FORBIDDEN_PAGE = (By.XPATH, "//div[@class='page-header']/h1[contains(text(), '403 Forbidden')]")
+    FORBIDDEN_PAGE = (
+        By.XPATH,
+        "//div[@class='message'][contains(text(), "
+        "'Unfortunately you are not permitted to see this content')]"
+    )
     PERMISSION_DENIED_ACCESS_MODE = (
         By.XPATH,
         "//main[@id='content']//div[@class='message'][contains(text(), "

--- a/selenium_test/test/teacher_list_test.py
+++ b/selenium_test/test/teacher_list_test.py
@@ -26,7 +26,7 @@ class TeacherListPage(BasePage):
             query.append("end_date=" + end_date.isoformat())
         query.append("with_assistants=" + ("true" if with_assistants else "false"))
 
-        self.load("/accounts/teachers/?" + "&".join(query), (By.CSS_SELECTOR, '.page-header'))
+        self.load("/accounts/teachers/?" + "&".join(query), (By.CSS_SELECTOR, '.container-fluid'))
 
     def get_table_data(self) -> List[List[str]]:
         rows = self.getElements((By.CSS_SELECTOR, "table tbody tr"))

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,34 +1,12 @@
+{% extends "base.html" %}
 {% load i18n %}
 {% load static %}
 {% load base %}
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>403 Forbidden</title>
-        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="{% static 'css/main.css' %}" />
-    </head>
-    <body>
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-md-8">
-                    <div class="page-header">
-                        <h1>403 Forbidden</h1>
-                    </div>
-                    {% include "_messages.html" %}
-                    <pre>
-   |        v
-   |   /\   |   ,.
-   ^\_("))_/| ´  .
-     /{%} \ |   `
-    /______\  ,'
- ,'  ^   ^  ,'
-;          :</pre>
-                </div>
-            </div>
-        </div>
-        {% tracking_html %}
-    </body>
-</html>
+{% block content %}
+<div class="container-fluid">
+	<div class="row">
+		<div class="col-md-8">
+		</div>
+	</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Description

**What?**

Improve the access denied message and 403 page.
- Make it more clear why user may not access certain pages.
- Make the texts more student friendly and less techy.
- Update the translations

Some translations were automatically formatted by ``makemessages``, which is why they look like they were edited.

**How?**

- Finish the previous PR #1106 by fixing some minor issues in it.

Fixes #858
Closes #1106

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the messages and 403 page look as expected.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface?

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature