### PR TITLE
Hide maintenance-mode content from ToC

### DIFF
--- a/exercise/cache/hierarchy.py
+++ b/exercise/cache/hierarchy.py
@@ -302,7 +302,10 @@ class ContentMixin:
             return (
                 entry.get('category_status') != LearningObjectCategory.STATUS.HIDDEN
                 and entry.get('module_status') != CourseModule.STATUS.UNLISTED
-                and entry['status'] != LearningObject.STATUS.UNLISTED
+                and not entry['status'] in (
+                    LearningObject.STATUS.UNLISTED,
+                    LearningObject.STATUS.MAINTENANCE,
+                )
             )
         if t == 'module':
             return entry['status'] != CourseModule.STATUS.UNLISTED

--- a/exercise/templates/exercise/_children.html
+++ b/exercise/templates/exercise/_children.html
@@ -15,7 +15,7 @@
   {% if entry.is_empty %}
     {{ entry.name|parse_localization }}
   {% else %}
-    <a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a>
+    <a href="{{ entry.link }}">{{ entry.name|parse_localization }}</a>
   {% endif %}
   {% if entry.submission_count %}
     {% points_badge entry %}


### PR DESCRIPTION
# Description

**What?**

Course exercises weren't normally listed in the ToC, but they appeared there if they were put into maintenance mode.

Modules' children that are in maintenance mode (LearningObject.status maintenance) are now hidden from the course table of contents. Modules are still shown in ToC even if they are in maintenance mode.

**Why?**

This change was requested by a teacher.

Fixes #1124
Fixes #438

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that module children were hidden from ToC if they were put into maintenance mode.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
