### PR TITLE
Add timeout and better error message to quiz submit request

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -366,6 +366,7 @@ $(function() {
     var defaults = {
         loader_selector: ".modal-progress",
         loader_text_selector: ".progress-bar",
+        alert_text_selector: ".modal-submit-error",
         title_selector: ".modal-title",
         content_selector: ".modal-body",
         error_message_attribute: "data-msg-error",
@@ -382,6 +383,7 @@ $(function() {
         init: function() {
             this.loader = this.element.find(this.settings.loader_selector);
             this.loaderText = this.loader.find(this.settings.loader_text_selector);
+            this.alertText = this.loader.find(this.settings.alert_text_selector);
             this.title = this.element.find(this.settings.title_selector);
             this.content = this.element.find(this.settings.content_selector);
             this.messages = {
@@ -407,6 +409,7 @@ $(function() {
         open: function(data) {
             this.title.hide();
             this.content.hide();
+            this.alertText.hide();
             this.loaderText
                 .removeClass('progress-bar-danger').addClass('active')
                 .text(data || this.messages.loading);
@@ -418,9 +421,10 @@ $(function() {
         },
 
         showError: function(data) {
-            this.loaderText
-                .removeClass('active').addClass('progress-bar-danger')
-                .text(data || this.messages.error);
+            if (data) {
+                this.alertText.text(data).show();
+            }
+            this.loaderText.removeClass('active').addClass('progress-bar-danger').text(this.messages.error);
         },
 
         showContent: function(data) {

--- a/edit_course/tests.py
+++ b/edit_course/tests.py
@@ -33,8 +33,9 @@ class CourseCloneTest(CourseTestCase):
             'key_month': 'Test',
         }, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "alert alert-danger")
-        self.assertContains(response, "alert alert-success")
+        stripped_content = response.content.decode("utf-8").replace("modal-submit-error alert alert-danger", "")
+        self.assertNotIn("alert alert-danger", stripped_content)
+        self.assertIn("alert alert-success", stripped_content)
 
         # Partial clone
         response = self.client.post(url, {
@@ -48,8 +49,9 @@ class CourseCloneTest(CourseTestCase):
             'key_month': 'Test',
         }, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "alert alert-danger")
-        self.assertContains(response, "alert alert-success")
+        stripped_content = response.content.decode("utf-8").replace("modal-submit-error alert alert-danger", "")
+        self.assertNotIn("alert alert-danger", stripped_content)
+        self.assertIn("alert alert-success", stripped_content)
 
         instance = CourseInstance.objects.get(id=1)
         self.assertEqual(instance.url, instance_url)
@@ -104,8 +106,9 @@ class CourseCloneTest(CourseTestCase):
             'sis': '123',
         }, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "alert alert-danger")
-        self.assertContains(response, "alert alert-success")
+        stripped_content = response.content.decode("utf-8").replace("modal-submit-error alert alert-danger", "")
+        self.assertNotIn("alert alert-danger", stripped_content)
+        self.assertIn("alert alert-success", stripped_content)
 
         # The asserted values are coming from in sis_test.py
         sis_instance = CourseInstance.objects.get(course=instance.course, url="sis-test")

--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -460,7 +460,8 @@
         data: formData,
         contentType: false,
         processData: false,
-        dataType: "html"
+        dataType: "html",
+        timeout: 10000,
       }).fail(function(xhr, textStatus, errorThrown) {
         //$(form_element).find(":input").prop("disabled", false);
         //exercise.showLoader("error");

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -3842,7 +3842,7 @@ msgid "TOTAL_NUMBER_OF_SUBMITTERS"
 msgstr "Total number of submitters"
 
 #: exercise/templates/exercise/_exercise_wait.html
-#: exercise/templates/exercise/exercise.html
+#: exercise/templates/exercise/exercise.html templates/base.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
 "There was a problem loading the assignment. Try loading the page again "

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -3979,9 +3979,10 @@ msgstr "Posting submission..."
 #: exercise/templates/exercise/_submit_progress.html
 msgid "SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE"
 msgstr ""
-"There was an error sending the submission for grading, so no submission was "
-"consumed. You can try again. Make sure you're connected to the internet. "
-"Course staff have been informed if the problem is with the service."
+"An error occurred while sending the submission for grading. Make sure you're "
+"connected to the internet. If a submission was consumed, the submission will "
+"be automatically graded after the service is available again. Course staff "
+"have been informed in case the problem is with the service."
 
 #: exercise/templates/exercise/_template_files.html
 msgid "EXERCISE_HAS_NO_TEMPLATE"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3987,9 +3987,10 @@ msgstr "Palautusta lähetetään..."
 #: exercise/templates/exercise/_submit_progress.html
 msgid "SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE"
 msgstr ""
-"Palautuksen lähettämisessä arvosteluun tapahtui virhe eikä palautuskertoja "
-"kulunut. Voit yrittää vielä uudestaan. Tarkistathan internet-yhteytesi. "
-"Henkilökunnalle on ilmoitettu mikäli onglema on palvelussa."
+"Palautuksen lähettämisessä arvosteluun tapahtui virhe. Tarkistathan internet-"
+"yhteytesi. Jos palautuskerta käytettiin, palautus arvostellaan "
+"automaattisesti, kun palvelu on jälleen käytettävissä. Kurssihenkilökunnalle "
+"on ilmoitettu mikäli ongelma on palvelussa."
 
 #: exercise/templates/exercise/_template_files.html
 msgid "EXERCISE_HAS_NO_TEMPLATE"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3849,7 +3849,7 @@ msgid "TOTAL_NUMBER_OF_SUBMITTERS"
 msgstr "Palauttaneita opiskelijoita yhteensä"
 
 #: exercise/templates/exercise/_exercise_wait.html
-#: exercise/templates/exercise/exercise.html
+#: exercise/templates/exercise/exercise.html templates/base.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
 "Tehtävän lataaminen epäonnistui. Yritä uudelleen myöhemmin. "

--- a/templates/base.html
+++ b/templates/base.html
@@ -249,6 +249,9 @@
 		<div class="modal-dialog modal-lg">
 			<div class="modal-content">
 				<div class="modal-progress">
+					<div class="modal-submit-error alert alert-danger" style="display:none">
+						{% translate "EXERCISE_ERROR_COMMUNICATION" %}
+					</div>
 					<div class="progress">
 						<div class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%"
 							data-msg-error="{% translate 'LOADING_FAILED' %}">


### PR DESCRIPTION
# Description

**What?**

Previously when the student's internet connection or MOOC-Grader was down, submitting a questionnaire resulted in the error message ``Connecting to the assessment service failed!`` to be displayed. A more suitable error message had existed, but it was not shown because of a bug.

This bug is now fixed by adding a timeout to the submit request (the request's failure handler is now properly called). The existing error message ``SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE`` was also modified to be more descriptive.

If A+ can't be reached, a submission is obviously not consumed by making the submit request. However, a submission is consumed if A+ receives the submit request, even if MOOC-Grader can't be reached. In this case, the submission is put into the ``Initialized`` state and should be automatically sent to the grading service when it is available.

It is not easy to distinguish whether the user's internet connection is down or if the grading service is down, since they both result in a similar timeout in ``chapter.js``. This is why we use the same error message for both scenarios.

Closes #852

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested scenarios where a questionnaire was submitted while A+ or MOOC-Grader wasn't reachable. The error message was displayed properly in both cases.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
