### PR TITLE
Check that starting and ending times are not None

### DIFF
--- a/course/models.py
+++ b/course/models.py
@@ -707,7 +707,7 @@ class CourseInstance(UrlMixin, models.Model):
             errors['instance_name'] = format_lazy(_('COURSE_INSTANCE_ERROR_INSTANCE_NAME -- {}'), self.instance_name)
         if self.url in RESERVED:
             errors['url'] = format_lazy(_('COURSE_INSTANCE_ERROR_URL -- {}'), self.url)
-        if self.ending_time <= self.starting_time:
+        if self.ending_time and self.starting_time and self.ending_time <= self.starting_time:
             errors['ending_time'] = _('COURSE_INSTANCE_ERROR_ENDING_TIME_BEFORE_STARTING')
         if self.lifesupport_time and self.lifesupport_time < self.ending_time:
             errors['lifesupport_time'] = _('COURSE_INSTANCE_ERROR_LIFESUPPORT_TIME_BEFORE_ENDING')


### PR DESCRIPTION
# Description

**What?**

Check that starting and ending time are not None.

**Why?**

Admin page crashed when creating new course instance with empty date fields.

**How?**

Check that starting and ending time are not None.

Fixes #1174

# Testing

Did basic checks that it doesn't crash anymore and can still create new instances.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

