### PR TITLE
Make course module folding optional and implement automatic scrolling

### DIFF
--- a/exercise/static/exercise/user_results.js
+++ b/exercise/static/exercise/user_results.js
@@ -1,0 +1,146 @@
+function checkButton(button) {
+  button
+    .attr("aria-pressed", "true")
+    .find("span")
+    .removeClass("glyphicon-unchecked")
+    .addClass("glyphicon-check");
+}
+
+function uncheckButton(button) {
+  button
+    .attr("aria-pressed", "false")
+    .find("span")
+    .removeClass("glyphicon-check")
+    .addClass("glyphicon-unchecked");
+}
+
+function expandModules(skipAnimation) {
+  if (skipAnimation) {
+    $(".module-panel > div").addClass("in"); // addClass("in") skips the expand animation
+  }
+  $(".module-panel > div").collapse("show");
+  checkButton($("#toggle-expand-all-modules"));
+}
+
+function collapseModules() {
+  $(".module-panel, .module-to-collapse > div").collapse("hide");
+  uncheckButton($("#toggle-expand-all-modules"));
+}
+
+function startListen(course) {
+  $(".filter-categories button").on("click", function(event) {
+    const button = $(this);
+    const id = button.attr("data-category");
+    if (button.attr("aria-pressed") === "false") {
+      checkButton(button);
+      $('.module-panel tr[data-category="' + id + '"]').removeClass("hide");
+    } else {
+      uncheckButton(button);
+      $('.module-panel tr[data-category="' + id + '"]').addClass("hide");
+    }
+    $('.module-panel').each(function(index, panel) {
+      const mod = $(panel);
+      if (mod.find("tr:not(.hide)").length > 0) {
+        mod.removeClass("hide");
+      } else {
+        mod.addClass("hide");
+      }
+    });
+  });
+
+  if ($(".module-to-collapse").length > 0) {
+    // Show the "Expand all modules" button if some modules are collapsed
+    $("#toggle-expand-all-modules").show();
+    // Check local storage and expand all modules if the variable "expandAllModules" is set to true
+    const expandAllModules = localStorage.getItem("expandAllModules") === "true";
+    if (expandAllModules) {
+      expandModules(true);
+    }
+
+    // Register an event handler to the "Expand all modules" button
+    $("#toggle-expand-all-modules").on("click", function(event) {
+      const expandAllModules = localStorage.getItem("expandAllModules") === "true";
+      if (expandAllModules) {
+        collapseModules();
+        localStorage.setItem("expandAllModules", false);
+      } else {
+        expandModules(false);
+        localStorage.setItem("expandAllModules", true);
+      }
+    });
+
+    // Check if automatic scrolling is enabled and initialize the local storage variable
+    $("#toggle-auto-scroll").show();
+    const autoScrollEnabled = localStorage.getItem("autoScrollEnabled");
+    if (autoScrollEnabled === "false") {
+      uncheckButton($("#toggle-auto-scroll"));
+    } else if (!autoScrollEnabled) {
+      localStorage.setItem("autoScrollEnabled", true); // Scroll automatically by default
+    }
+
+    // Check if automatic scrolling behavior is set to "instant" and initialize the local storage variable
+    if (autoScrollEnabled !== "false") {
+      $("#auto-scroll-behavior-instant").show();
+    }
+    const autoScrollBehavior = localStorage.getItem("autoScrollBehavior");
+    if (autoScrollBehavior === "instant") {
+      checkButton($("#auto-scroll-behavior-instant"));
+    } else if (!autoScrollBehavior) {
+      localStorage.setItem("autoScrollBehavior", "smooth"); // Scroll smoothly by default
+    }
+
+    // Register event handlers to both buttons related to automatic scrolling
+    $("#toggle-auto-scroll").on("click", function(event) {
+      const autoScrollEnabled = localStorage.getItem("autoScrollEnabled");
+      if (autoScrollEnabled === "false") {
+        checkButton($("#toggle-auto-scroll"));
+        $("#auto-scroll-behavior-instant").show();
+        localStorage.setItem("autoScrollEnabled", "true");
+      } else {
+        uncheckButton($("#toggle-auto-scroll"));
+        $("#auto-scroll-behavior-instant").hide();
+        localStorage.setItem("autoScrollEnabled", "false");
+      }
+    });
+
+    $("#auto-scroll-behavior-instant").on("click", function(event) {
+      const autoScrollBehavior = localStorage.getItem("autoScrollBehavior");
+      if (autoScrollBehavior === "instant") {
+        uncheckButton($("#auto-scroll-behavior-instant"));
+        localStorage.setItem("autoScrollBehavior", "smooth");
+      } else {
+        checkButton($("#auto-scroll-behavior-instant"));
+        localStorage.setItem("autoScrollBehavior", "instant");
+      }
+    });
+  }
+
+  // Get current course news from the document and previously shown course news from local storage
+  const news = [];
+  $(".news-panel > .list-group > .list-group-item").each(function() {
+    const title = $(this).children(".list-group-item-heading").children(".list-group-item-title")[0].innerText || "";
+    const body = $(this).children(".list-group-item-text")[0].innerText || "";
+    news.push({ [title]: body });
+  });
+  const allPreviousNews = JSON.parse(localStorage.getItem("courseNews")) || {};
+  const previousNews = course in allPreviousNews ? allPreviousNews[course] : [];
+  const currentNews = news.length > 0 ? news : previousNews;
+  if (news.length > 0) {
+    const allCurrentNews = { ...allPreviousNews, [course]: currentNews };
+    localStorage.setItem("courseNews", JSON.stringify(allCurrentNews));
+  }
+
+  function autoScroll() {
+    const autoScrollEnabled = localStorage.getItem("autoScrollEnabled");
+    if (autoScrollEnabled === "true" && $(".module-to-collapse").length > 0) {
+      const autoScrollBehavior = localStorage.getItem("autoScrollBehavior");
+      // Scroll to the first open module if there are no new news items
+      const openModules = $(".module-panel:not(.module-to-collapse)");
+      if (openModules.length > 0 && JSON.stringify(currentNews) === JSON.stringify(previousNews)) {
+        openModules[0].querySelector(".panel-heading").scrollIntoView({ behavior: autoScrollBehavior });
+      }
+    }
+  }
+
+  setTimeout(autoScroll, 10); // Instant automatic scrolling does not work without a small delay
+}

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -1,13 +1,16 @@
 {% load i18n %}
+{% load static %}
 {% load course %}
 {% load exercise %}
+
+<script src="{% static 'exercise/user_results.js' %}"></script>
 
 {% if categories|len_listed > 1 %}
 <p class="filter-categories">
 	<small>{% translate "FILTER_VIEW" %}:</small>
 	{% for entry in categories %}
 	{% if entry|is_listed %}
-	<button class="aplus-button--secondary aplus-button--xs" data-category="{{ entry.id }}">
+	<button class="aplus-button--secondary aplus-button--xs" data-category="{{ entry.id }}" aria-pressed="true">
 		<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
 		{{ entry.name|parse_localization }}
 	</button>
@@ -16,10 +19,18 @@
 </p>
 {% endif %}
 
-<p id="toggle-expired" class="hide">
-	<button class="aplus-button--secondary aplus-button--xs">
-		<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-		{% translate "SHOW_OLDER_ASSIGNMENTS" %}
+<p>
+	<button id="toggle-expand-all-modules" class="aplus-button--secondary aplus-button--xs" aria-pressed="false" style="display:none">
+		<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+		{% translate "EXPAND_ALL_MODULES" %}
+	</button>
+	<button id="toggle-auto-scroll" class="aplus-button--secondary aplus-button--xs" aria-pressed="true" style="display:none">
+		<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+		{% translate "AUTO_SCROLL" %}
+	</button>
+	<button id="auto-scroll-behavior-instant" class="aplus-button--secondary aplus-button--xs" aria-pressed="false" style="display:none">
+		<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+		{% translate "AUTO_SCROLL_BEHAVIOR_INSTANT" %}
 	</button>
 </p>
 
@@ -28,7 +39,7 @@
 {% with open=module|exercises_open:now after_open=module|has_opened:now %}
 {% module_accessible module as accessible %}
 {% exercise_accessible module as exercise_accessible %}
-<div class="panel panel-primary module-panel{% if not open and after_open %} module-expired{% endif %}">
+<div class="panel panel-primary module-panel{% if not accessible or not open and after_open %} module-to-collapse{% endif %}">
 	<a class="panel-heading{% if not accessible or not open and after_open %} collapsed{% endif %}"
 		role="button" href="#module{{ module.id }}" data-toggle="collapse"
 		aria-expanded="{% if accessible and not after_open or open %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
@@ -221,41 +232,8 @@
 {% endfor %}
 
 <script>
-var aplusPointsTotal = {{ total_json|safe }};
-
-$(function() {
-	var limit = 2;
-	var expired = $(".module-expired");
-	if (expired.length > limit) {
-		expired.slice(0, expired.length - limit).hide();
-		$("#toggle-expired").removeClass("hide")
-		.find("button").on("click", function(event) {
-			event.preventDefault();
-			$(".module-expired:hidden").show();
-			$(this).parent().hide();
-		});
-	}
-
-	$('.filter-categories button').on("click", function(event) {
-		var button = $(this);
-		var id = button.attr("data-category");
-		if (button.hasClass("active")) {
-			button.removeClass("active")
-			.find("span").removeClass("glyphicon-unchecked").addClass("glyphicon-check");
-			$('.module-panel tr[data-category="' + id + '"]').removeClass("hide");
-		} else {
-			button.addClass("active")
-			.find("span").removeClass("glyphicon-check").addClass("glyphicon-unchecked");
-			$('.module-panel tr[data-category="' + id + '"]').addClass("hide");
-		}
-		$('.module-panel').each(function(index, panel) {
-			var mod = $(panel);
-			if (mod.find("tr:not(.hide)").length > 0) {
-				mod.removeClass("hide");
-			} else {
-				mod.addClass("hide");
-			}
-		});
-	});
-});
+	var aplusPointsTotal = {{ total_json|safe }};
+	window.addEventListener("load", function() {
+		startListen("{{course|safe}}");
+	}, false);
 </script>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 14:12+0300\n"
+"POT-Creation-Date: 2023-07-19 08:06+0300\n"
 "PO-Revision-Date: 2021-05-27 14:47+0300\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: English<>\n"
@@ -4011,8 +4011,16 @@ msgid "FILTER_VIEW"
 msgstr "Show"
 
 #: exercise/templates/exercise/_user_results.html
-msgid "SHOW_OLDER_ASSIGNMENTS"
-msgstr "Show older assignments"
+msgid "EXPAND_ALL_MODULES"
+msgstr "Expand all modules"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "AUTO_SCROLL"
+msgstr "Automatic scrolling"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "AUTO_SCROLL_BEHAVIOR_INSTANT"
+msgstr "Instant scrolling"
 
 #: exercise/templates/exercise/_user_results.html
 msgid "OPENS ON"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 14:12+0300\n"
+"POT-Creation-Date: 2023-07-19 08:06+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -4021,8 +4021,16 @@ msgid "FILTER_VIEW"
 msgstr "Näytä"
 
 #: exercise/templates/exercise/_user_results.html
-msgid "SHOW_OLDER_ASSIGNMENTS"
-msgstr "Näytä vanhemmat tehtävät"
+msgid "EXPAND_ALL_MODULES"
+msgstr "Laajenna kaikki moduulit"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "AUTO_SCROLL"
+msgstr "Automaattinen vieritys"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "AUTO_SCROLL_BEHAVIOR_INSTANT"
+msgstr "Nopea vieritys"
 
 #: exercise/templates/exercise/_user_results.html
 msgid "OPENS ON"


### PR DESCRIPTION
# Description

**What?**

The automatic folding and hiding of expired course modules on the user results page was suboptimal and annoying for some students/teachers.

Old course modules are no longer hidden behind a button and folding is made optional with the use of a new "Expand all modules" button. Automatic scrolling takes the user to the first open module, unless the page contains previously unseen course news.

**Why?**

Improvements to course module folding were requested by a teacher.

**How?**

Local storage is used to save the state of the "Expand all modules" button and the course news strings for each course.

If the "Expand all modules" button is checked, all course modules will be expanded upon page load, even if they are expired or inaccessible.

If the page contains course news that aren't found in local storage, the page will not be automatically scrolled to the first open module, so that the student has a chance of noticing the news. 

Fixes #1125

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the folding and scrolling work as expected.

**Did you test the changes in**

- [x] Chrome
- [x] Safari
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface?

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
