### PR TITLE
Separate unconfirmed points in all results data

### DIFF
--- a/exercise/api/csv/tests.py
+++ b/exercise/api/csv/tests.py
@@ -1,0 +1,201 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from course.models import Course, CourseInstance, CourseModule
+from exercise.models import BaseExercise, CourseChapter, LearningObjectCategory
+from exercise.submission_models import Submission
+
+from .views import CourseResultsDataViewSet
+
+class CourseResultsDataViewSetTest(TestCase):
+    def setUp(self):
+        # Make a student
+        self.student = User(username="testUser", first_name="Superb",
+                            last_name="Student", email="test@aplus.com")
+        self.student.set_password("testPassword")
+        self.student.save()
+        self.student_profile = self.student.userprofile
+        self.student_profile.student_id = "12345X"
+        self.student_profile.save()
+
+        self.student2 = User(username="testUser2", first_name="Superb",
+                            last_name="Student", email="test@aplus.com")
+        self.student2.set_password("testPassword")
+        self.student2.save()
+        self.student_profile2 = self.student2.userprofile
+        self.student_profile2.student_id = "12345Y"
+        self.student_profile2.save()
+
+        # Make a course and course instance
+        self.course = Course.objects.create(
+            name="test course",
+            code="123456",
+            url="Course-Url"
+        )
+
+        self.today = timezone.now()
+        self.tomorrow = self.today + timedelta(days=1)
+
+        self.course_instance1 = CourseInstance.objects.create(
+            instance_name="Fall 2011 day 1",
+            starting_time=self.today,
+            ending_time=self.tomorrow,
+            course=self.course,
+            url="T-00.1000_d1"
+        )
+
+        # Add learning object categories to course
+        self.chapter_category = LearningObjectCategory.objects.create(
+            name="chapter",
+            course_instance=self.course_instance1
+        )
+        self.learning_object_category1 = LearningObjectCategory.objects.create(
+            name="test category 1",
+            course_instance=self.course_instance1
+        )
+        self.mandatory_category1 = LearningObjectCategory.objects.create(
+            name="mandatory category 1",
+            confirm_the_level=True,
+            course_instance=self.course_instance1
+        )
+
+        self.module1 = CourseModule.objects.create(
+            name="module1",
+            url="module1",
+            course_instance=self.course_instance1,
+        )
+
+        # Add learning objects to module1
+        self.learning_object1 = BaseExercise.objects.create(
+            name="learning object 1",
+            url="lo1",
+            course_module=self.module1,
+            category=self.learning_object_category1,
+        )
+        self.mandatory_learning_object1 = BaseExercise.objects.create(
+            name="mandatory learning object 1",
+            url="mlo1",
+            course_module=self.module1,
+            category=self.mandatory_category1,
+            points_to_pass=1,
+        )
+
+        # Add learning objects to module1
+        self.chapter1 = CourseChapter.objects.create(
+            name="chapter 1",
+            url="c1",
+            course_module=self.module1,
+            category=self.chapter_category,
+        )
+        self.c1_learning_object1 = BaseExercise.objects.create(
+            name="c1 learning object 1",
+            url="c1lo1",
+            course_module=self.module1,
+            parent=self.chapter1,
+            category=self.learning_object_category1,
+        )
+        self.c1_mandatory_learning_object1 = BaseExercise.objects.create(
+            name="c1 mandatory learning object 1",
+            url="c1mlo1",
+            course_module=self.module1,
+            parent=self.chapter1,
+            category=self.mandatory_category1,
+            points_to_pass=1,
+        )
+
+        # Add a student to course instance
+        self.course_instance1.enroll_student(self.student_profile.user)
+        self.course_instance1.enroll_student(self.student_profile2.user)
+
+    def test_get_submissions_query_unconfirmed_points(self):
+        def query(unconfirmed: bool):
+            qset = view.get_submissions_query(
+                ids,
+                self.course_instance1.students,
+                [],
+                ids,
+                True,
+                unconfirmed,
+            )
+            return {(row["submitters__user_id"], row["exercise_id"], row["count"]) for row in qset}
+
+        def create_submission(user_profile, exercise, **kwargs):
+            nonlocal submissions
+            sub = Submission.objects.create(exercise=exercise, **kwargs)
+            sub.submitters.add(user_profile)
+
+            submissions.setdefault((user_profile.user_id, exercise.id), [0, False])
+            submissions[(user_profile.user_id, exercise.id)][0] += 1
+
+            if exercise.category.confirm_the_level and sub.grade >= exercise.points_to_pass:
+                if exercise.parent is not None:
+                    children = exercise.parent.children.all()
+                else:
+                    children = [lo for lo in exercise.course_module.learning_objects.all() if lo.parent is None]
+
+                for c in children:
+                    if (user_profile.user_id, c.id) in submissions:
+                        submissions[(user_profile.user_id, c.id)][1] = True
+
+            return (user_profile.user_id, exercise.id, 1)
+
+        def all_submissions():
+            nonlocal submissions
+            return {
+                (user_id, ex_id, count)
+                for (user_id, ex_id), (count, confirmed) in submissions.items()
+            }
+
+        def confirmed_submissions():
+            nonlocal submissions
+            return {
+                (user_id, ex_id, count)
+                for (user_id, ex_id), (count, confirmed) in submissions.items()
+                if confirmed
+            }
+
+        view = CourseResultsDataViewSet()
+        view.instance = self.course_instance1
+
+        submissions = {}
+
+        ids = [
+            self.learning_object1.id,
+            self.mandatory_learning_object1.id,
+            self.c1_learning_object1.id,
+            self.c1_mandatory_learning_object1.id,
+        ]
+
+        create_submission(self.student_profile, exercise=self.learning_object1)
+        create_submission(self.student_profile, exercise=self.c1_learning_object1)
+        create_submission(self.student_profile2, exercise=self.learning_object1)
+        create_submission(self.student_profile2, exercise=self.c1_learning_object1)
+
+        self.assertEqual(query(True), all_submissions())
+        self.assertEqual(query(False), confirmed_submissions())
+
+
+        create_submission(self.student_profile, exercise=self.mandatory_learning_object1, grade=2)
+
+        self.assertEqual(query(True), all_submissions())
+        self.assertEqual(query(False), confirmed_submissions())
+
+
+        create_submission(self.student_profile, exercise=self.c1_mandatory_learning_object1, grade=2)
+
+        self.assertEqual(query(True), all_submissions())
+        self.assertEqual(query(False), confirmed_submissions())
+
+
+        create_submission(self.student_profile2, exercise=self.c1_mandatory_learning_object1, grade=0)
+
+        self.assertEqual(query(True), all_submissions())
+        self.assertEqual(query(False), confirmed_submissions())
+
+        create_submission(self.student_profile2, exercise=self.c1_mandatory_learning_object1, grade=2)
+
+        self.assertEqual(query(True), all_submissions())
+        self.assertEqual(query(False), confirmed_submissions())

--- a/exercise/api/csv/views.py
+++ b/exercise/api/csv/views.py
@@ -1,5 +1,13 @@
-from typing import Any, Dict, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
+from django.db.models import (
+    Exists,
+    ExpressionWrapper,
+    F,
+    IntegerField,
+    OuterRef,
+    Q,
+)
 from django.db.models.aggregates import Count
 from django.db.models.query import QuerySet
 from rest_framework import viewsets
@@ -14,6 +22,8 @@ from lib.api.mixins import MeUserMixin
 from lib.api.constants import REGEX_INT_ME
 from course.api.mixins import CourseResourceMixin
 from course.permissions import IsCourseAdminOrUserObjIsSelf
+from exercise.exercise_models import BaseExercise
+from exercise.submission_models import SubmissionQuerySet
 from userprofile.models import UserProfile
 
 from ...cache.points import CachedPoints
@@ -320,11 +330,74 @@ class CourseResultsDataViewSet(NestedViewSetMixin,
         return self.serialize_profiles(request, [self.get_object()])
 
     # pylint: disable-next=too-many-arguments
-    def get_submissions_query(self, ids, profiles, exclude_list, revealed_ids, show_unofficial):
+    def get_submissions_query(
+            self,
+            ids: List[int],
+            profiles: QuerySet[UserProfile],
+            exclude_list: List[str], # Submission.STATUS
+            revealed_ids: Iterable[int],
+            show_unofficial: bool,
+            show_unconfirmed: bool,
+            ) -> SubmissionQuerySet:
         query = (
             Submission.objects
             .filter(exercise__in=ids, submitters__in=profiles)
             .exclude(status__in=(exclude_list))
+        )
+
+        if not show_unconfirmed:
+            # Select mandatory sibling exercises
+            need_to_confirm = (
+                BaseExercise.objects
+                .annotate(
+                    # ExpressionWrapper is needed due to https://code.djangoproject.com/ticket/31714
+                    outer_parent_id=ExpressionWrapper(
+                        OuterRef("exercise__parent_id"),
+                        output_field=IntegerField(),
+                    )
+                )
+                .filter(
+                    Q(parent_id=F("outer_parent_id"))
+                    # Exercises directly under a module have NULL parents
+                    | Q(parent_id=None, outer_parent_id=None),
+                )
+                .filter(
+                    course_module__course_instance=self.instance,
+                    category__confirm_the_level=True,
+                    course_module_id=OuterRef("exercise__course_module_id"),
+                )
+            )
+            # Select submissions that pass mandatory sibling exercises
+            confirmed = (
+                Submission.objects
+                .annotate(
+                    # ExpressionWrapper is needed due to https://code.djangoproject.com/ticket/31714
+                    outer_parent_id=ExpressionWrapper(
+                        OuterRef("exercise__parent_id"),
+                        output_field=IntegerField(),
+                    )
+                )
+                .filter(
+                    Q(exercise__parent_id=F("outer_parent_id"))
+                    # Exercises directly under a module have NULL parents
+                    | Q(exercise__parent_id=None, outer_parent_id=None),
+                )
+                .filter(
+                    submitters=OuterRef("submitters"),
+                    exercise__category__confirm_the_level=True,
+                    exercise__course_module_id=OuterRef("exercise__course_module_id"),
+                )
+                .passes()
+            )
+            # Exclude unconfirmed submissions: a submission is unconfirmed
+            # if it has at least one mandatory exercise sibling (including the exercise itself)
+            # and none of them have been completed yet
+            query = query.filter(
+                ~Exists(need_to_confirm) | Exists(confirmed)
+            )
+
+        query = (
+            query
             .values('submitters__user_id', 'exercise_id')
             .annotate(count=Count('id'))
         )
@@ -344,7 +417,8 @@ class CourseResultsDataViewSet(NestedViewSetMixin,
         show_unofficial = request.GET.get('show_unofficial') == 'true'
         if not show_unofficial:
             exclude_list.append(Submission.STATUS.UNOFFICIAL)
-        aggr = self.get_submissions_query(ids, profiles, exclude_list, revealed_ids, show_unofficial)
+        show_unconfirmed = request.GET.get('show_unconfirmed') == 'true'
+        aggr = self.get_submissions_query(ids, profiles, exclude_list, revealed_ids, show_unofficial, show_unconfirmed)
         data,fields = aggregate_points(
             profiles,
             self.instance.taggings.all(),

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -1123,6 +1123,16 @@
      * @param {*} show_unofficial
      */
     function loadStudentData(show_unofficial, show_unconfirmed, ignore_last_grading_mode) {
+        if(show_unofficial == undefined) {
+            show_unofficial = $('input.unofficial-checkbox').prop('checked')
+        }
+        if(show_unconfirmed == undefined) {
+            show_unconfirmed = $('input.unconfirmed-checkbox').prop('checked')
+        }
+        if(ignore_last_grading_mode == undefined) {
+            ignore_last_grading_mode = $('#ignore-last-mode-checkbox').prop('checked');
+        }
+
         // Destroy old data table if it exists
         // Also multiselects and event handlers that will be recreated
         if(dtApi !== undefined) {
@@ -1574,21 +1584,10 @@
      * To toggle whether only official points are displayed, we need to refetch the
      * data from backend. This is because the frontend logic is already very complex.
      */
-    $('input.unconfirmed-checkbox').change(function(){
-        loadStudentData($('input.unofficial-checkbox').prop('checked'), $(this).prop('checked'), $('#ignore-last-mode-checkbox').prop('checked'));
-    });
-
-    $('input.unofficial-checkbox').change(function(){
-        loadStudentData($(this).prop('checked'), $('input.unconfirmed-checkbox').prop('checked'), $('#ignore-last-mode-checkbox').prop('checked'));
-    });
-
-    $('#ignore-last-mode-checkbox').change(function(){
-        loadStudentData($('input.unofficial-checkbox').prop('checked'), $('input.unconfirmed-checkbox').prop('checked'), $(this).prop('checked'));
-    });
-
-    $(document).on("aplus:translation-ready", function() {
-        loadStudentData(false, false, true);
-    });
+    $('input.unconfirmed-checkbox').change(() => loadStudentData());
+    $('input.unofficial-checkbox').change(() => loadStudentData());
+    $('#ignore-last-mode-checkbox').change(() => loadStudentData());
+    $(document).on("aplus:translation-ready", () => loadStudentData());
 
 })(jQuery, document, window);
 

--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -1122,7 +1122,7 @@
      * Loads new data on page load, and when "Show only official points" checkbox clicked
      * @param {*} show_unofficial
      */
-    function loadStudentData(show_unofficial, ignore_last_grading_mode) {
+    function loadStudentData(show_unofficial, show_unconfirmed, ignore_last_grading_mode) {
         // Destroy old data table if it exists
         // Also multiselects and event handlers that will be recreated
         if(dtApi !== undefined) {
@@ -1138,6 +1138,7 @@
         let pUrl = pointsBestUrl;
         if (!ignore_last_grading_mode) pUrl = pointsUrl;
         if (show_unofficial) pUrl = pUrl + "&show_unofficial=true";
+        if (show_unconfirmed) pUrl = pUrl + "&show_unconfirmed=true";
         $.when(
             $.ajax(exercisesUrl),
             $.ajax(pUrl),
@@ -1573,16 +1574,20 @@
      * To toggle whether only official points are displayed, we need to refetch the
      * data from backend. This is because the frontend logic is already very complex.
      */
-    $('input.official-checkbox').change(function(){
-        loadStudentData(!$(this).prop('checked'), $('#ignore-last-mode-checkbox').prop('checked'));
+    $('input.unconfirmed-checkbox').change(function(){
+        loadStudentData($('input.unofficial-checkbox').prop('checked'), $(this).prop('checked'), $('#ignore-last-mode-checkbox').prop('checked'));
+    });
+
+    $('input.unofficial-checkbox').change(function(){
+        loadStudentData($(this).prop('checked'), $('input.unconfirmed-checkbox').prop('checked'), $('#ignore-last-mode-checkbox').prop('checked'));
     });
 
     $('#ignore-last-mode-checkbox').change(function(){
-        loadStudentData(!$('input.official-checkbox').prop('checked'), $(this).prop('checked'));
+        loadStudentData($('input.unofficial-checkbox').prop('checked'), $('input.unconfirmed-checkbox').prop('checked'), $(this).prop('checked'));
     });
 
     $(document).on("aplus:translation-ready", function() {
-        loadStudentData(false, true);
+        loadStudentData(false, false, true);
     });
 
 })(jQuery, document, window);

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -3,7 +3,7 @@ import json
 import logging
 from mimetypes import guess_type
 import os
-from typing import IO, Dict, Iterable, List, Tuple, TYPE_CHECKING
+from typing import IO, Dict, Iterable, List, Tuple, TYPE_CHECKING, Callable
 from urllib.parse import urlparse
 
 from binaryornot.check import is_binary
@@ -36,6 +36,10 @@ logger = logging.getLogger('aplus.exercise')
 
 
 class SubmissionQuerySet(models.QuerySet):
+    def passes(self) -> "SubmissionQuerySet":
+        """Filter only submissions that pass the exercise"""
+        return self.filter(grade__gte=F("exercise__points_to_pass"))
+
     def annotate_submitter_points(
             self,
             field_name: str = 'total',
@@ -219,6 +223,9 @@ class SubmissionQuerySet(models.QuerySet):
 
 class SubmissionManager(JWTAccessible["Submission"], models.Manager):
     _queryset_class = SubmissionQuerySet
+
+    # Hints the correct return type for .filter(...)
+    filter: Callable[..., SubmissionQuerySet]
 
     def get_queryset(self):
         return super().get_queryset()\

--- a/exercise/templates/exercise/staff/results.html
+++ b/exercise/templates/exercise/staff/results.html
@@ -111,11 +111,17 @@ that includes the correct DataTables extensions. -->
 			<h4>{% translate "OPTIONS" %}</h4>
 			<span class="has-error">
 				<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
-				data-placement="right"
-				title="{% translate 'OFFICIAL_POINTS_TOOLTIP' %}">
-					<input type="checkbox" class="official-checkbox" value="official" checked>
-					{% translate "RESULTS_SHOW_ONLY_OFFICIAL_POINTS" %}
-			</label>
+					data-placement="right"
+					title="{% translate 'UNOFFICIAL_POINTS_TOOLTIP' %}">
+						<input type="checkbox" class="unofficial-checkbox" value="unofficial">
+						{% translate "RESULTS_SHOW_UNOFFICIAL_POINTS" %}
+				</label>
+				<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
+					data-placement="right"
+					title="{% translate 'UNCONFIRMED_POINTS_TOOLTIP' %}">
+						<input type="checkbox" class="unconfirmed-checkbox" value="unconfirmed">
+						{% translate "RESULTS_SHOW_UNCONFIRMED_POINTS" %}
+				</label>
 			</span>
 			<label style="margin-left: 10px;" class="checkbox-inline" data-toggle="tooltip"
 				title="{% translate 'RESULTS_SHOW_ONLY_STUDENT_WITH_SUBMISSIONS' %}">

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4522,20 +4522,29 @@ msgid "OPTIONS"
 msgstr "Options"
 
 #: exercise/templates/exercise/staff/results.html
-msgid "OFFICIAL_POINTS_TOOLTIP"
+msgid "UNOFFICIAL_POINTS_TOOLTIP"
 msgstr ""
 "Points are official if the submission is within deadline and submission "
 "count limits. Unofficial submissions are allowed only if they have been "
-"enabled in the assignment category settings. KNOWN ISSUES: (1) the official "
-"points currently include also unconfirmed points. Unconfirmed points exist "
-"only if mandatory activities have been enabled in the assignment category "
-"settings. Usually, mandatory activities are used for mandatory chapter "
-"feedback questionnaires. (2) DO NOT PRESS this checkbox MORE THAN ONCE. If "
-"you do, the points table will keep showing UNOFFICIAL points."
+"enabled in the assignment category settings. KNOWN ISSUE: DO NOT PRESS "
+"this checkbox MORE THAN ONCE. If you do, the points table will keep "
+"showing UNOFFICIAL points."
 
 #: exercise/templates/exercise/staff/results.html
-msgid "RESULTS_SHOW_ONLY_OFFICIAL_POINTS"
-msgstr "Show only official points"
+msgid "RESULTS_SHOW_UNOFFICIAL_POINTS"
+msgstr "Include unofficial points"
+
+#: exercise/templates/exercise/staff/results.html
+msgid "UNCONFIRMED_POINTS_TOOLTIP"
+msgstr ""
+"Points are unconfirmed if a mandatory exercise exists in the same chapter "
+"and the user has not passed it. Unconfirmed points exist only if mandatory "
+"activities have been enabled in the assignment category settings. Usually, "
+"mandatory activities are used for mandatory chapter feedback questionnaires."
+
+#: exercise/templates/exercise/staff/results.html
+msgid "RESULTS_SHOW_UNCONFIRMED_POINTS"
+msgstr "Include unconfirmed points"
 
 #: exercise/templates/exercise/staff/results.html
 msgid "RESULTS_SHOW_ONLY_STUDENT_WITH_SUBMISSIONS"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4534,21 +4534,30 @@ msgid "OPTIONS"
 msgstr "Valinnat"
 
 #: exercise/templates/exercise/staff/results.html
-msgid "OFFICIAL_POINTS_TOOLTIP"
+msgid "UNOFFICIAL_POINTS_TOOLTIP"
 msgstr ""
 "Pisteet ovat virallisia, jos palautus on tehty määräajassa ja sallittujen "
 "palautuskertojen sisällä. Epäviralliset palautukset ovat mahdollisia vain, "
 "jos epäviralliset palautukset on sallittu tehtäväkategorian asetuksissa. "
-"TUNNETUT ONGELMAT: (1) viralliset pisteet sisältävät myös vahvistamattomat "
-"pisteet. Vahvistamattomia pisteitä on olemassa vain, jos tehtäväkategoriassa "
-"on asetettu pakolliset osiot. Yleensä pakollisia osioita käytetään "
-"pakollisiin palautelomakkeisiin lukujen lopussa. (2) ÄLÄ PAINA tätä valintaa "
-"YLI YHDEN KERRAN. Jos tätä painetaan useammin kuin kerran, taulukko näyttää "
-"kuitenkin aina EPÄVIRALLISIA pisteitä."
+"TUNNETTU ONGELMA: ÄLÄ PAINA tätä valintaa YLI YHDEN KERRAN. Jos tätä "
+"painetaan useammin kuin kerran, taulukko näyttää kuitenkin aina "
+"EPÄVIRALLISIA pisteitä."
 
 #: exercise/templates/exercise/staff/results.html
-msgid "RESULTS_SHOW_ONLY_OFFICIAL_POINTS"
-msgstr "Näytä vain viralliset pisteet"
+msgid "RESULTS_SHOW_UNOFFICIAL_POINTS"
+msgstr "Sisällytä epäviralliset pisteet"
+
+#: exercise/templates/exercise/staff/results.html
+msgid "UNCONFIRMED_POINTS_TOOLTIP"
+msgstr ""
+"Pisteet ovat vahvistamattomia, jos samassa luvussa on pakollinen tehtävä ja "
+"käyttäjä ei ole päässyt sitä läpi. Vahvistamattomia pisteitä on olemassa "
+"vain, jos tehtäväkategoriassa on asetettu pakolliset osiot. Yleensä "
+"pakollisia osioita käytetään pakollisiin palautelomakkeisiin lukujen lopussa."
+
+#: exercise/templates/exercise/staff/results.html
+msgid "RESULTS_SHOW_UNCONFIRMED_POINTS"
+msgstr "Sisällytä vahvistamattomat pisteet"
 
 #: exercise/templates/exercise/staff/results.html
 msgid "RESULTS_SHOW_ONLY_STUDENT_WITH_SUBMISSIONS"


### PR DESCRIPTION
# Description

**What?**

Add checkbox to the all results UI to include/exclude unconfirmed points and backend logic for it.

**Why?**

#941

**How?**

Add a filter to the submission query to filter out unconfirmed submissions.

Closes #941

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [X] Django unit tests.
- [X] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Made unconfirmed submissions and checked that the filter leaves them out.

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [X] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
