### PR TITLE
Add "add deadline deviations" buttons to the points page

### DIFF
--- a/deviations/viewbase.py
+++ b/deviations/viewbase.py
@@ -1,5 +1,5 @@
 from itertools import groupby
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 from django.db import models
 from django.http import HttpRequest, HttpResponse
@@ -40,6 +40,19 @@ class AddDeviationsView(CourseInstanceMixin, BaseFormView):
         kwargs = super().get_form_kwargs()
         kwargs["instance"] = self.instance
         return kwargs
+
+    def get_initial_get_param_spec(self) -> Dict[str, Optional[Callable[[str], Any]]]:
+        def list_arg(arg):
+            return arg.split(",")
+
+        spec = super().get_initial_get_param_spec()
+        spec.update({
+            "module": list_arg,
+            "exercise": list_arg,
+            "submitter": list_arg,
+            "submitter_tag": list_arg,
+        })
+        return spec
 
     def form_valid(self, form: forms.BaseForm) -> HttpResponse:
         exercises = get_exercises(form.cleaned_data)

--- a/deviations/views.py
+++ b/deviations/views.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Optional
 
 from django.utils.dateparse import parse_datetime
 
@@ -27,6 +27,15 @@ class AddDeadlinesView(AddDeviationsView):
     form_class = DeadlineRuleDeviationForm
     deviation_model = DeadlineRuleDeviation
     session_key = 'add-deviations-data-dl'
+
+    def get_initial_get_param_spec(self) -> Dict[str, Optional[Callable[[str], Any]]]:
+        spec = super().get_initial_get_param_spec()
+        spec.update({
+            "minutes": int,
+            "new_date": None,
+            "without_late_penalty": lambda x: x == "true",
+        })
+        return spec
 
     def serialize_session_data(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
         result = super().serialize_session_data(form_data)

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -99,6 +99,9 @@
 
 		{% points_progress module %}
 		{{ module.introduction|safe }}
+		{% if student %}
+			{% adddeviationsbutton instance module submitters=student %}
+		{% endif %}
 	</div>
 	{% if not exercise_accessible and not is_course_staff %}
 	<div class="alert alert-warning clearfix site-message">
@@ -170,6 +173,9 @@
 						<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
 						{% translate "INSPECT" %}
 					</a>
+					{% endif %}
+					{% if student %}
+						{% adddeviationsbutton instance exercise=entry submitters=student %}
 					{% endif %}
 				</td>
 				<td>

--- a/exercise/templates/exercise/staff/_deviationslink.html
+++ b/exercise/templates/exercise/staff/_deviationslink.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% load course %}
+<a class="aplus-button--secondary aplus-button--xs" href="{{ instance|url:'deviations-add-dl' }}?module={{module.id}}&exercise={{exercise.id}}&submitter={{submitters}}">
+	<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+	{% translate "ADD_DEADLINE_DEVIATIONS" %}
+</a>

--- a/exercise/templates/exercise/staff/inspect_submission.html
+++ b/exercise/templates/exercise/staff/inspect_submission.html
@@ -48,6 +48,7 @@
 			<a href="{{ submission|url:'submission-edit-submitters' }}" class="aplus-button--secondary aplus-button--xs">
 				{% translate "EDIT" %}
 			</a>
+			{% adddeviationsbutton instance exercise=exercise submitters=submission.submitters.all %}
 			{% endif %}
 			{% profiles submission.submitters.all instance is_teacher %}
 		</div>


### PR DESCRIPTION
# Description

**What?**

Adds buttons to the points and inspect submission pages that take the user directly to the add deadline deviations page with some appropriate fields prepopulated (submitter and exercise, module or neither)

**Why?**

#1123

**How?**

Set initial values from GET parameters

Fixes #1123
Closes #1122 as unnecessary

# Testing

**What type of test did you run?**

- [X] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested that the buttons and GET parameters work.

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
