### PR TITLE
Fix ae submissions when alerts are present

### DIFF
--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -598,24 +598,25 @@
           var url = exercise.url;
           exercise.submitAjax(url, formData, function(data) {
             const content = $(data);
+
+            const site_alerts = content.find('.site-messages');
+            output.find(".site-messages").replaceWith(site_alerts);
+
             // Look for error alerts in the feedback, but skip the hidden element
             // that is always included: <div class="quiz-submit-error alert alert-danger hide">
-            const alerts = content.find('.alert-danger:not(.hide)');
-            if (!alerts.length) {
+            const alerts = content.find(':not(.site-messages) .alert-danger:not(.hide)');
+            output.find(".site-messages").append(alerts);
+
+            if (content.find(".exercise-wait").length != 0) {
               const poll_url = content.find(".exercise-wait").attr("data-poll-url");
               output.attr('data-poll-url', poll_url);
               const ready_url = content.find(".exercise-wait").attr("data-ready-url");
               output.attr('data-ready-url', ready_url);
 
               exercise.updateSubmission(content);
-            } else if (alerts.contents().text()
-            .indexOf("The grading queue is not configured.") >= 0) {
-              output.find(exercise.settings.ae_result_selector)
-              .html(content.find(".alert:not(.hide)").text());
-              output.find(exercise.settings.ae_result_selector).append(content.find(".grading-task").text());
             } else {
-              output.find(exercise.settings.ae_result_selector)
-              .html(alerts.contents());
+              out_content.html("<p>Failed to submit:</p>")
+              out_content.append(output.find(".site-messages").clone());
             }
           });
         });

--- a/templates/_messages.html
+++ b/templates/_messages.html
@@ -1,8 +1,10 @@
 {% if messages %}
-    {% for message in messages %}
-        <div class="alert alert-{% if message.level == 10 %}success{% elif message.level == 40 %}danger{% else %}{{ message.tags }}{% endif %} clearfix site-message" role="alert">
-            <span class="glyphicon glyphicon-{% if message.level == 25 %}check{% else %}warning-sign{% endif %}" aria-hidden="true"></span>
-            <div class="message">{{ message|safe }}</div>
-        </div>
-    {% endfor %}
+    <div class="site-messages">
+        {% for message in messages %}
+            <div class="alert alert-{% if message.level == 10 %}success{% elif message.level == 40 %}danger{% else %}{{ message.tags }}{% endif %} clearfix site-message" role="alert">
+                <span class="glyphicon glyphicon-{% if message.level == 25 %}check{% else %}warning-sign{% endif %}" aria-hidden="true"></span>
+                <div class="message">{{ message|safe }}</div>
+            </div>
+        {% endfor %}
+    </div>
 {% endif %}


### PR DESCRIPTION
# Description

**What?**

Fix ae submissions when alerts are present

**Why?**

Danger alerts overrode the output and caused the submission to be skipped. For example, deadline having passed or being staff without enrolling in the course would cause issues.

**How?**

Always show the alerts (replace the previous alerts above the exercise output), and poll the submission whenever one is created (even if a danger alert was included).

Part of #487

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested submitting with and without alerts to see that they show up but can still submit.

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
