### PR TITLE
Show all submissions by default

### DIFF
--- a/exercise/staff_views.py
+++ b/exercise/staff_views.py
@@ -92,14 +92,15 @@ class ListSubmissionsView(ExerciseListBaseView):
 
         for submission in qs:
             format_submission(submission, self.pseudonymize)
-        self.all = self.request.GET.get('all', None)
-        self.all_url = self.exercise.get_submission_list_url() + "?all=yes"
-        self.submissions = qs if self.all else qs[:self.default_limit]
+        self.limited = self.request.GET.get('limited', False)
+        self.not_all_url = self.exercise.get_submission_list_url() + "?limited=true"
+        self.all_url = self.exercise.get_submission_list_url()
+        self.submissions = qs[:self.default_limit] if self.limited else qs
         self.count = len(self.submissions)
         self.percentage_graded = (
             f"{graded_submitters} / {total_submitters} ({int(graded_submitters / total_submitters * 100)}%)"
         )
-        self.note("all", "all_url", "submissions", "default_limit", "count", "percentage_graded")
+        self.note("limited", "not_all_url", "all_url", "submissions", "default_limit", "count", "percentage_graded")
 
 
 class SubmissionsSummaryView(ExerciseBaseView):

--- a/exercise/templates/exercise/staff/_submissions_table.html
+++ b/exercise/templates/exercise/staff/_submissions_table.html
@@ -42,13 +42,17 @@
 	</div>
 	<p>
 		{% exercise_text_stats exercise %} |
-		{% if not all and count == default_limit %}
-		{% blocktranslate trimmed with limit=default_limit count=count url=all_url %}
+		{% if count <= default_limit and not limited %}
+		{% blocktranslate trimmed with count=count url=all_url %}
+			NUM_OF_SUBMISSIONS_DISPLAYED -- {{ count }}, {{ url }}
+		{% endblocktranslate %}
+		{% elif limited %}
+		{% blocktranslate trimmed with limit=default_limit url=all_url %}
 			NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_ALL_BTN -- {{ limit }}, {{ url }}
 		{% endblocktranslate %}
 		{% else %}
-		{% blocktranslate trimmed with count=count %}
-			NUM_OF_SUBMISSIONS_DISPLAYED -- {{ count }}
+		{% blocktranslate trimmed with count=count url=not_all_url limit=default_limit %}
+			NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_LATEST_BTN -- {{ count }}, {{ url }}, {{ limit }}
 		{% endblocktranslate %}
 		{% endif %}
 		<a class="aplus-button--secondary aplus-button--xs" href="{{ exercise|url:'submitter-list' }}">
@@ -56,7 +60,7 @@
 		</a>
 	</p>
 </div>
-<table class="table table-bordered{% if all or count < default_limit %} filtered-table ordered-table{% endif %}">
+<table class="table table-bordered{% if not limited or count < default_limit %} filtered-table ordered-table{% endif %}">
 		<thead>
 				<tr>
 						<th>{% translate "SUBMITTERS" %} {{percentage_graded}} {% translate "GRADED" %}</th>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4415,6 +4415,10 @@ msgid "SUMMARY"
 msgstr "Summary"
 
 #: exercise/templates/exercise/staff/_submissions_table.html
+msgid "NUM_OF_SUBMISSIONS_DISPLAYED -- %(count)s, %(url)s"
+msgstr "%(count)s submissions."
+
+#: exercise/templates/exercise/staff/_submissions_table.html
 #, python-format
 msgid "NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_ALL_BTN -- %(limit)s, %(url)s"
 msgstr ""
@@ -4423,8 +4427,12 @@ msgstr ""
 
 #: exercise/templates/exercise/staff/_submissions_table.html
 #, python-format
-msgid "NUM_OF_SUBMISSIONS_DISPLAYED -- %(count)s"
-msgstr "%(count)s submissions"
+msgid ""
+"NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_LATEST_BTN -- %(count)s, %(url)s, "
+"%(limit)s"
+msgstr ""
+"%(count)s submissions. <a class=\"aplus-button--secondary aplus-button--xs\" "
+"role=\"button\" href=\"%(url)s\">Show latest %(limit)s</a>"
 
 #: exercise/templates/exercise/staff/_submissions_table.html
 msgid "GROUP_BY_SUBMITTER"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4430,16 +4430,24 @@ msgid "SUMMARY"
 msgstr "Yhteenveto"
 
 #: exercise/templates/exercise/staff/_submissions_table.html
+msgid "NUM_OF_SUBMISSIONS_DISPLAYED -- %(count)s, %(url)s"
+msgstr "%(count)s palautusta."
+
+#: exercise/templates/exercise/staff/_submissions_table.html
 #, python-format
 msgid "NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_ALL_BTN -- %(limit)s, %(url)s"
 msgstr ""
-"%(limit)s viimeistä palautusta. <a class=\"aplus-button--secondary aplus-"
+"%(limit)s viimeisintä palautusta. <a class=\"aplus-button--secondary aplus-"
 "button--xs\" role=\"button\" href=\"%(url)s\">Näytä kaikki</a>"
 
 #: exercise/templates/exercise/staff/_submissions_table.html
 #, python-format
-msgid "NUM_OF_SUBMISSIONS_DISPLAYED -- %(count)s"
-msgstr "%(count)s palautusta"
+msgid ""
+"NUM_OF_SUBMISSIONS_DISPLAYED_AND_SHOW_LATEST_BTN -- %(count)s, %(url)s, "
+"%(limit)s"
+msgstr ""
+"%(count)s palautusta. <a class=\"aplus-button--secondary aplus-button--xs\" "
+"role=\"button\" href=\"%(url)s\">Näytä %(limit)s viimeisintä</a>"
 
 #: exercise/templates/exercise/staff/_submissions_table.html
 msgid "GROUP_BY_SUBMITTER"


### PR DESCRIPTION
# Description

**What?**

Shows all submissions in submission modal, instead of first 50. Adds a button to only show first 50 submissions.

**Why?**

The teacher probably wants to see all submissions, not just the first 50.

**How?**

Shows all submissions, unless an additional query parameter is specified.

Fixes #923


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Buttons "show latest x" and "show all" display the expected number of submissions.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

If the user wants to see all submissions on the full page (instead of the modal), it is now two clicks away.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
