### PR TITLE
Display personal deadline extensions on a student’s points page

### DIFF
--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Union
+from copy import deepcopy
 
 from django import template
 from django.db import models
@@ -20,6 +21,11 @@ def _prepare_topmenu(context):
         request = context.get('request', None)
         context['topmenu'] = CachedTopMenu(request.user if request else None)
     return context['topmenu']
+
+
+def _deadline_extended_exercise_open(entry, now):
+    personal_deadline = entry.get('personal_deadline')
+    return personal_deadline is not None and entry['opening_time'] <= now <= personal_deadline
 
 
 @register.inclusion_tag("course/_course_dropdown_menu.html", takes_context=True)
@@ -85,6 +91,17 @@ def is_in_maintenance(entry):
 @register.filter
 def exercises_open(entry, now):
     return entry['opening_time'] <= now <= entry['closing_time']
+
+
+@register.filter
+def deadline_extended_exercise_open(entry, now):
+    return _deadline_extended_exercise_open(entry, now)
+
+
+@register.filter
+def deadline_extended_exercises_open(entry, now):
+    entries = deepcopy(entry['flatted'])
+    return any(_deadline_extended_exercise_open(entry, now) for entry in entries)
 
 
 @register.filter

--- a/exercise/templates/exercise/_exercise_info.html
+++ b/exercise/templates/exercise/_exercise_info.html
@@ -54,7 +54,7 @@
 			<dd class="exercise-info-deadline">{{ exercise.course_module.closing_time }}</dd>
 
 			{% if cached_points.personal_deadline %}
-			<dt>{% translate "EXTENDED_DEADLINE" %}</dt>
+			<dt>{% translate "PERSONAL_EXTENDED_DEADLINE" %}</dt>
 			<dd class="exercise-info-extended-deadline">
 				{{ cached_points.personal_deadline }}
 				{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -135,10 +135,10 @@
 					{% if entry|deadline_extended_exercise_open:now %}
 						<span
 							data-toggle="tooltip"
-							title="{% translate 'PERSONAL_DEADLINE_DEVIATION' %} {{ entry.personal_deadline }}"
+							title="{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}"
 						>
 							<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-							<span class="sr-only">{% translate 'PERSONAL_DEADLINE_DEVIATION' %} {{ entry.personal_deadline }}</span>
+							<span class="sr-only">{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}</span>
 						</span>
 					{% endif %}
 					{% else %}

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -57,6 +57,11 @@
 				{% translate "OPEN_FOR_READING" %}
 			</span>
 			{% endif %}
+			{% if module|deadline_extended_exercises_open:now %}
+			<span class="badge pull-right">
+				{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
+			</span>
+			{% endif %}
 			{% if module.requirements|length > 0 %}
 			<span class="badge pull-right">
 				{% translate "REQUIRES" %}:
@@ -127,6 +132,15 @@
 				<td>
 					{% if exercise_accessible or is_course_staff %}
 					<a href="{{ entry.link }}" class="{% if entry|is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a>
+					{% if entry|deadline_extended_exercise_open:now %}
+						<span
+							data-toggle="tooltip"
+							title="{% translate 'PERSONAL_DEADLINE_DEVIATION' %} {{ entry.personal_deadline }}"
+						>
+							<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
+							<span class="sr-only">{% translate 'PERSONAL_DEADLINE_DEVIATION' %} {{ entry.personal_deadline }}</span>
+						</span>
+					{% endif %}
 					{% else %}
 					{{ entry.name|parse_localization }}
 					{% endif %}

--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -124,7 +124,7 @@
 											<li>
 												<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
 												{% if cached_points.personal_deadline %}
-													{% translate "EXTENDED_DEADLINE" %}
+													{% translate "PERSONAL_EXTENDED_DEADLINE" %}
 													{{ cached_points.personal_deadline }}
 													{% if module.late_submission_penalty > 0 and cached_points.personal_deadline_has_penalty %}
 													({% blocktranslate trimmed with penalty=module.late_submission_penalty|percent deadline=module.closing_time %}

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-19 08:06+0300\n"
+"POT-Creation-Date: 2023-08-25 12:04+0300\n"
 "PO-Revision-Date: 2021-05-27 14:47+0300\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: English<>\n"
@@ -4035,6 +4035,10 @@ msgid "OPEN_FOR_READING"
 msgstr "Open for reading"
 
 #: exercise/templates/exercise/_user_results.html
+msgid "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION"
+msgstr "Assignments with personal deadline extensions"
+
+#: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
 #: lti_tool/templates/lti_tool/lti_course.html
 msgid "REQUIRES"
@@ -4058,6 +4062,10 @@ msgstr "There may be changes in the assignments before the module opens!"
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "SUBMISSIONS"
 msgstr "Submissions"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "PERSONAL_DEADLINE_DEVIATION"
+msgstr "Personal deadline extension"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_base.html

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -3824,9 +3824,10 @@ msgid "POINTS_REQUIRED_TO_PASS"
 msgstr "Points required to pass"
 
 #: exercise/templates/exercise/_exercise_info.html
+#: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_plain.html
-msgid "EXTENDED_DEADLINE"
-msgstr "Extended deadline"
+msgid "PERSONAL_EXTENDED_DEADLINE"
+msgstr "Personal extended deadline"
 
 #: exercise/templates/exercise/_exercise_info.html
 #: exercise/templates/exercise/exercise_plain.html
@@ -4062,10 +4063,6 @@ msgstr "There may be changes in the assignments before the module opens!"
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "SUBMISSIONS"
 msgstr "Submissions"
-
-#: exercise/templates/exercise/_user_results.html
-msgid "PERSONAL_DEADLINE_DEVIATION"
-msgstr "Personal deadline extension"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_base.html

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-19 08:06+0300\n"
+"POT-Creation-Date: 2023-08-25 12:04+0300\n"
 "PO-Revision-Date: 2019-08-14 12:16+0200\n"
 "Last-Translator: Jimmy Ihalainen <jimmy.ihalainen@aalto.fi>\n"
 "Language-Team: Finnish <>\n"
@@ -4045,6 +4045,10 @@ msgid "OPEN_FOR_READING"
 msgstr "Lukumateriaali avoinna"
 
 #: exercise/templates/exercise/_user_results.html
+msgid "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION"
+msgstr "Tehtäviä henkilökohtaisella määräaikapidennyksellä"
+
+#: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/_user_toc.html
 #: lti_tool/templates/lti_tool/lti_course.html
 msgid "REQUIRES"
@@ -4068,6 +4072,10 @@ msgstr "Tehtäviin saattaa tulla muutoksia ennen kierroksen avautumista!"
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "SUBMISSIONS"
 msgstr "Palautukset"
+
+#: exercise/templates/exercise/_user_results.html
+msgid "PERSONAL_DEADLINE_DEVIATION"
+msgstr "Henkilökohtainen määräaikapidennys"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_base.html

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3831,9 +3831,10 @@ msgid "POINTS_REQUIRED_TO_PASS"
 msgstr "Pistevaatimus"
 
 #: exercise/templates/exercise/_exercise_info.html
+#: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_plain.html
-msgid "EXTENDED_DEADLINE"
-msgstr "Pidennetty määräaika"
+msgid "PERSONAL_EXTENDED_DEADLINE"
+msgstr "Henkilökohtainen pidennetty määräaika"
 
 #: exercise/templates/exercise/_exercise_info.html
 #: exercise/templates/exercise/exercise_plain.html
@@ -4072,10 +4073,6 @@ msgstr "Tehtäviin saattaa tulla muutoksia ennen kierroksen avautumista!"
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "SUBMISSIONS"
 msgstr "Palautukset"
-
-#: exercise/templates/exercise/_user_results.html
-msgid "PERSONAL_DEADLINE_DEVIATION"
-msgstr "Henkilökohtainen määräaikapidennys"
 
 #: exercise/templates/exercise/_user_results.html
 #: exercise/templates/exercise/exercise_base.html


### PR DESCRIPTION
# Description

**What?**

Displays deadline extensions in the points page with a tag in the module heading and a clock icon next to each exercise.

**Why?**

Students and staff members see deadline extensions more easily.

**How?**

Adds two custom template tags that check if an exercise/module has a personal deadline.

Fixes #1119


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

The deadline deviations are only shown on the points page when the module is open and the student has time left to submit the exercise. Works for both module are exercise deviations. Both students and staff members see the deviations.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

Template blocks are not indented.

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
