### PR TITLE
Change html_url to use display_url in API

### DIFF
--- a/course/api/tests.py
+++ b/course/api/tests.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
 from course.models import CourseInstance
@@ -9,6 +9,7 @@ class CourseInstanceAPITest(TestCase):
     from ..tests import CourseTest # pylint: disable=import-outside-toplevel
     setUp = CourseTest.setUp
 
+    @override_settings(BASE_URL="http://testserver/")
     def test_get_courselist(self):
         """
         Test if list of courses are given correctly via REST.

--- a/lib/api/serializers.py
+++ b/lib/api/serializers.py
@@ -8,6 +8,7 @@ from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 from rest_framework.fields import get_attribute
 
 from .fields import NestedHyperlinkedIdentityField, NestedHyperlinkedRelatedField
+from lib.helpers import build_aplus_url
 
 
 class NestedHyperlinkedModelSerializer(HyperlinkedModelSerializer):
@@ -61,9 +62,8 @@ class HtmlViewField(serializers.ReadOnlyField):
         super().__init__(*args, **kwargs)
 
     def to_representation(self, obj): # pylint: disable=arguments-renamed
-        request = self.context['request']
-        url = obj.get_absolute_url()
-        return request.build_absolute_uri(url)
+        url = obj.get_display_url()
+        return build_aplus_url(url, True)
 
 
 class NestedHyperlinkedIdentityFieldWithQuery(NestedHyperlinkedIdentityField):


### PR DESCRIPTION
# Description

**What?**

In the API, change the html_url to use the display_url rather than the absolute_url of an object.

Also, slightly clarify and simplify code by using local function build_aplus_api rather than building the url using the request object.

**Why?**

Exercises are often embedded in chapters, and if that is the case, it's more convenient for the html_url to direct the user to the display_url, which links to the chapter if the exercise is embedded.

**How?**

Change HtmlViewField to use display_url rather than absolute_url.

Fixes [Jutut issue #29](https://github.com/apluslms/mooc-jutut/issues/29)

Fixes #1217


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested locally that the field gets the correct value in the API. Also tested locally that Jutut works correctly (possible to respond to feedback, etc.) and that the link does in fact direct the chapter when the feedback questionnaire is embedded.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
