### PR TITLE
Add hierarchical name to CachedContent and remove regex hack

### DIFF
--- a/course/api/views.py
+++ b/course/api/views.py
@@ -1,5 +1,3 @@
-import re
-
 from rest_framework import filters, viewsets, status, mixins
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
@@ -206,17 +204,6 @@ class CourseExercisesViewSet(NestedViewSetMixin,
     def __recurse_exercises(self, module, exercises):
         for child in filter(lambda ex: ex['type'] == 'exercise', module['children']):
             if child['submittable']:
-                # check if there is a xx.yy pattern at the start of the name (e.g. 6.2 Hello Python). Also matches 1.
-                # Also matches roman numerals
-                # https://stackoverflow.com/questions/267399/how-do-you-match-only-valid-roman-numerals-with-a-regular-expression
-                hierarchical_name = (
-                    child['name']
-                    if re.match(
-                        r"^([0-9]+\.[0-9.]* )|(M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})) ",
-                        child['name'],
-                    )
-                    else f"{child['number']} {child['name']}"
-                )
                 exercise_dictionary = {
                     'id': child['id'],
                     'url': build_aplus_url(
@@ -227,7 +214,7 @@ class CourseExercisesViewSet(NestedViewSetMixin,
                     'display_name': child['name'],
                     'max_points': child['max_points'],
                     'max_submissions': child['max_submissions'],
-                    'hierarchical_name': hierarchical_name,
+                    'hierarchical_name': child['hierarchical_name'],
                     'difficulty': child['difficulty'],
                 }
                 exercises.append(exercise_dictionary)

--- a/exercise/cache/content.py
+++ b/exercise/cache/content.py
@@ -59,6 +59,7 @@ class CachedContent(ContentMixin, CachedAbstract):
                     'order': o.order,
                     'status': o.status,
                     'name': str(o),
+                    'hierarchical_name': o.hierarchical_name(),
                     'number': module['number'] + '.' + o.number(),
                     'link': o.get_display_url(),
                     'submittable': False,


### PR DESCRIPTION
# Description

**What?**

Add the learning object's hierarchical name to ``CachedContent`` and remove the regex hack in ``CourseExercisesViewSet``.

This fixes the hierarchical name for Roman content numbering, since the hierarchical name should always use Arabic numbering.

Fixes #1228

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the API now returns correct hierarchical names for all numbering styles.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
