### PR TITLE
Make 'grader is unstable' banner course specific

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -829,6 +829,24 @@ class PendingSubmissionManager(models.Manager):
         return not (total_retries and total_retries > settings.GRADER_STABLE_THRESHOLD)
 
 
+    def get_exercise_names_if_grader_is_unstable(self, instance):
+        total_retries_per_exercise = self.values(
+            'submission__exercise__name',
+        ).filter(
+            submission__exercise__course_module__course_instance=instance.id,
+        ).annotate(
+            num_retries=models.Sum('num_retries'),
+        ).order_by(
+            '-num_retries',
+        )[:10]
+        total_retries = sum(entry['num_retries'] for entry in total_retries_per_exercise)
+        # Check if the grader can be considered unstable on this course instance
+        if total_retries > settings.GRADER_STABLE_THRESHOLD:
+            exercises = ", ".join(f"'{entry['submission__exercise__name']}'" for entry in total_retries_per_exercise)
+            return exercises
+        return ''
+
+
 class PendingSubmission(models.Model):
     submission = models.OneToOneField(Submission,
         verbose_name=_('LABEL_SUBMISSION'),

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1445,10 +1445,11 @@ msgstr ""
 "users cannot re-enrol in the course.</p>"
 
 #: course/templatetags/base.py
-msgid "GRADER_PROBLEMS_ALERT"
+#, python-brace-format
+msgid "GRADER_PROBLEMS_ALERT -- {exercises}"
 msgstr ""
-"Automatic grading has currently issues. You may experience delay in "
-"receiving feedback."
+"Automatic grading currently has issues. You may experience delay in "
+"receiving feedback. Affected exercises include at least {exercises}."
 
 #: course/views.py
 msgid "COURSE_INSTANCES_NOT_VISIBLE_TO_STUDENTS"
@@ -1653,6 +1654,7 @@ msgstr ""
 
 #: deviations/templates/deviations/add_dl.html
 #: deviations/templates/deviations/override_dl.html
+#: exercise/templates/exercise/staff/_deviationslink.html
 msgid "ADD_DEADLINE_DEVIATIONS"
 msgstr "Add deadline deviations"
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1453,10 +1453,12 @@ msgstr ""
 "käyttäjät eivät pysty ilmoittautumaan kurssille uudelleen.</p>"
 
 #: course/templatetags/base.py
-msgid "GRADER_PROBLEMS_ALERT"
+#, python-brace-format
+msgid "GRADER_PROBLEMS_ALERT -- {exercises}"
 msgstr ""
 "Automaattisessa arvioinnissa on tällä hetkellä ongelmia. Palautteen "
-"saamisessa saattaa esiintyä viivettä."
+"saamisessa saattaa esiintyä viivettä. Ongelmia on havaittu ainakin "
+"tehtävissä {exercises}."
 
 #: course/views.py
 msgid "COURSE_INSTANCES_NOT_VISIBLE_TO_STUDENTS"
@@ -1663,6 +1665,7 @@ msgstr ""
 
 #: deviations/templates/deviations/add_dl.html
 #: deviations/templates/deviations/override_dl.html
+#: exercise/templates/exercise/staff/_deviationslink.html
 msgid "ADD_DEADLINE_DEVIATIONS"
 msgstr "Lisää määräaikojen poikkeamia"
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -235,6 +235,9 @@
 		<main class="site-content container-fluid" id="content">
 			{% endblock %}
 			{% site_alert %}
+			{% if instance %}
+			{% course_alert instance %}
+			{% endif %}
 			{% include "_messages.html" %}
 			{% block content %}
 			<div class="error">


### PR DESCRIPTION
# Description

**What?**

- Previously, when there were many unfinished grading tasks in ``PendingSubmissions`` table, a globally visible "Grader is unstable" banner was shown in A+ on all pages. However, oftentimes the problem may have concerned a particular exercise and course, and the alert unnecessarily bothered teachers and students on other courses. The banner is therefore made course-specific, and only shows on courses that have more than ``GRADER_STABLE_THRESHOLD`` (``settings.py`` parameter) retries pending.

- Additionally, the banner identifies the exercises that have retries pending, since it seems that when problems start occurring, typically it has been a specific exercise that raises this condition.

Fixes #1146

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the banner now appears only on courses that have more than ``GRADER_STABLE_THRESHOLD`` retries pending.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
