### PR TITLE
Improve and remove duplicate connection error strings

### DIFF
--- a/exercise/templates/exercise/_submit_progress.html
+++ b/exercise/templates/exercise/_submit_progress.html
@@ -8,7 +8,5 @@
 </div>
 
 <div class="quiz-submit-error alert alert-danger hide">
-	{% blocktranslate trimmed %}
-		SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE
-	{% endblocktranslate %}
+	{% translate "EXERCISE_ERROR_COMMUNICATION" %}
 </div>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2951,7 +2951,7 @@ msgstr ""
 msgid "ERROR_ALERT_EXERCISE_ASSESSMENT_SERVICE_MALFUNCTIONING"
 msgstr ""
 "<div class=\"alert alert-error\">\n"
-"<p>The assessment is malfunctioning. Staff has been notified.</p>\n"
+"<p>The assessment is malfunctioning. Course staff has been notified.</p>\n"
 "<p>This submission is now marked as erroneous.</p>\n"
 "</div>"
 
@@ -3538,11 +3538,13 @@ msgstr "You are not allowed to view model answers for this assignment."
 
 #: exercise/protocol/aplus.py
 msgid "EXERCISE_SERVICE_ERROR_CONNECTION_FAILED"
-msgstr "Connecting to the assignment service failed!"
+msgstr ""
+"Connecting to the assignment service failed! Course staff has been notified."
 
 #: exercise/protocol/aplus.py
 msgid "ASSESSMENT_SERVICE_ERROR_CONNECTION_FAILED"
-msgstr "Connecting to the assessment service failed!"
+msgstr ""
+"Connecting to the assessment service failed! Course staff has been notified."
 
 #: exercise/protocol/aplus.py
 #, python-brace-format
@@ -3863,13 +3865,13 @@ msgid "TOTAL_NUMBER_OF_SUBMITTERS"
 msgstr "Total number of submitters"
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: exercise/templates/exercise/_submit_progress.html
 #: exercise/templates/exercise/exercise.html templates/base.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
-"There was a problem loading the assignment. Try loading the page again "
-"later. The course staff has been notified. If the problem persists for over "
-"a day and hasn't been addressed on the course news, please contact course "
-"staff."
+"An error occurred while sending the submission for grading. Make sure you're "
+"connected to the internet. If a submission was consumed, the submission will "
+"be automatically graded after the service is available again."
 
 #: exercise/templates/exercise/_exercise_wait.html
 msgid "EXERCISE_ERROR_GRADING_TIMEOUT"
@@ -3996,14 +3998,6 @@ msgstr "Includes late penalty"
 #: exercise/templates/exercise/exercise.html
 msgid "POSTING_SUBMISSION"
 msgstr "Posting submission..."
-
-#: exercise/templates/exercise/_submit_progress.html
-msgid "SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE"
-msgstr ""
-"An error occurred while sending the submission for grading. Make sure you're "
-"connected to the internet. If a submission was consumed, the submission will "
-"be automatically graded after the service is available again. Course staff "
-"have been informed in case the problem is with the service."
 
 #: exercise/templates/exercise/_template_files.html
 msgid "EXERCISE_HAS_NO_TEMPLATE"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -3550,11 +3550,13 @@ msgstr "Sinulla ei ole lupaa katsoa tämän tehtävän esimerkkiratkaisua."
 
 #: exercise/protocol/aplus.py
 msgid "EXERCISE_SERVICE_ERROR_CONNECTION_FAILED"
-msgstr "Tehtäväpalveluun ei saatu yhteyttä!"
+msgstr ""
+"Tehtäväpalveluun ei saatu yhteyttä! Kurssihenkilökunnalle on ilmoitettu."
 
 #: exercise/protocol/aplus.py
 msgid "ASSESSMENT_SERVICE_ERROR_CONNECTION_FAILED"
-msgstr "Arviointipalveluun ei saatu yhteyttä!"
+msgstr ""
+"Arviointipalveluun ei saatu yhteyttä! Kurssihenkilökunnalle on ilmoitettu."
 
 #: exercise/protocol/aplus.py
 #, python-brace-format
@@ -3873,13 +3875,13 @@ msgid "TOTAL_NUMBER_OF_SUBMITTERS"
 msgstr "Palauttaneita opiskelijoita yhteensä"
 
 #: exercise/templates/exercise/_exercise_wait.html
+#: exercise/templates/exercise/_submit_progress.html
 #: exercise/templates/exercise/exercise.html templates/base.html
 msgid "EXERCISE_ERROR_COMMUNICATION"
 msgstr ""
-"Tehtävän lataaminen epäonnistui. Yritä uudelleen myöhemmin. "
-"Kurssihenkilökunnalle on ilmoitettu ongelmasta. Mikäli ongelma jatkuu yli "
-"vuorokauden eikä siitä ole mainintaa kurssiuutisissa, otathan yhteyttä "
-"kurssihenkilökuntaan."
+"Palautuksen lähettämisessä arvosteluun tapahtui virhe. Tarkistathan internet-"
+"yhteytesi. Jos palautuskerta käytettiin, palautus arvostellaan "
+"automaattisesti, kun palvelu on jälleen käytettävissä."
 
 #: exercise/templates/exercise/_exercise_wait.html
 msgid "EXERCISE_ERROR_GRADING_TIMEOUT"
@@ -4007,14 +4009,6 @@ msgstr "Sisältää myöhästymissakon"
 #: exercise/templates/exercise/exercise.html
 msgid "POSTING_SUBMISSION"
 msgstr "Palautusta lähetetään..."
-
-#: exercise/templates/exercise/_submit_progress.html
-msgid "SUBMISSION_ERROR_ALERT_COMMUNICATION_ERROR_W_SERVICE"
-msgstr ""
-"Palautuksen lähettämisessä arvosteluun tapahtui virhe. Tarkistathan internet-"
-"yhteytesi. Jos palautuskerta käytettiin, palautus arvostellaan "
-"automaattisesti, kun palvelu on jälleen käytettävissä. Kurssihenkilökunnalle "
-"on ilmoitettu mikäli ongelma on palvelussa."
 
 #: exercise/templates/exercise/_template_files.html
 msgid "EXERCISE_HAS_NO_TEMPLATE"


### PR DESCRIPTION
# Description

**What?**

Error messages related to connection/communication issues have been improved and duplicates removed.

The new error messages are as follows:

- `EXERCISE_ERROR_COMMUNICATION` (Submit exercise or a questionnaire, when submitting takes too long. Does not send email to course staff):
  ```
  An error occurred while sending the submission for grading. Make sure you're
  connected to the internet. If a submission was consumed, the submission will
  be automatically graded after the service is available again.
  ```

- `EXERCISE_SERVICE_ERROR_CONNECTION_FAILED` (When loading an exercise fails, e.g., MOOC-Grader is down. Sends error email to course staff):
  ```
  Connecting to the assignment service failed! Course staff has been notified.
  ```

- `ASSESSMENT_SERVICE_ERROR_CONNECTION_FAILED` (When loading feedback from MOOC-Grader fails, e.g., MOOC-Grader is down. Sends error email to course staff):
  ```
  Connecting to the assessment service failed! Course staff has been notified.
  ```

- `ERROR_ALERT_EXERCISE_ASSESSMENT_SERVICE_MALFUNCTIONING` (When a graded submission form from MOOC-Grader is not valid. Sends error email to course staff): 
  ```
  <div class=\"alert alert-error\">\n
  <p>The assessment is malfunctioning. Course staff has been notified.</p>\n
  <p>This submission is now marked as erroneous.</p>\n
  </div>
  ```

Fixes #1244