### PR TITLE
Strip remote page language suffix only on multilingual courses

### DIFF
--- a/exercise/protocol/aplus.py
+++ b/exercise/protocol/aplus.py
@@ -164,7 +164,8 @@ def parse_page_content(
         page.is_accepted = True
         page.is_wait = False
 
-    remote_page.fix_relative_urls()
+    is_multilingual_course = len(exercise.course_module.course_instance.languages) > 1
+    remote_page.fix_relative_urls(is_multilingual_course)
     remote_page.find_and_replace('data-aplus-exercise', [{
         'id': ('chapter-exercise-' + str(o.order)),
         'data-aplus-exercise': o.get_absolute_url(),

--- a/lib/remote_page.py
+++ b/lib/remote_page.py
@@ -210,7 +210,7 @@ class RemotePage:
     def body(self) -> Optional[Tag]:
         return self.soup.body if self.soup else None
 
-    def fix_relative_urls(self):
+    def fix_relative_urls(self, is_multilingual_course):
         url = self.base_address()
         for tag,attr in [
             ("img","src"),
@@ -221,9 +221,10 @@ class RemotePage:
             ("video","poster"),
             ("source","src"),
         ]:
-            self._fix_relative_urls(url, tag, attr)
+            self._fix_relative_urls(url, tag, attr, is_multilingual_course)
 
-    def _fix_relative_urls(self, url, tag_name, attr_name): # pylint: disable=too-many-locals too-many-branches
+    # pylint: disable-next=too-many-locals too-many-branches
+    def _fix_relative_urls(self, url, tag_name, attr_name, is_multilingual_course):
         # Starts with "#", "//" or "https:".
         test = re.compile('^(#|\/\/|\w+:)', re.IGNORECASE) # noqa: W605
         # Ends with filename extension ".html" and possibly "#anchor".
@@ -294,7 +295,7 @@ class RemotePage:
                 # Remove lang suffix in chapter2_en#anchor without modifying the #anchor.
                 # Add slash / to the end before the #anchor.
                 m = lang_suffix.search(new_val)
-                if m:
+                if m and is_multilingual_course:
                     anchor = m.group('anchor')
                     if anchor is None:
                         anchor = ''


### PR DESCRIPTION
# Description

**What?**

Strip remote page language suffix only on multilingual courses.

**Why?**

The language suffix in remote page links should not be removed on single language courses, because it can break the links.

Fixes #1255

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that CS-A1143 links work correctly now

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
