### PR TITLE
Do not add line numbers to extremely long feedback or code

### DIFF
--- a/assets/js/aplus.js
+++ b/assets/js/aplus.js
@@ -331,14 +331,17 @@ $(function() {
 
             hljs.highlightElement(codeBlock[0]);
 
-            // Add line numbers.
+            // Add line numbers if there are less than 5000 lines.
+            // The for-loop can freeze the page if line numbers are added to extremely long feedback/code.
             const pre = $(codeBlock);
             const lines = pre.html().split(/\r\n|\r|\n/g);
-            const list = $("<table/>").addClass("src");
-            for (var i = 1; i <= lines.length; i++) {
-                list.append('<tr><td class="num unselectable">' + i + '</td><td class="src">' + lines[i - 1] + '</td></tr>');
+            if (lines.length < 5000) {
+              const list = $("<table/>").addClass("src");
+              for (var i = 1; i <= lines.length; i++) {
+                  list.append('<tr><td class="num unselectable">' + i + '</td><td class="src">' + lines[i - 1] + '</td></tr>');
+              }
+              pre.html(list);
             }
-            pre.html(list);
 
             if (!options || !options.noWrap) {
               addButton(buttonContainer, {


### PR DESCRIPTION
# Description

**What?**

Previously, the inspect submission page froze if line numbers were added to extremely long feedback/code. Line numbers are now added only if the feedback or code is shorter than 5000 lines.

- A page with ~5000 lines of feedback takes about 3 seconds to load with line numbers.
- A page with ~230 000 lines of feedback used to freeze the page. Now it loads fine, but without line numbers.

Fixes #1210


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the inspect submission page no longer freezes.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
