### PR TITLE
Show only localized exercise name in grader unstable banner

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -26,6 +26,7 @@ from lib.helpers import (
     safe_file_name,
     Enum,
 )
+from lib.localization_syntax import pick_localized
 from lib.models import UrlMixin
 from userprofile.models import UserProfile
 from aplus.celery import retry_submissions
@@ -873,7 +874,11 @@ class PendingSubmissionManager(models.Manager):
         total_retries = sum(entry['num_retries'] for entry in total_retries_per_exercise)
         # Check if the grader can be considered unstable on this course instance
         if total_retries > settings.GRADER_STABLE_THRESHOLD:
-            exercises = ", ".join(f"'{entry['submission__exercise__name']}'" for entry in total_retries_per_exercise)
+            lang = get_language()
+            exercises = ", ".join(
+                f"'{pick_localized(entry['submission__exercise__name'], lang)}'"
+                for entry in total_retries_per_exercise
+            )
             return exercises
         return ''
 


### PR DESCRIPTION
# Description

**What?**

The 'grader unstable' banner showed exercise names in multiple languages on multilingual courses, which made it look bad. Now, the exercise names are shown only in the currently selected language.

Fixes #1259

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the exercise names are now shown only in the selected language.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.


# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
