### PR TITLE
Hide student notifications from hidden course instances

### DIFF
--- a/edit_course/course_forms.py
+++ b/edit_course/course_forms.py
@@ -16,6 +16,7 @@ from course.models import LearningObjectCategory, CourseModule, CourseInstance, 
 from lib.validators import generate_url_key_validator
 from lib.fields import UsersSearchSelectField
 from lib.widgets import DateTimeLocalInput
+from notification.cache import CachedNotifications
 from userprofile.models import UserProfile
 from course.sis import get_sis_configuration, StudentInfoSystem
 
@@ -192,6 +193,10 @@ class CourseInstanceForm(forms.ModelForm):
     def save(self, *args, **kwargs):
         self.instance.set_assistants(self.cleaned_data['assistants'])
         self.instance.set_teachers(self.cleaned_data['teachers'])
+
+        if not self.instance.visible_to_students:
+            for userprofile in self.instance.all_students:
+                CachedNotifications.invalidate(userprofile.user)
 
         return super().save(*args, **kwargs)
 

--- a/notification/cache.py
+++ b/notification/cache.py
@@ -35,9 +35,11 @@ class CachedNotifications(CachedAbstract):
             }
 
         notifications = list(
-            user.userprofile.received_notifications\
-                .filter(seen=False)\
-                .select_related(
+            user.userprofile.received_notifications
+                .filter(
+                    seen=False,
+                    course_instance__visible_to_students=True,
+                ).select_related(
                     'submission',
                     'submission__exercise',
                     'course_instance',


### PR DESCRIPTION
# Description

**What?**

Notifications could previously come from hidden course instances, which made it impossible to clear the notification icon due to `CourseVisiblePermission`.

This is now fixed by filtering courses that are not visible to students and invalidating the `CachedNotifications` when a course instance is made hidden.

Fixes #683


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that a student no longer sees notifications from hidden courses.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature