### PR TITLE
Fix ModuleRevealState crashing if it contains no exercises

### DIFF
--- a/exercise/reveal_states.py
+++ b/exercise/reveal_states.py
@@ -148,6 +148,8 @@ class ModuleRevealState(BaseRevealState):
         self.max_deviation: Optional[DeadlineRuleDeviation] = None
 
     def get_deadline(self) -> Optional[datetime.datetime]:
+        if len(self.exercises) == 0:
+            return None
         return max(_get_exercise_deadline(exercise) for exercise in self.exercises)
 
     def get_latest_deadline(self) -> Optional[datetime.datetime]:
@@ -167,6 +169,8 @@ class ModuleRevealState(BaseRevealState):
             deadlines.append(
                 self.max_deviation.get_new_deadline(exercise_dict[self.max_deviation.exercise_id].closing_time)
             )
+        if len(deadlines) == 0:
+            return None
         return max(deadlines)
 
     def get_points(self) -> Optional[int]:


### PR DESCRIPTION
# Description

**What?**

ModuleRevealState stores the exercises of the module. If the module has none, an empty list is passed to max function, which throws an exception.

**Why?**

It is unlikely that any chapter should be hidden before a module with no exercises is "completed". However, if a teacher does set a model solution to this kind of module, the site will crash.

**How?**

Check if the list is empty before feeding it to the max function.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

The site does not crash anymore if a module with no exercises has a model solution.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
