### PR TITLE
Support disabling duplicate submission check

### DIFF
--- a/exercise/static/exercise/chapter.js
+++ b/exercise/static/exercise/chapter.js
@@ -156,6 +156,7 @@
     quiz_attr: "data-aplus-quiz",
     ajax_attr: "data-aplus-ajax",
     autosave_attr: "data-aplus-autosave",
+    disable_duplicate_check_attr: "data-aplus-disable-duplicate-check",
     message_selector: ".progress-bar",
     content_element: '<div class="exercise-content"></div>',
     content_selector: '.exercise-content',
@@ -211,6 +212,9 @@
 
       // Enable AplusAutosave for this exercise.
       this.autosave = (this.element.attr(this.settings.autosave_attr) !== undefined);
+
+      // Disable duplicate submission check for this exercise.
+      this.disable_duplicate_check = (this.element.attr(this.settings.disable_duplicate_check_attr) !== undefined);
 
       // Check if the exercise is an active element.
       this.active_element = (this.element.attr(this.settings.active_element_attr) !== undefined);

--- a/exercise/static/exercise/duplicate_check.js
+++ b/exercise/static/exercise/duplicate_check.js
@@ -1,6 +1,6 @@
 function openDuplicateModalOrSubmit(exercise, hashes, hash, submitCallback) {
   const isDuplicate = hashes.includes(hash);
-  if (isDuplicate) {
+  if (isDuplicate && !exercise.disable_duplicate_check) {
     // Set the number of the existing duplicate submission
     $("#duplicate-submission-modal").find("[data-dup-submission]").text(hashes.reverse().indexOf(hash) + 1);
     // Unbind previous event handlers and bind a new one


### PR DESCRIPTION
# Description

**What?**

Support the new option implemented in apluslms/a-plus-rst-tools#174 to disable duplicate submission check for individual questionnaires and submit exercises or the whole course.

**Why?**

Some exercises often expect the submissions to be identical, so always showing the confirmation dialog is unnecessary.

Fixes #1076

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the new feature works as expected.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
