### PR TITLE
Always classify files ending with '.pdf' as binary

### DIFF
--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -832,6 +832,9 @@ class SubmittedFile(UrlMixin, models.Model):
         return guess_type(self.file_object.path)[0]
 
     def is_passed(self):
+        if self.file_object.path.endswith(".pdf"):
+            # PDF files are sometimes incorrectly classified as non-binary by the 'binaryornot' library
+            return True
         return is_binary(self.file_object.path)
 
 


### PR DESCRIPTION
# Description

**What?**

When a student submitted a large PDF file and it was incorrectly detected as non-binary data by the binaryornot library, the inspect submission page tried to render it and caused the page to load slowly.

This is now fixed by always classifying files ending with '.pdf' as non-binary data.

Fixes #1298
