### PR TITLE
Redirect to previous page when cancelling new deadline deviation

### DIFF
--- a/deviations/templates/deviations/add_dl.html
+++ b/deviations/templates/deviations/add_dl.html
@@ -21,7 +21,7 @@
 		<div class="form-group">
 			<div class="col-sm-10 col-sm-offset-2">
 				<button type="submit" class="aplus-button--default aplus-button--md">{% translate "SAVE" %}</button>
-				<a href="{{ instance|url:'deviations-list-dl' }}" class="aplus-button--secondary aplus-button--md" role="button">{% translate "CANCEL" %}</a>
+				<a href="{{ cancel_action }}" class="aplus-button--secondary aplus-button--md" role="button">{% translate "CANCEL" %}</a>
 			</div>
 		</div>
 	</form>

--- a/deviations/viewbase.py
+++ b/deviations/viewbase.py
@@ -36,6 +36,14 @@ class AddDeviationsView(CourseInstanceMixin, BaseFormView):
     deviation_model: Type[SubmissionRuleDeviation]
     session_key: str
 
+    def get_context_data(self, **kwargs: Any) -> dict:
+        context = super().get_context_data(**kwargs)
+        if self.request.GET.get('previous'):
+            context.update({'cancel_action': self.request.GET.get('previous')})
+        else:
+            context.update({'cancel_action': self.instance.get_url('deviations-list-dl')})
+        return context
+
     def get_form_kwargs(self) -> Dict[str, Any]:
         kwargs = super().get_form_kwargs()
         kwargs["instance"] = self.instance

--- a/exercise/static/exercise/assessment.js
+++ b/exercise/static/exercise/assessment.js
@@ -1,5 +1,10 @@
 $(function () {
   $(document).on('aplus:translation-ready', function() {
+    const currentPath = window.location.pathname;
+    $("a.deviations-link").attr("href", function(i, href) {
+      return `${href}&previous=${currentPath}`;
+    });
+
     // Activate the first tab
     $('.grader-container-tabs').find('li a').first().tab('show');
 

--- a/exercise/static/exercise/user_results.js
+++ b/exercise/static/exercise/user_results.js
@@ -28,6 +28,11 @@ function collapseModules() {
 }
 
 function startListen(course) {
+  const currentPath = window.location.pathname;
+  $("a.deviations-link").attr("href", function(i, href) {
+    return `${href}&previous=${currentPath}`;
+  });
+
   $(".filter-categories button").on("click", function(event) {
     const button = $(this);
     const id = button.attr("data-category");

--- a/exercise/templates/exercise/staff/_deviationslink.html
+++ b/exercise/templates/exercise/staff/_deviationslink.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load course %}
-<a class="aplus-button--secondary aplus-button--xs" href="{{ instance|url:'deviations-add-dl' }}?module={{module.id}}&exercise={{exercise.id}}&submitter={{submitters}}">
+<a class="deviations-link aplus-button--secondary aplus-button--xs" href="{{ instance|url:'deviations-add-dl' }}?module={{module.id}}&exercise={{exercise.id}}&submitter={{submitters}}">
 	<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 	{% translate "ADD_DEADLINE_DEVIATIONS" %}
 </a>


### PR DESCRIPTION
# Description

**What?**

Previously, the cancel button always sent the user to the deadline deviation list page. Now, it sends the user to the page where they came from, if possible.

**Why?**

This was requested by a teacher.

Fixes #1278

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that redirection works after cancelling new deadline deviation on inspect submission page and user results page.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
