### PR TITLE
Optimize inefficient database query in the deviation list view

### DIFF
--- a/deviations/viewbase.py
+++ b/deviations/viewbase.py
@@ -257,6 +257,12 @@ def get_deviation_groups(
             'submitter', 'submitter__user',
             'granter', 'granter__user',
             'exercise', 'exercise__course_module',
+            'exercise__course_module__course_instance',
+        )
+        .defer(
+            'exercise__exercise_info',
+            'exercise__description',
+            'exercise__course_module__course_instance__description',
         )
         # parent is prefetched because there may be multiple ancestors, and
         # they are needed for building the deviation's URL.


### PR DESCRIPTION
# Description

**What?**

The course module name is no longer queried separately for each deviation. This reduces the number of performed queries significantly. Additionally, some large unnecessary attributes are no longer loaded.

**Why?**

The deviations list page loaded extremely slowly before. This should help with the problem.

Fixes #1302