### PR TITLE
Teacher-facing UI message is technically incorrect in the Inspect view

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4527,7 +4527,7 @@ msgstr "There is another submission that is marked as final."
 
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "NOTE_BETTER_SUBMISSIONS"
-msgstr "There are submissions with better grades submitted by this student."
+msgstr "Another submission determines the grade for this assignment."
 
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "NOTE_LATER_SUBMISSIONS"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4540,8 +4540,7 @@ msgstr "Toinen palautus on merkitty opiskelijan lopulliseksi palautukseksi."
 
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "NOTE_BETTER_SUBMISSIONS"
-msgstr ""
-"Opiskelijalla on tätä palautusta paremman arvosanan saaneita palautuksia."
+msgstr "Toinen palautus määrittää tämän tehtävän arvosanan."
 
 #: exercise/templates/exercise/staff/inspect_submission.html
 msgid "NOTE_LATER_SUBMISSIONS"


### PR DESCRIPTION
# Description

**What?**

[Teacher-facing UI message is technically incorrect in the Inspect view](https://github.com/apluslms/a-plus/issues/1269)

**Why?**

The Inspect view may claim that there are higher-scoring submissions, even though there aren’t.

Fixes # 1269


# Testing

<img width="1234" alt="English" src="https://github.com/apluslms/a-plus/assets/150142776/e5d5ee8d-531b-489c-9dce-1df7f335211c">


**What type of test did you run?**

- [ ] Manual testing.

Changed the text and replicated the situation on aplus-manual. It's now showing the updated text, which better maps to the situation.

**Did you test the changes in**

- [ ] Chrome

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))
- [ ] The strings that were changed we're for NOTE_BETTER_SUBMISSIONS, both finnish and english.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
