### PR TITLE
Users should not be able to edit content hierarchy

### DIFF
--- a/edit_course/exercise_forms.py
+++ b/edit_course/exercise_forms.py
@@ -55,6 +55,8 @@ class LearningObjectMixin:
         self.fields["parent"].queryset = LearningObject.objects\
             .exclude(id=self.lobject.id)\
             .filter(course_module=self.lobject.course_module)
+        self.fields['parent'].widget.attrs.update(
+            {'readonly': True, 'disabled': True})
 
     @property
     def remote_service_head(self):


### PR DESCRIPTION
Fixes #1306

# Description

**What?**

Users should not be able to edit content hierarchy

**Why?**

By editing the parent selection it is possible to create a circular reference loop between two learning objects pointing to each other as a parent, that leads to excessive number of database operations, and as a result, leading the system to become unusable due to heavy database load.

**How?**

Now the parent field has been disabled so the case should not occur again.

Fixes #1306


# Testing

<img width="1204" alt="image" src="https://github.com/apluslms/a-plus/assets/150142776/4db8359e-5366-4446-b80c-79a4e8d8061e">


**What type of test did you run?**

- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [ ] Manual testing.

The parent field in the hierarchy has been disabled. It was tested and is no longer editable as seen in the picture.

**Did you test the changes in**

- [ ] Chrome

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
