### PR TITLE
Show personal deadline extensions in ToC view

### DIFF
--- a/course/templates/course/module.html
+++ b/course/templates/course/module.html
@@ -43,7 +43,7 @@
 	</p>
 	{% endif %}
 
-  {% include "exercise/_children.html" with children=children accessible=True exercise_accessible=current|exercises_submittable:now %}
+  {% include "exercise/_children.html" with module_specific=True children=children accessible=True exercise_accessible=current|exercises_submittable:now %}
 {% endblock %}
 
 {% block sidecontent %}

--- a/exercise/templates/exercise/_children.html
+++ b/exercise/templates/exercise/_children.html
@@ -15,6 +15,11 @@
 				{{ entry.name|parse_localization }}
 			{% else %}
 				<a href="{{ entry.link }}">{{ entry.name|parse_localization }}</a>
+				{% if module_specific %}
+					{% check_exercise_deadline_extensions entry.children entry.name module_specific %}
+				{% else %}
+					{% check_exercise_deadline_extensions children entry.name %}
+				{% endif %}
 			{% endif %}
 			{% if entry.submission_count %}
 				{% points_badge entry %}

--- a/exercise/templates/exercise/_user_toc.html
+++ b/exercise/templates/exercise/_user_toc.html
@@ -11,6 +11,11 @@
     {% if accessible %}
     <h3>
       <a href="{{ module.link }}" class="{% if module.is_in_maintenance %}maintenance{% endif %}">{{ module.name|parse_localization }}</a>
+      {% if module|deadline_extended_exercises_open:now %}
+        <span class="badge">
+          {% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
+        </span>
+      {% endif %}
     </h3>
     <h4>
       {% if module.requirements|length > 0 %}

--- a/exercise/templates/exercise/_user_toc.html
+++ b/exercise/templates/exercise/_user_toc.html
@@ -3,51 +3,54 @@
 {% load exercise %}
 
 <ul class="toc">
-  {% for module in modules %}
-  {% if module.is_listed %}
-  {% module_accessible module as accessible %}
-  {% exercise_accessible module as exercise_accessible %}
-  <li>
-    {% if accessible %}
-    <h3>
-      <a href="{{ module.link }}" class="{% if module.is_in_maintenance %}maintenance{% endif %}">{{ module.name|parse_localization }}</a>
-      {% if module|deadline_extended_exercises_open:now %}
-        <span class="badge">
-          {% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
-        </span>
-      {% endif %}
-    </h3>
-    <h4>
-      {% if module.requirements|length > 0 %}
-      <span class="label label-info">
-        {% translate "REQUIRES" %}:
-        {% for requirement in module.requirements %}{{ requirement }}{% endfor %}
-      </span>
-      {% endif %}
-      <small>{{ module.opening_time }} &ndash; {{ module.closing_time }}</small>
-    </h4>
-    {% else %}
-    <h3>
-      {{ module.name|parse_localization }}
-      {% if is_course_staff %}
-      <a href="{{ module.link }}">
-        <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
-        {% translate "EARLY_ACCESS" %}
-      </a>
-      {% endif %}
-    </h3>
-    <h4>
-      {% if module.requirements|length > 0 %}
-      <span class="label label-info">
-        {% translate "REQUIRES" %}:
-        {% for requirement in module.requirements %}{{ requirement }}{% endfor %}
-      </span>
-      {% endif %}
-      <span class="label label-info">{% translate "OPENS" %} {{ module.opening_time }}</span> <small>&ndash; {{ module.closing_time }}</small>
-    </h4>
-    {% endif %}
-    {% include "exercise/_children.html" with children=module.flatted accessible=accessible exercise_accessible=exercise_accessible %}
-  </li>
-  {% endif %}
-  {% endfor %}
+	{% for module in modules %}
+	{% if module.is_listed %}
+	{% module_accessible module as accessible %}
+	{% exercise_accessible module as exercise_accessible %}
+	<li>
+		{% if accessible %}
+		<h3>
+			<a href="{{ module.link }}" class="{% if module.is_in_maintenance %}maintenance{% endif %}">{{
+				module.name|parse_localization }}</a>
+			{% if module|deadline_extended_exercises_open:now %}
+			<span class="badge">
+				{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
+			</span>
+			{% endif %}
+		</h3>
+		<h4>
+			{% if module.requirements|length > 0 %}
+			<span class="label label-info">
+				{% translate "REQUIRES" %}:
+				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
+			</span>
+			{% endif %}
+			<small>{{ module.opening_time }} &ndash; {{ module.closing_time }}</small>
+		</h4>
+		{% else %}
+		<h3>
+			{{ module.name|parse_localization }}
+			{% if is_course_staff %}
+			<a href="{{ module.link }}">
+				<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+				{% translate "EARLY_ACCESS" %}
+			</a>
+			{% endif %}
+		</h3>
+		<h4>
+			{% if module.requirements|length > 0 %}
+			<span class="label label-info">
+				{% translate "REQUIRES" %}:
+				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
+			</span>
+			{% endif %}
+			<span class="label label-info">{% translate "OPENS" %} {{ module.opening_time }}</span> <small>&ndash; {{
+				module.closing_time }}</small>
+		</h4>
+		{% endif %}
+		{% include "exercise/_children.html" with children=module.flatted accessible=accessible
+		exercise_accessible=exercise_accessible %}
+	</li>
+	{% endif %}
+	{% endfor %}
 </ul>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4065,6 +4065,7 @@ msgid "OPEN_FOR_READING"
 msgstr "Open for reading"
 
 #: exercise/templates/exercise/_user_results.html
+#: exercise/templates/exercise/_user_toc.html
 msgid "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION"
 msgstr "Assignments with personal deadline extensions"
 
@@ -4711,6 +4712,15 @@ msgstr "Date"
 #: exercise/templates/exercise/submission_plain.html
 msgid "FILES"
 msgstr "Files"
+
+#: exercise/templatetags/exercise.py
+#, python-brace-format
+msgid "PERSONAL_EXTENDED_DEADLINE_PLURAL -- {count}"
+msgstr ""
+"<span data-toggle=\"tooltip\" title=\"Personal extended deadlines: "
+"{count}\"><span class=\"glyphicon glyphicon-time\" aria-hidden=\"true\"></"
+"span><span class=\"sr-only\">Personal extended deadlines: {count}</span></"
+"span>"
 
 #: exercise/templatetags/exercise.py
 msgid "LATEST_SUBMISSIONS"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4077,6 +4077,7 @@ msgid "OPEN_FOR_READING"
 msgstr "Lukumateriaali avoinna"
 
 #: exercise/templates/exercise/_user_results.html
+#: exercise/templates/exercise/_user_toc.html
 msgid "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION"
 msgstr "Tehtäviä henkilökohtaisella määräaikapidennyksellä"
 
@@ -4724,6 +4725,15 @@ msgstr "Päiväys"
 #: exercise/templates/exercise/submission_plain.html
 msgid "FILES"
 msgstr "Tiedostot"
+
+#: exercise/templatetags/exercise.py
+#, python-brace-format
+msgid "PERSONAL_EXTENDED_DEADLINE_PLURAL -- {count}"
+msgstr ""
+"<span data-toggle=\"tooltip\" title=\"Henkilökohtaiset pidennetyt määräajat: "
+"{count}\"><span class=\"glyphicon glyphicon-time\" aria-hidden=\"true\"></"
+"span><span class=\"sr-only\">Henkilökohtaiset pidennetyt määräajat: {count}</"
+"span></span>"
 
 #: exercise/templatetags/exercise.py
 msgid "LATEST_SUBMISSIONS"


### PR DESCRIPTION
Fixes #1277

# Description

**What?**

A student’s points page displays personal deadline extensions, which is useful. But it might make sense to add a similar notification elsewhere in the A+ web UI as well.

**How?**

Now, the ToC view also shows labels for personal deadline extensions.

Fixes #1277 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
