### PR TITLE
Enable most recent first sorting in deadline deviations

### DIFF
--- a/deviations/templates/deviations/list_dl.html
+++ b/deviations/templates/deviations/list_dl.html
@@ -33,7 +33,7 @@
 			<div class="panel-heading">
 				<h3 class="panel-title">{% translate "DEADLINE_DEVIATIONS" %}</h3>
 			</div>
-			<table class="table table-striped table-bordered table-condensed filtered-table ordered-table grouped-table">
+			<table class="table table-striped table-bordered table-condensed filtered-table ordered-table grouped-table" data-default-sort-column="6" data-default-sort-order="desc">
 				<thead>
 					<tr>
 						<th>{% translate "SUBMITTER" %}</th>

--- a/deviations/templates/deviations/list_submissions.html
+++ b/deviations/templates/deviations/list_submissions.html
@@ -33,7 +33,7 @@
 			<div class="panel-heading">
 				<h3 class="panel-title">{% translate "SUBMISSION_DEVIATIONS" %}</h3>
 			</div>
-			<table class="table table-striped table-bordered table-condensed filtered-table ordered-table grouped-table">
+			<table class="table table-striped table-bordered table-condensed filtered-table ordered-table grouped-table" data-default-sort-column="4" data-default-sort-order="desc">
 				<thead>
 					<tr>
 						<th>{% translate "SUBMITTER" %}</th>


### PR DESCRIPTION
Fixes #1279

# Description

**What?**

On deadline deviations page, table rows can be sorted but only in oldest-first order.  It would be nice to support newest-first sorting order. Actually, it wouldn’t object to newest-first being the default sorting on that page.

**Why?**

The deadline deviations page currently sorts the table rows only in oldest-first order but the most recently added deviations tend to be of most interest for anyone visiting this page.

**How?**

The solution adds the possibility to sort table rows both in newest-first or oldest-first sorting order. The new changes are applied on all the pages that use `<table>` tag with `"ordered-table"` attribute. But the sorting is applied by default only to the deadline deviations page by adding two new attributes `data-default-sort-column` and `data-default-sort-order` in the `<table>` tag, which restricts the default sorting to this page only.

Fixes #1279


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Ensuring that newest-first sorting in enabled only on deadline deviations page by default. Also tested that clicking a column name does sort the table rows based on the values of that column and clicking column name multiple times will toggle between newest-first / oldest-first sorting orders.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
