### PR TITLE
Add LTI session id to parameters sent to ACOS

### DIFF
--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -61,6 +61,9 @@ def _post_async_submission(request, exercise, submission, errors=None):
         if (form.cleaned_data["lti_launch_id"]
                 and submission.meta_data.get("lti-launch-id") is None):
             submission.meta_data["lti-launch-id"] = form.cleaned_data["lti_launch_id"]
+        if (form.cleaned_data["lti_session_id"]
+                and submission.meta_data.get("lti-session-id") is None):
+            submission.meta_data["lti-session-id"] = form.cleaned_data["lti_session_id"]
 
         if form.cleaned_data["error"]:
             submission.set_error()

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -977,7 +977,8 @@ class BaseExercise(LearningObject):
             )
             return self._build_service_url(
                 language, students,
-                ordinal, url_name, submission_url, lti_launch_id=request.session.get("lti-launch-id")
+                ordinal, url_name, submission_url, lti_launch_id=request.session.get("lti-launch-id"),
+                lti_session_id=request.COOKIES.get("lti1p3-session-id")
             )
         return super().get_load_url(language, request, students, url_name, ordinal)
 
@@ -1016,7 +1017,8 @@ class BaseExercise(LearningObject):
         """
 
     # pylint: disable-next=too-many-arguments
-    def _build_service_url(self, language, students, ordinal_number, url_name, submission_url, lti_launch_id=None):
+    def _build_service_url(self, language, students, ordinal_number, url_name, submission_url,
+                           lti_launch_id=None, lti_session_id=None):
         """
         Generates complete URL with added parameters to the exercise service.
         """
@@ -1032,6 +1034,8 @@ class BaseExercise(LearningObject):
         }
         if lti_launch_id:
             params["lti_launch_id"] = lti_launch_id
+        if lti_session_id:
+            params["lti_session_id"] = lti_session_id
         return update_url_params(self.get_service_url(language), params)
 
     @property

--- a/exercise/forms.py
+++ b/exercise/forms.py
@@ -21,6 +21,7 @@ class SubmissionCallbackForm(forms.Form):
     notify = forms.CharField(required=False)
     grading_payload = forms.CharField(required=False)
     lti_launch_id = forms.CharField(required=False)
+    lti_session_id = forms.CharField(required=False)
     error = forms.BooleanField(required=False)
 
     def clean(self):


### PR DESCRIPTION
# Description

Add lti session id to the built service url for services such as ACOS. Fixes #1305.

# Testing

**What type of test did you run?**
- [X] Manual testing.

Tested submitting ACOS exercises in the mycourses-test + aplus-test testing environment.