### PR TITLE
Fix issue with querying user submissions that could cause some submissions to be hidden

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -204,7 +204,7 @@ class PointsDBData(DBDataManager):
                 Submission.objects
                 .filter(submitters=user.userprofile, exercise_id__in=exercise_ids)
                 .prefetch_related("exercise", "notifications", "submitters")
-                .order_by('-submission_time', 'exercise_id')
+                .order_by('exercise_id', '-submission_time')
             )
             for exercise_id, exercise_submissions in groupby(submissions, key=lambda s: s.exercise_id):
                 self.submissions[(user_id, exercise_id)] = list(exercise_submissions)


### PR DESCRIPTION
# Description

Fixed an issue where not all user submissions would be shown for an exercise when the user had made submissions to another exercise in between. This was caused by unsorted data provided for the `groupby` function on the subsequent line - it requires data to be sorted by the key that's used for grouping.

# Testing

Ran manual tests at minus.cs to verify that all user submissions are now shown.