### PR TITLE
Hide module model answers on lifesupport

### DIFF
--- a/exercise/cache/basetypes.py
+++ b/exercise/cache/basetypes.py
@@ -496,6 +496,8 @@ class CachedDataBase(CourseInstanceProto, CacheBase, Generic[ModuleEntry, Learni
     exercise_index: Dict[int, LearningObjectEntry]
     paths: Dict[int, Dict[str, int]]
     modules: List[ModuleEntry]
+    is_on_lifesupport: bool
+    lifesupport_start: Optional[datetime]
     categories: Dict[int, CategoryEntry]
     total: Totals
 
@@ -529,6 +531,8 @@ class CachedDataBase(CourseInstanceProto, CacheBase, Generic[ModuleEntry, Learni
 
         self.url = instance.url
         self.course_url_kwargs = instance.course.get_url_kwargs()
+        self.is_on_lifesupport = instance.is_on_lifesupport()
+        self.lifesupport_start = instance.lifesupport_start
 
         self.exercise_index = exercise_index = {}
         self.module_index = module_index = {}

--- a/exercise/tests.py
+++ b/exercise/tests.py
@@ -994,6 +994,13 @@ class ExerciseTest(ExerciseTestBase):
         self.assertTrue(self.base_exercise.can_be_shown_as_module_model_solution(self.user))
         self.assertTrue(self.static_exercise.can_be_shown_as_module_model_solution(self.user))
 
+        self.course_instance.ending_time = self.today - timedelta(days=2)
+        self.course_instance.lifesupport_time = self.yesterday
+        self.course_instance.save()
+        # Model answer chapters not visible after lifesupport time
+        self.assertFalse(chapter.can_be_shown_as_module_model_solution(self.user))
+        self.assertFalse(self.base_exercise.can_be_shown_as_module_model_solution(self.user2))
+
     def test_reveal_rule(self):
         reveal_rule = RevealRule.objects.create(
             trigger=RevealRule.TRIGGER.MANUAL,


### PR DESCRIPTION
# Description

**What?**

Now also chapters that are marked as model answers for a module are hidden after the lifesupport time passes.

**Why?**

Model answers should be hidden after the course ends.

Should the message in the info tooltip inside a hidden chapter MODULE_MODEL_ANSWER_NOT_VISIBLE also be changed accordingly? Now it only says: "This chapter is hidden, since it contains model answers that have not been published yet." even if the course is ended.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Student wasn't able to see model chapters after setting lifesupport time to a past date.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
