### PR TITLE
Fix issues with points badge colors

### DIFF
--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -92,8 +92,6 @@ def none_min(a: Optional[float], b: Optional[float]) -> Optional[float]:
 
 
 def _add_to(target: Union[ModulePoints, CategoryPoints, Totals], entry: ExercisePoints) -> None:
-    target._true_passed = target._true_passed and entry._true_passed
-    target._passed = target._passed and entry._passed
     target.feedback_revealed = target.feedback_revealed and entry.feedback_revealed
 
     if not entry.graded:
@@ -549,8 +547,6 @@ class LearningObjectPoints(CommonPointData, LearningObjectEntryBase["ModulePoint
                 self.max_points += entry.max_points
                 self.submission_count += entry.submission_count
                 self._expires_on = none_min(self._expires_on, entry._expires_on)
-                self._true_passed = self._true_passed and entry._true_passed
-                self._passed = self._passed and entry._passed
                 # pylint: disable-next=unidiomatic-typecheck
                 if type(entry) is LearningObjectPoints or entry.graded:
                     self._true_points += entry._true_points
@@ -678,8 +674,8 @@ class ExercisePoints(LearningObjectPoints):
             )
 
         self.submission_count = 0
-        self._true_passed = False
-        self._passed = False
+        self._true_passed = self.points_to_pass == 0
+        self._passed = self.points_to_pass == 0
         self._true_points = 0
         self.submittable = True
         self.submissions = []


### PR DESCRIPTION
# Description

The logic for counting exercises as passed, and thus coloring the points badges, was previously changed as such that unpassed children caused the parent to count as not passed. This has now been changed to work similarly as before so that exercises / chapters only consider themselves unpassed if their own points-to-pass has been defined and the points threshold has not been reached --> status of children won't be considered.

Also fixed an issue where exercises with 0 submissions were making parents count as unpassed even if they didn't have points-to-pass defined. This is technically moot until deciding what to do with exercise-based points-to-pass.

The points-to-pass attribute on exercises as a concept is currently weird, since it doesn't affect passing modules at all, and the logic should probably be taken a look at at some point, either by

1) scrapping the idea of "passing exercises" altogether, or
2) actually causing unpassed children to affect passing the parent.

**Why?**

Functionality should be as current master, until otherwise decided.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.