### PR TITLE
Save deadline deviations as seconds instead of minutes

### DIFF
--- a/deviations/admin.py
+++ b/deviations/admin.py
@@ -20,7 +20,7 @@ class DeadlineRuleDeviationAdmin(admin.ModelAdmin):
     list_display = (
         'submitter',
         'exercise',
-        'extra_minutes',
+        'extra_seconds',
         'granter',
         'grant_time',
     )

--- a/deviations/forms.py
+++ b/deviations/forms.py
@@ -80,11 +80,11 @@ class BaseDeviationForm(forms.Form):
 
 
 class DeadlineRuleDeviationForm(BaseDeviationForm):
-    minutes = DurationField(
+    seconds = DurationField(
         required=False,
         min_value=1,
-        label=_('LABEL_MINUTES'),
-        help_text=_('DEVIATION_EXTRA_MINUTES_HELPTEXT'),
+        label=_('LABEL_SECONDS'),
+        help_text=_('DEVIATION_EXTRA_SECONDS_HELPTEXT'),
     )
     new_date = forms.DateTimeField(
         required=False,
@@ -108,10 +108,10 @@ class DeadlineRuleDeviationForm(BaseDeviationForm):
     def clean(self) -> Dict[str, Any]:
         cleaned_data = super().clean()
         new_date = cleaned_data.get("new_date")
-        minutes = cleaned_data.get("minutes")
-        if minutes and new_date or not minutes and not new_date:
+        seconds = cleaned_data.get("seconds")
+        if seconds and new_date or not seconds and not new_date:
             raise forms.ValidationError(
-                _("MINUTES_AND_DATE_MISSING"))
+                _("SECONDS_AND_DATE_MISSING"))
         return cleaned_data
 
 

--- a/deviations/migrations/0006_rename_extra_minutes_deadlineruledeviation_extra_seconds.py
+++ b/deviations/migrations/0006_rename_extra_minutes_deadlineruledeviation_extra_seconds.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+def multiply_by_sixty(apps, schema_editor):
+    DeadlineRuleDeviation = apps.get_model('deviations', 'DeadlineRuleDeviation')
+    # Retrieve all instances of DeadlineRuleDeviation and update extra_seconds field
+    for deviation in DeadlineRuleDeviation.objects.all():
+        deviation.extra_seconds *= 60
+        deviation.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deviations', '0005_auto_20220211_1540'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='deadlineruledeviation',
+            old_name='extra_minutes',
+            new_name='extra_seconds',
+        ),
+        migrations.AlterField(
+            model_name='deadlineruledeviation',
+            name='extra_seconds',
+            field=models.IntegerField(verbose_name='LABEL_EXTRA_SECONDS'),
+        ),
+        migrations.RunPython(multiply_by_sixty),
+    ]

--- a/deviations/models.py
+++ b/deviations/models.py
@@ -154,12 +154,12 @@ class SubmissionRuleDeviation(UrlMixin, models.Model):
 
 
 class DeadlineRuleDeviationManager(SubmissionRuleDeviationManager['DeadlineRuleDeviation']):
-    max_order_by = "-extra_minutes"
+    max_order_by = "-extra_seconds"
 
 
 class DeadlineRuleDeviation(SubmissionRuleDeviation):
-    extra_minutes = models.IntegerField(
-        verbose_name=_('LABEL_EXTRA_MINUTES'),
+    extra_seconds = models.IntegerField(
+        verbose_name=_('LABEL_EXTRA_SECONDS'),
     )
     without_late_penalty = models.BooleanField(
         verbose_name=_('LABEL_WITHOUT_LATE_PENALTY'),
@@ -173,7 +173,7 @@ class DeadlineRuleDeviation(SubmissionRuleDeviation):
         verbose_name_plural = _('MODEL_NAME_DEADLINE_RULE_DEVIATION_PLURAL')
 
     def get_extra_time(self):
-        return timedelta(minutes=self.extra_minutes)
+        return timedelta(seconds=self.extra_seconds)
 
     def get_new_deadline(self, normal_deadline: Optional[datetime] = None) -> datetime:
         """
@@ -191,18 +191,18 @@ class DeadlineRuleDeviation(SubmissionRuleDeviation):
         return self.exercise.course_module.closing_time
 
     def update_by_form(self, form_data: Dict[str, Any]) -> None:
-        minutes = form_data.get('minutes')
+        seconds = form_data.get('seconds')
         new_date = form_data.get('new_date')
         if new_date:
-            minutes = self.exercise.delta_in_minutes_from_closing_to_date(new_date)
+            seconds = self.exercise.delta_in_seconds_from_closing_to_date(new_date)
         else:
-            minutes = int(minutes)
-        self.extra_minutes = minutes
+            seconds = int(seconds)
+        self.extra_seconds = seconds
         self.without_late_penalty = bool(form_data.get('without_late_penalty'))
 
     def is_groupable(self, other: 'DeadlineRuleDeviation') -> bool:
         return (
-            self.extra_minutes == other.extra_minutes
+            self.extra_seconds == other.extra_seconds
             and self.without_late_penalty == other.without_late_penalty
         )
 

--- a/deviations/templates/deviations/list_dl.html
+++ b/deviations/templates/deviations/list_dl.html
@@ -38,7 +38,7 @@
 					<tr>
 						<th>{% translate "SUBMITTER" %}</th>
 						<th>{% translate "EXERCISE" %}</th>
-						<th>{% translate "EXTRA_MINUTES" %}</th>
+						<th>{% translate "EXTRA_SECONDS" %}</th>
 						<th>{% translate "DEADLINE" %}</th>
 						<th
 							data-filter-type="options"
@@ -70,7 +70,7 @@
 								{% endblocktranslate %})
 							</strong>
 						</td>
-						<td>{{ deviations.0.extra_minutes }}</td>
+						<td>{{ deviations.0.extra_seconds }}</td>
 						<td data-datetime="{{ deviations.0.get_new_deadline|date:'Y-m-d H:i:s' }}">
 							{{ deviations.0.get_new_deadline|date:'SHORT_DATETIME_FORMAT' }}
 						</td>
@@ -114,7 +114,7 @@
 							</a>
 						</td>
 						<td>{{ deviation.exercise.hierarchical_name }}</td>
-						<td>{{ deviation.extra_minutes }}</td>
+						<td>{{ deviation.extra_seconds }}</td>
 						<td data-datetime="{{ deviation.get_new_deadline|date:'Y-m-d H:i:s' }}">
 							{{ deviation.get_new_deadline|date:'SHORT_DATETIME_FORMAT' }}
 						</td>

--- a/deviations/templates/deviations/override_dl.html
+++ b/deviations/templates/deviations/override_dl.html
@@ -22,8 +22,8 @@
 					<tr>
 						<th>{% translate "SUBMITTER" %}</th>
 						<th>{% translate "EXERCISE" %}</th>
-						<th>{% translate "EXTRA_MINUTES" %} ({% translate "OVERRIDE_BEFORE" %})</th>
-						<th>{% translate "EXTRA_MINUTES" %} ({% translate "OVERRIDE_AFTER" %})</th>
+						<th>{% translate "EXTRA_SECONDS" %} ({% translate "OVERRIDE_BEFORE" %})</th>
+						<th>{% translate "EXTRA_SECONDS" %} ({% translate "OVERRIDE_AFTER" %})</th>
 						<th>{% translate "DEADLINE" %} ({% translate "OVERRIDE_BEFORE" %})</th>
 						<th>{% translate "DEADLINE" %} ({% translate "OVERRIDE_AFTER" %})</th>
 						<th
@@ -46,8 +46,8 @@
 				<tbody>
 				{% translate "UNKNOWN" as unknown %}
 				{% for deviations, can_group, group_id, _ in deviation_groups %}
-				{% new_deviation_minutes deviations.0 session_data.minutes session_data.new_date as new_deviation_minutes %}
-				{% new_deviation_date deviations.0 session_data.minutes session_data.new_date as new_deviation_date %}
+				{% new_deviation_seconds deviations.0 session_data.seconds session_data.new_date as new_deviation_seconds %}
+				{% new_deviation_date deviations.0 session_data.seconds session_data.new_date as new_deviation_date %}
 				{% if can_group %}
 				<tr data-group-parent="{{ group_id }}">
 					<td>
@@ -63,8 +63,8 @@
 							{% endblocktranslate %})
 						</strong>
 					</td>
-					<td>{{ deviations.0.extra_minutes }}</td>
-					<td>{{ new_deviation_minutes }}</td>
+					<td>{{ deviations.0.extra_seconds }}</td>
+					<td>{{ new_deviation_seconds }}</td>
 					<td data-datetime="{{ deviations.0.get_new_deadline|date:'Y-m-d H:i:s' }}">
 						{{ deviations.0.get_new_deadline|date:'SHORT_DATETIME_FORMAT' }}
 					</td>
@@ -102,8 +102,8 @@
 						</a>
 					</td>
 					<td>{{ deviation.exercise.hierarchical_name }}</td>
-					<td>{{ deviation.extra_minutes }}</td>
-					<td>{{ new_deviation_minutes }}</td>
+					<td>{{ deviation.extra_seconds }}</td>
+					<td>{{ new_deviation_seconds }}</td>
 					<td data-datetime="{{ deviation.get_new_deadline|date:'Y-m-d H:i:s' }}">
 						{{ deviation.get_new_deadline|date:'SHORT_DATETIME_FORMAT' }}
 					</td>

--- a/deviations/templatetags/deviations.py
+++ b/deviations/templatetags/deviations.py
@@ -10,23 +10,23 @@ register = template.Library()
 
 
 @register.simple_tag
-def new_deviation_minutes(
+def new_deviation_seconds(
         deviation: DeadlineRuleDeviation,
-        minutes: Optional[int],
+        seconds: Optional[int],
         date: Optional[datetime.datetime]
         ) -> int:
     """
-    Get the extra minutes for a deadline deviation after being overridden.
+    Get the extra seconds for a deadline deviation after being overridden.
     """
     if date:
-        return deviation.exercise.delta_in_minutes_from_closing_to_date(date)
-    return minutes
+        return deviation.exercise.delta_in_seconds_from_closing_to_date(date)
+    return seconds
 
 
 @register.simple_tag
 def new_deviation_date(
         deviation: DeadlineRuleDeviation,
-        minutes: Optional[int],
+        seconds: Optional[int],
         date: Optional[datetime.datetime]
         ) -> datetime.datetime:
     """
@@ -34,4 +34,4 @@ def new_deviation_date(
     """
     if date:
         return date
-    return deviation.exercise.course_module.closing_time + datetime.timedelta(minutes=minutes)
+    return deviation.exercise.course_module.closing_time + datetime.timedelta(seconds=seconds)

--- a/deviations/views.py
+++ b/deviations/views.py
@@ -34,7 +34,7 @@ class AddDeadlinesView(AddDeviationsView):
     def get_initial_get_param_spec(self) -> Dict[str, Optional[Callable[[str], Any]]]:
         spec = super().get_initial_get_param_spec()
         spec.update({
-            "minutes": int,
+            "seconds": int,
             "new_date": None,
             "without_late_penalty": lambda x: x == "true",
         })
@@ -43,7 +43,7 @@ class AddDeadlinesView(AddDeviationsView):
     def serialize_session_data(self, form_data: Dict[str, Any]) -> Dict[str, Any]:
         result = super().serialize_session_data(form_data)
         result.update({
-            'minutes': form_data['minutes'],
+            'seconds': form_data['seconds'],
             'new_date': str(form_data['new_date']) if form_data['new_date'] else None,
             'without_late_penalty': form_data['without_late_penalty'],
         })
@@ -61,7 +61,7 @@ class OverrideDeadlinesView(OverrideDeviationsView):
     def deserialize_session_data(self, session_data: Dict[str, Any]) -> Dict[str, Any]:
         result = super().deserialize_session_data(session_data)
         result.update({
-            'minutes': session_data['minutes'],
+            'seconds': session_data['seconds'],
             'new_date': parse_datetime(session_data['new_date']) if session_data['new_date'] else None,
             'without_late_penalty': session_data['without_late_penalty'],
         })

--- a/exercise/cache/points.py
+++ b/exercise/cache/points.py
@@ -665,7 +665,7 @@ class ExercisePoints(LearningObjectPoints):
         self.personal_deadline_has_penalty = None
         for deviation in deadline_deviations:
             self.personal_deadline = (
-                self.closing_time + datetime.timedelta(minutes=deviation.extra_minutes)
+                self.closing_time + datetime.timedelta(seconds=deviation.extra_seconds)
             )
             self.personal_deadline_has_penalty = not deviation.without_late_penalty
 

--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -730,18 +730,18 @@ class BaseExercise(LearningObject):
 
         return self.TIMING.CLOSED_AFTER, dl
 
-    def delta_in_minutes_from_closing_to_date(self, future_date):
+    def delta_in_seconds_from_closing_to_date(self, future_date):
         module_close = self.course_module.closing_time
         # module_close is in utc format 2018-04-10 23:59:00+00:00
         # while future_date from the teacher submitted form might
-        # be in different formet, eg. 2018-05-15 23:59:00+03:00
+        # be in a different format, e.g., 2018-05-15 23:59:00+03:00
         # -> convert future_date to same format as module_close
-        string_date = str(future_date)[:16]
+        string_date = str(future_date)[:19]
         converted = timezone.make_aware(
                 parse_datetime(string_date),
                 timezone.get_current_timezone())
         delta = converted - module_close
-        return delta.days * 24 * 60 + delta.seconds // 60
+        return delta.days * 24 * 60 * 60 + delta.seconds
 
     def one_has_access(self, students, when=None):
         """

--- a/exercise/management/commands/export_submissions.py
+++ b/exercise/management/commands/export_submissions.py
@@ -270,7 +270,7 @@ class Command(BaseCommand):
                     'exercise__course_module__closing_time',
                     'exercise__course_module__course_instance__id',
                     'submitter__user__id',
-                    'extra_minutes',
+                    'extra_seconds',
                 )
 
                 for dl_dev in all_deadline_deviations_queryset:

--- a/exercise/reveal_models.py
+++ b/exercise/reveal_models.py
@@ -75,11 +75,13 @@ class RevealRule(models.Model):
         if self.trigger in [RevealRule.TRIGGER.DEADLINE, RevealRule.TRIGGER.DEADLINE_OR_FULL_POINTS]:
             deadline = state.get_deadline()
             if deadline is not None:
-                return deadline + datetime.timedelta(minutes=self.delay_minutes or 0)
+                seconds = self.delay_minutes * 60 if self.delay_minutes else 0
+                return deadline + datetime.timedelta(seconds=seconds)
         elif self.trigger == RevealRule.TRIGGER.DEADLINE_ALL:
             latest_deadline = state.get_latest_deadline()
             if latest_deadline is not None:
-                return latest_deadline + datetime.timedelta(minutes=self.delay_minutes or 0)
+                seconds = self.delay_minutes * 60 if self.delay_minutes else 0
+                return latest_deadline + datetime.timedelta(seconds=seconds)
 
         return None
 

--- a/exercise/reveal_states.py
+++ b/exercise/reveal_states.py
@@ -117,7 +117,7 @@ class ExerciseRevealState(BaseRevealState):
             self.max_deviation = (
                 DeadlineRuleDeviation.objects
                 .filter(exercise_id=self.cache.id)
-                .order_by('-extra_minutes').first()
+                .order_by('-extra_seconds').first()
             )
             self.max_deviation_fetched = True
         if self.max_deviation is not None:
@@ -163,7 +163,7 @@ class ModuleRevealState(BaseRevealState):
             self.max_deviation = (
                 DeadlineRuleDeviation.objects
                 .filter(exercise__course_module_id=self.module_id)
-                .order_by('-extra_minutes').first()
+                .order_by('-extra_seconds').first()
             )
             self.max_deviation_fetched = True
         if self.max_deviation is not None:

--- a/exercise/tests.py
+++ b/exercise/tests.py
@@ -259,7 +259,7 @@ class ExerciseTestBase(TestCase):
             exercise=self.exercise_with_attachment,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=1440  # One day
+            extra_seconds=24*60*60  # One day
         )
 
 
@@ -431,7 +431,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=10*24*60
+            extra_seconds=10*24*60*60 # Ten days
         )
         self.assertTrue(self.old_base_exercise.one_has_access([self.user.userprofile])[0])
 
@@ -557,7 +557,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.base_exercise_with_late_submission_allowed,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=10*24*60,
+            extra_seconds=10*24*60*60,
             without_late_penalty=True
         )
         self.late_late_submission_when_late_allowed.set_points(5, 10)
@@ -913,7 +913,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=1440, # One day
+            extra_seconds=24*60*60, # One day
         )
         self.assertFalse(self.old_base_exercise.can_show_model_solutions_to_student(self.user))
         # Change the deadline extension so that it is not active anymore.
@@ -924,7 +924,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=10,
+            extra_seconds=10*60,
         )
         self.assertTrue(self.old_base_exercise.can_show_model_solutions_to_student(self.user))
 
@@ -941,7 +941,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=base_exercise_with_late_closed,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=60*24*2,
+            extra_seconds=2*24*60*60, # Two days
         )
         self.assertFalse(base_exercise_with_late_closed.can_show_model_solutions_to_student(self.user))
         self.assertFalse(base_exercise_with_late_closed.can_show_model_solutions_to_student(self.user2))
@@ -951,7 +951,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=base_exercise_with_late_closed,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=10,
+            extra_seconds=10*60,
         )
         self.assertTrue(base_exercise_with_late_closed.can_show_model_solutions_to_student(self.user))
         self.assertTrue(base_exercise_with_late_closed.can_show_model_solutions_to_student(self.user2))
@@ -967,7 +967,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=1440, # One day
+            extra_seconds=24*60*60, # One day
         )
         reveal_rule = RevealRule.objects.create(
             trigger=RevealRule.TRIGGER.DEADLINE,
@@ -987,7 +987,7 @@ class ExerciseTest(ExerciseTestBase):
         self.assertFalse(self.static_exercise.can_be_shown_as_module_model_solution(self.user))
         self.assertTrue(chapter.can_be_shown_as_module_model_solution(self.user2))
 
-        deadline_deviation_old_base_exercise.extra_minutes = 0
+        deadline_deviation_old_base_exercise.extra_seconds = 0
         deadline_deviation_old_base_exercise.save()
         self.assertTrue(chapter.can_be_shown_as_module_model_solution(self.user))
         self.assertTrue(self.base_exercise.can_be_shown_as_module_model_solution(self.user))
@@ -1037,7 +1037,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=30,
+            extra_seconds=30*60,
         )
         old_reveal_state_deviation = ExerciseRevealState(self.old_base_exercise, self.user)
         user2_old_reveal_state_deviation = ExerciseRevealState(self.old_base_exercise, self.user2)
@@ -1176,7 +1176,7 @@ class ExerciseTest(ExerciseTestBase):
             exercise=self.old_base_exercise,
             submitter=self.user.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=4320,
+            extra_seconds=3*24*60*60, # Three days
         ) # this should have not effect on the module reveal state
 
         user_reveal_state = ModuleRevealState(self.course_module, self.user)

--- a/exercise/tests_cache.py
+++ b/exercise/tests_cache.py
@@ -604,7 +604,7 @@ class CachedPointsTest(CourseTestCase):
             exercise=self.exercise0,
             submitter=self.student.userprofile,
             granter=self.teacher.userprofile,
-            extra_minutes=2*24*60,
+            extra_seconds=2*24*60*60,
         )
         reveal_rule = RevealRule.objects.create(
             trigger=RevealRule.TRIGGER.DEADLINE,

--- a/lib/fields.py
+++ b/lib/fields.py
@@ -31,14 +31,15 @@ class DurationField(forms.MultiValueField):
     boxes, one for each given unit of time. The units of time are, by default,
     days, hours and minutes, but they can also be customized by passing a list
     of tuples where the first item is the name of the unit and the second item
-    is its factor relative to minutes (e.g. 60 for hours).
+    is its factor relative to seconds (e.g. 3600 for hours).
     """
-    DAYS = (_('DURATION_UNIT_DAYS'), 60 * 24)
-    HOURS = (_('DURATION_UNIT_HOURS'), 60)
-    MINUTES = (_('DURATION_UNIT_MINUTES'), 1)
+    DAYS = (_('DURATION_UNIT_DAYS'), 60 * 60 * 24)
+    HOURS = (_('DURATION_UNIT_HOURS'), 60 * 60)
+    MINUTES = (_('DURATION_UNIT_MINUTES'), 60)
+    SECONDS = (_('DURATION_UNIT_SECONDS'), 1)
 
     # Default units
-    units: List[Tuple[str, int]] = [DAYS, HOURS, MINUTES]
+    units: List[Tuple[str, int]] = [DAYS, HOURS, MINUTES, SECONDS]
 
     def __init__( # pylint: disable=keyword-arg-before-vararg
             self,
@@ -62,16 +63,16 @@ class DurationField(forms.MultiValueField):
 
     def compress(self, data_list: List[Optional[int]]) -> Optional[int]:
         """
-        Convert the values given in different units into minutes.
+        Convert the values given in different units into seconds.
         """
-        total_minutes = None
+        total_seconds = None
         for value, (_name, factor) in zip(data_list, self.units):
             if value is None:
                 continue
-            if total_minutes is None:
-                total_minutes = 0
-            total_minutes += value * factor
-        return total_minutes
+            if total_seconds is None:
+                total_seconds = 0
+            total_seconds += value * factor
+        return total_seconds
 
 
 class SearchSelectField(forms.ModelMultipleChoiceField):

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1524,11 +1524,11 @@ msgid "SUBMITTERS_AND_TAGS_MISSING"
 msgstr "You have to define submitters or tags."
 
 #: deviations/forms.py
-msgid "LABEL_MINUTES"
+msgid "LABEL_SECONDS"
 msgstr "Extra time"
 
 #: deviations/forms.py
-msgid "DEVIATION_EXTRA_MINUTES_HELPTEXT"
+msgid "DEVIATION_EXTRA_SECONDS_HELPTEXT"
 msgstr "Amount of extra time given. Leave blank if you fill in the date below."
 
 #: deviations/forms.py
@@ -1571,7 +1571,7 @@ msgstr ""
 "granted to these students IN ADDITION to the ones with the tags."
 
 #: deviations/forms.py
-msgid "MINUTES_AND_DATE_MISSING"
+msgid "SECONDS_AND_DATE_MISSING"
 msgstr "You have to provide either the extra time or a date in the future."
 
 #: deviations/forms.py deviations/models.py
@@ -1622,8 +1622,8 @@ msgid "MODEL_NAME_SUBMISSION_RULE_DEVIATION_PLURAL"
 msgstr "submission rule deviations"
 
 #: deviations/models.py
-msgid "LABEL_EXTRA_MINUTES"
-msgstr "extra minutes"
+msgid "LABEL_EXTRA_SECONDS"
+msgstr "extra seconds"
 
 #: deviations/models.py
 msgid "MODEL_NAME_DEADLINE_RULE_DEVIATION"
@@ -1727,8 +1727,8 @@ msgstr "Assignment"
 
 #: deviations/templates/deviations/list_dl.html
 #: deviations/templates/deviations/override_dl.html
-msgid "EXTRA_MINUTES"
-msgstr "Extra minutes"
+msgid "EXTRA_SECONDS"
+msgstr "Extra seconds"
 
 #: deviations/templates/deviations/list_dl.html
 #: deviations/templates/deviations/override_dl.html
@@ -5280,6 +5280,10 @@ msgstr "hours"
 #: lib/fields.py
 msgid "DURATION_UNIT_MINUTES"
 msgstr "minutes"
+
+#: lib/fields.py
+msgid "DURATION_UNIT_SECONDS"
+msgstr "seconds"
 
 #: lib/fields.py
 msgid "CLIPBOARD_STUDENT_IDS"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1533,11 +1533,11 @@ msgid "SUBMITTERS_AND_TAGS_MISSING"
 msgstr "Valitse opiskelijat tai merkinnät."
 
 #: deviations/forms.py
-msgid "LABEL_MINUTES"
+msgid "LABEL_SECONDS"
 msgstr "Ylimääräistä palautusaikaa"
 
 #: deviations/forms.py
-msgid "DEVIATION_EXTRA_MINUTES_HELPTEXT"
+msgid "DEVIATION_EXTRA_SECONDS_HELPTEXT"
 msgstr ""
 "Annettu ylimääräinen palautusaika. Jätä tyhjäksi mikäli ilmoitat määräajan "
 "alempana."
@@ -1582,7 +1582,7 @@ msgstr ""
 "joilla on kyseiset merkinnät."
 
 #: deviations/forms.py
-msgid "MINUTES_AND_DATE_MISSING"
+msgid "SECONDS_AND_DATE_MISSING"
 msgstr "Syötä joko ylimääräinen palautusaika tai uusi määräaika."
 
 #: deviations/forms.py deviations/models.py
@@ -1633,8 +1633,8 @@ msgid "MODEL_NAME_SUBMISSION_RULE_DEVIATION_PLURAL"
 msgstr "palautusääntöjen poikkeamat"
 
 #: deviations/models.py
-msgid "LABEL_EXTRA_MINUTES"
-msgstr "ylimääräiset minuutit"
+msgid "LABEL_EXTRA_SECONDS"
+msgstr "ylimääräiset sekunnit"
 
 #: deviations/models.py
 msgid "MODEL_NAME_DEADLINE_RULE_DEVIATION"
@@ -1738,7 +1738,7 @@ msgstr "Tehtävä"
 
 #: deviations/templates/deviations/list_dl.html
 #: deviations/templates/deviations/override_dl.html
-msgid "EXTRA_MINUTES"
+msgid "EXTRA_SECONDS"
 msgstr "Ylimääräiset minuutit"
 
 #: deviations/templates/deviations/list_dl.html
@@ -5301,6 +5301,10 @@ msgstr "tunnit"
 #: lib/fields.py
 msgid "DURATION_UNIT_MINUTES"
 msgstr "minuutit"
+
+#: lib/fields.py
+msgid "DURATION_UNIT_SECONDS"
+msgstr "sekunnit"
 
 #: lib/fields.py
 msgid "CLIPBOARD_STUDENT_IDS"


### PR DESCRIPTION
# Description

**What?**

Saving deadline deviations as seconds instead of minutes
allows teachers to better set midnight deadlines, such as
23:59:59.

The minutes are no longer discarded, when a deadline deviation is made using a date.

**Testing**

Tested that the deviations work as expected using a docker image [ihalaij1/run-aplus-front:faketime](https://github.com/ihalaij1/run-aplus-front/commit/335f9ad477ee639d71cf67649953a1ba2cdf47f0) that allows changing of the internal time.

docker-compose.yml:
```
plus:
  image: ihalaij1/run-aplus-front:faketime
  environment:
    FAKETIME: "@2024-01-01 23:55:00"
```

Fixes #1138