### PR TITLE
Update to Jutut that a feedback response has been read

### DIFF
--- a/exercise/api/full_serializers.py
+++ b/exercise/api/full_serializers.py
@@ -172,6 +172,7 @@ class SubmissionGraderSerializer(AplusModelSerializerBase):
     )
     submission = SubmissionInGraderSerializer(source='*')
     exercise = ExerciseBriefSerializer()
+    feedback_response_seen = serializers.SerializerMethodField()
 
     class Meta(AplusSerializerMeta):
         model = Submission
@@ -181,7 +182,18 @@ class SubmissionGraderSerializer(AplusModelSerializerBase):
             'exercise',
             'grading_data',
             'is_graded',
+            'feedback_response_seen',
         )
+
+    def get_feedback_response_seen(self, obj: Submission) -> bool:
+        """Returns whether all feedback responses (notifications) have
+        been seen by the submitter. Used to inform the author of the
+        feedback about the status of the feedback responses.
+        If there are no notifications, the feedback response is not
+        considered seen so that a new submission is not immediately
+        marked as 'feedback response seen'.
+        """
+        return not obj.notifications.filter(seen=False).exists() and obj.notifications.count() > 0
 
 
 class TreeExerciseSerializer(serializers.Serializer):

--- a/notification/views.py
+++ b/notification/views.py
@@ -21,6 +21,9 @@ class NotificationRedirectView(CourseInstanceMixin, BaseRedirectView):
     def get(self, request, *args, **kwargs):
         self.notification.seen = True
         self.notification.save()
+        submission = self.notification.submission
+        # Sends an update to Jutut that the feedback response has been seen.
+        submission.exercise.grade(submission)
         if self.notification.submission:
             return self.redirect(
                 self.notification.submission.get_url('submission-plain')


### PR DESCRIPTION
# Description

**What?**

Sends an update to Jutut when a student has read a feedback response.

**Why?**

For urgent messages, teachers need to know whether the student has read the message.

**How?**

Send a post request to Jutut endpoint /feedback/ that is responsible for creating and updating Feedback instances based on feedback submissions in A+. Adds an attribute to Submission serializer that indicates whether there are unread feedback responses for that (feedback) submission.

Fixes https://github.com/apluslms/mooc-jutut/issues/40.

Has to be merged with https://github.com/apluslms/mooc-jutut/pull/105.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Logged in with student and root. Sent a feedback with student and responded to it through Jutut with root. Opened the response notification in A+ and checked that the ok-icon appeared in Jutut. Same test on multiple feedbacks to the same assignment and on editing the response message.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
