### PR TITLE
Get started with Bootstrap 5 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ aplus/secret_key.py
 *.sublime-workspace
 
 venv/
+venv_aplus/
 /static/
 /media/
 

--- a/assets/sass/layout/_header.scss
+++ b/assets/sass/layout/_header.scss
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25),
 		inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+	margin-bottom: 22px;
 
 	.navbar-brand,
 	.navbar-dropdown > a,
@@ -26,8 +27,8 @@
 	}
 
 	.navbar-dropdown > li.dropdown > a.dropdown-toggle {
-		padding-top: $navbar-padding-vertical;
-		padding-bottom: $navbar-padding-vertical;
+		/*padding-top: $navbar-padding-vertical;
+		padding-bottom: $navbar-padding-vertical;*/
 	}
 
 	a.navbar-brand:hover,

--- a/assets/sass/legacy/_main.scss
+++ b/assets/sass/legacy/_main.scss
@@ -26,7 +26,7 @@ iframe {
 .unread {
     font-weight: bold;
 }
-.panel-title .pull-right {
+.panel-title .float-end {
     margin-left: 0.5em;
 }
 .nav .navbar-btn {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -37,15 +37,53 @@ $font-family-sans-serif: $aplus-font-family-sans-serif;
 $font-family-serif: $aplus-font-family-serif;
 $font-family-monospace: $aplus-font-family-monospace;
 $font-family-base: $aplus-font-family-base;
-$font-size-base:  $aplus-font-size-base;
+//$font-size-base:  $aplus-font-size-base;
 
-@import 'vendor/bootstrap3';
+@import 'vendor/bootstrap5';
 
 /*!
  * A+ Legacy Styles
  */
 
 // Start wit the "old" styles, which are going to be progressively replaced.
+//** Deprecated `$screen-sm` as of v3.0.1
+$screen-sm:                  768px !default;
+$screen-sm-min:              $screen-sm !default;
+$screen-xs-max: 575px;//** Point at which the navbar becomes uncollapsed.
+//** Deprecated `$screen-md` as of v3.0.1
+$screen-md:                  992px !default;
+$screen-md-min:              $screen-md !default;
+//** Deprecated `$screen-lg` as of v3.0.1
+$screen-lg:                  1200px !default;
+$screen-lg-min:              $screen-lg !default;
+$screen-md-max:              ($screen-lg-min - 1) !default;
+$screen-sm-max:              ($screen-md-min - 1) !default;
+// Navbar collapse
+//** Point at which the navbar becomes uncollapsed.
+$grid-float-breakpoint:     $screen-sm-min !default;
+//** Point at which the navbar begins collapsing.
+$grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
+$line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~20px
+// Basics of a navbar
+$navbar-height:                    3.125rem !default;
+//$navbar-margin-bottom:             $line-height-computed !default;
+//$navbar-border-radius:             $border-radius-base !default;
+$navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
+$navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
+$font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
+$font-size-small:         ceil(($font-size-base * .85)) !default; // ~12px
+$gray-base:              #000 !default;
+$gray-darker:            lighten($gray-base, 13.5%) !default; // #222
+$gray-dark:              lighten($gray-base, 20%) !default;   // #333
+$gray:                   lighten($gray-base, 33.5%) !default; // #555
+$gray-light:             lighten($gray-base, 46.7%) !default; // #777
+$gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+$nav-link-padding:                          10px 15px !default;
+$cursor-disabled:                not-allowed !default;
+$form-group-margin-bottom:       15px !default;
+$padding-base-vertical:     0.375rem !default;
+$padding-base-horizontal:   0.75rem !default;
+$input-height-base:              ($line-height-computed + ($padding-base-vertical * 2) + 2) !default;
 
 @import 'legacy/main';
 

--- a/assets_src/bootstrap5/install.sh
+++ b/assets_src/bootstrap5/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+NAME="${PWD##*/}"
+ROOT="../.."
+ASSETS="$ROOT/assets"
+DEST_JS="$ASSETS/js/"
+DEST_SASS="$ASSETS/sass/vendor/$NAME"
+DEST_FONTS="$ASSETS/fonts/$NAME"
+
+echo "Populating ${DEST_SASS#$ROOT/}"
+mkdir -p "${DEST_SASS%/*}"
+rm -rf "$DEST_SASS"
+# Change import paths in _bootstrap5.scss to include a "bootstrap5/" prefix
+# since the scss files to be imported are placed in this subdirectory in the next step
+sed 's,@import ",@import "'"$NAME"'/,g' node_modules/bootstrap/scss/bootstrap.scss \
+	> "${DEST_SASS%/*}/_$NAME.scss"
+cp -r node_modules/bootstrap/scss "$DEST_SASS"
+
+echo "Populating ${DEST_JS#$ROOT/}"
+mkdir -p "$DEST_JS"
+rm -f "$DEST_JS/$NAME".*.js
+cp node_modules/bootstrap/dist/js/bootstrap.min.js "$DEST_JS/$NAME.min.js"
+cp node_modules/@popperjs/core/dist/umd/popper.min.js "$DEST_JS/popper.min.js"

--- a/assets_src/bootstrap5/package-lock.json
+++ b/assets_src/bootstrap5/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "aplus-bootstrap5",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+    },
+    "bootstrap": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg=="
+    }
+  }
+}

--- a/assets_src/bootstrap5/package.json
+++ b/assets_src/bootstrap5/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aplus-bootstrap5",
+  "description": "Bootstrap 5 for A+",
+  "repository": ".",
+  "license": "MIT",
+  "version": "1.0.0",
+  "dependencies": {
+    "@popperjs/core": "^2.11.8",
+    "bootstrap": "^5.3.3"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "install": "./install.sh",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/course/templates/course/_course_cards.html
+++ b/course/templates/course/_course_cards.html
@@ -12,7 +12,7 @@
 						<img class="card-img-top" src="{{ instance.image.url }}" alt="" />
 					{% else %}
 					<div class="card-img-top">
-						<i class="glyphicon glyphicon-book"></i>
+						<i class="bi-book"></i>
 					</div>
 					{% endif %}
 				</div>

--- a/course/templates/course/_course_dropdown_menu.html
+++ b/course/templates/course/_course_dropdown_menu.html
@@ -5,14 +5,14 @@
 	<li role="presentation" class="divider"></li>
 	{% else %}
 	<li role="presentation">
-		<a href="{{ entry.link }}">
+		<a class="dropdown-item" href="{{ entry.link }}">
 			{{ entry.name }}
 		</a>
 	</li>
 	{% endif %}
 	{% empty %}
 	<li role="presentation">
-		<a href="/">
+		<a class="dropdown-item" href="/">
 			{% translate "COURSE_DROPDOWN_EMPTY_TEXT" %}
 		</a>
 	</li>

--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -8,19 +8,19 @@
 {% prepare_course_menu %}
 
 <li>
-	<a href="#course-content" class="skip-link page-skip-link hidden-xs">
+	<a href="#course-content" class="skip-link page-skip-link d-none d-sm-block">
 		{% translate "SKIP_COURSE_NAVIGATION" %}
 	</a>
 </li>
 
 {% if instance.language|first == "|" %}
-<li class="header visible-xs">
+<li class="header d-block d-sm-none">
 	<h4 id="course-menu-heading">{% translate "LANGUAGE" %}</h4>
 </li>
-<li class="visible-xs dropdown">
+<li class="d-block d-sm-none dropdown">
 	<a href="#" class="dropdown-toggle" id="lang-dropdown-mobile" data-toggle="dropdown" role="button"
 		aria-haspopup="true" aria-expanded="false">
-		{% translate "CHANGE_LANGUAGE" %} <span class="caret"></span>
+		{% translate "CHANGE_LANGUAGE" %} 
 	</a>
 	<ul class="dropdown-menu" aria-labelledby="lang-dropdown-mobile">
 		{% for language in instance.language|list_unselected %}
@@ -38,7 +38,7 @@
 {% endif %}
 <li class="header">
 	{% if instance.language|first == "|" %}
-	<div class="course-sidebar-button pull-right hidden-xs dropdown">
+	<div class="course-sidebar-button float-end d-none d-sm-block dropdown">
 		<button class="aplus-button--secondary aplus-button--xs" id="lang-dropdown-desktop" type="button"
 			data-toggle="dropdown" title="{% translate "CHANGE_LANGUAGE" %}"
 			aria-label="{% translate "CHANGE_LANGUAGE" %}" aria-haspopup="true" aria-expanded="false"
@@ -60,41 +60,41 @@
 		</ul>
 	</div>
 	{% endif %}
-	<div class="course-sidebar-button pull-right hidden-xs">
+	<div class="course-sidebar-button float-end d-none d-sm-block">
 		<button
 			class="aplus-button--secondary aplus-button--xs course-sidebar-collapser"
 			title="{% translate "CLOSE_SIDEBAR" %}"
 			aria-label="{% translate "CLOSE_SIDEBAR" %}"
 		>
-			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+			<i class="bi-caret-left-fill" aria-hidden="true"></i>
 		</button>
 	</div>
 	<h4 id="course-menu-heading">{% translate "COURSE" %}</h4>
 </li>
 
-<li class="menu-home">
-	<a href="{{ instance|url }}">
-		<span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-home" href="{{ instance|url }}">
+		<i class="bi-house-door-fill" aria-hidden="true"></i>
 		{{ course.code }}
 	</a>
 </li>
-<li class="menu-toc">
-	<a href="{{ instance|url:'toc' }}">
-		<span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-toc" href="{{ instance|url:'toc' }}">
+		<i class="bi-book" aria-hidden="true"></i>
 		{% translate "COURSE_MATERIALS" %}
 	</a>
 </li>
-<li class="menu-results">
-	<a href="{{ instance|url:'results' }}">
-		<span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-results" href="{{ instance|url:'results' }}">
+		<i class="bi-bar-chart-fill" aria-hidden="true"></i>
 		{% translate "EXERCISE_RESULTS" %}
 	</a>
 </li>
 
 {% if instance_max_group_size > 1 %}
-<li class="menu-groups">
-	<a href="{{ instance|url:'groups' }}">
-		<span class="glyphicon glyphicon-heart" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-groups" href="{{ instance|url:'groups' }}">
+		<i class="bi-heart-fill" aria-hidden="true"></i>
 		{% translate "FORM_A_GROUP" %}
 	</a>
 </li>
@@ -112,7 +112,7 @@
 <li>
 	<a href="{{ entry.url }}" {% if entry.blank %} target="_blank" {% endif %}>
 		{% if entry.icon_class %}
-		<span class="glyphicon glyphicon-{{ entry.icon_class }}" aria-hidden="true"></span>
+		<i class="bi-{{ entry.icon_class }}" aria-hidden="true"></i>
 		{% endif %}
 		{{ entry.label|parse_localization }}
 	</a>
@@ -129,7 +129,7 @@
 {% endif %}
 <li class="menu-tab{{ tab.id }}">
 	<a href="{% url 'apps-tab' course_slug=course.url instance_slug=instance.url tab_id=tab.id %}">
-		<span class="glyphicon glyphicon-th-large" aria-hidden="true"></span>
+		<i class="bi-th-large" aria-hidden="true"></i>
 		{{ tab.label }}
 	</a>
 </li>
@@ -140,76 +140,76 @@
 	<h4>{% translate "COURSE_STAFF" %}</h4>
 </li>
 
-<li class="menu-participants">
-	<a href="{{ instance|url:'participants' }}">
-		<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-participants" href="{{ instance|url:'participants' }}">
+		<i class="bi-list" aria-hidden="true"></i>
 		{% translate "PARTICIPANTS" %}
 	</a>
 </li>
 
-<li class="menu-groups-edit">
-	<a href="{{ instance|url:'groups-list' }}">
-		<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-groups-edit" href="{{ instance|url:'groups-list' }}">
+		<i class="bi-list" aria-hidden="true"></i>
 		{% translate "GROUPS" %}
 	</a>
 </li>
 
 {% if instance.coursediplomadesign %}
-<li class="menu-grades">
-	<a href="{% url 'diploma-list' instance.coursediplomadesign.id %}">
-		<span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-grades" href="{% url 'diploma-list' instance.coursediplomadesign.id %}">
+		<i class="bi-certificate" aria-hidden="true"></i>
 		{% translate "GRADES" %}
 	</a>
 </li>
 {% endif %}
 
-<li class="menu-all-results">
-	<a href="{{ instance|url:'all-results' }}">
-		<span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-all-results" href="{{ instance|url:'all-results' }}">
+		<i class="bi-folder2-open" aria-hidden="true"></i>
 		{% translate "ALL_RESULTS" %}
 	</a>
 </li>
 
-<li class="menu-analytics">
-	<a href="{{ instance|url:'analytics' }}">
-		<span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-analytics" href="{{ instance|url:'analytics' }}">
+		<i class="bi-bar-chart-fill" aria-hidden="true"></i>
 		{% translate "VISUALIZATIONS" %}
 	</a>
 </li>
 
 {% if is_teacher %}
-<li class="menu-edit-news">
-	<a href="{{ instance|url:'news-list' }}">
-		<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-edit-news" href="{{ instance|url:'news-list' }}">
+		<i class="bi-pencil" aria-hidden="true"></i>
 		{% translate "EDIT_NEWS" %}
 	</a>
 </li>
-<li class="menu-edit-course">
-	<a href="{{ instance|url:'course-edit' }}">
-		<span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-course" href="{{ instance|url:'course-edit' }}">
+		<i class="bi-gear-fill" aria-hidden="true"></i>
 		{% translate "EDIT_COURSE" %}
 	</a>
 </li>
-<li class="menu-deadline-deviations">
-	<a href="{{ instance|url:'deviations-list-dl' }}">
-		<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-deadline-deviations" href="{{ instance|url:'deviations-list-dl' }}">
+		<i class="bi-list" aria-hidden="true"></i>
 		{% translate "DEADLINE_DEVIATIONS" %}
 	</a>
 </li>
-<li class="menu-submission-deviations">
-	<a href="{{ instance|url:'deviations-list-submissions' }}">
-		<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+<li class="nav-item">
+	<a class="nav-link menu-submission-deviations" href="{{ instance|url:'deviations-list-submissions' }}">
+		<i class="bi-list" aria-hidden="true"></i>
 		{% translate "SUBMISSION_DEVIATIONS" %}
 	</a>
 </li>
 
-<li class="menu-pseudonymize">
-	<a href="{% url 'toggle-pseudonymization' %}">
+<li class="nav-item">
+	<a class="nav-link menu-pseudonymize" href="{% url 'toggle-pseudonymization' %}">
 		{% if pseudonymize %}
-			<span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+			<i class="bi-eye-fill" aria-hidden="true"></i>
 			{% translate "UNPSEUDONYMIZE" %}
 		{% else %}
-			<span class="glyphicon glyphicon-eye-close" aria-hidden="true"></span>
+			<i class="bi-eye-slash-fill" aria-hidden="true"></i>
 			{% translate "PSEUDONYMIZE" %}
 		{% endif %}
 	</a>
@@ -229,7 +229,7 @@
 <li>
 	<a href="{{ entry.url }}" {% if entry.blank %} target="_blank" {% endif %}>
 		{% if entry.icon_class %}
-		<span class="glyphicon glyphicon-{{ entry.icon_class }}" aria-hidden="true"></span>
+		<i class="bi-{{ entry.icon_class }}" aria-hidden="true"></i>
 		{% endif %}
 		{{ entry.label|parse_localization }}
 	</a>
@@ -248,7 +248,7 @@
 </li>
 <li class="menu-unenroll">
 	<a data-toggle="modal" data-target="#unenroll-modal" role="button">
-		<span class="glyphicon glyphicon-remove-sign" aria-hidden="true"></span>
+		<i class="bi-remove-sign" aria-hidden="true"></i>
 		{% trans "UNENROLL" %}
 	</a>
 </li>

--- a/course/templates/course/_siblings.html
+++ b/course/templates/course/_siblings.html
@@ -18,7 +18,7 @@
 		<span aria-hidden="true">&laquo;</span> {{ previous.name|parse_localization }}
 		{% if is_course_staff %}
 		<a href="{{ previous.link }}">
-			<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+			<i class="bi-lock" aria-hidden="true"></i>
 			{% translate "EARLY_ACCESS" %}
 		</a>
 		{% endif %}
@@ -26,7 +26,7 @@
 	{% endif %}
 	{% endif %}
 
-	<span class="hidden-md hidden-sm hidden-xs" style="display: block; margin: auto; text-align: center;">
+	<span class="hidden-md hidden-sm d-none d-sm-block" style="display: block; margin: auto; text-align: center;">
 		<a href="{{ instance|url:'toc' }}">
 			{% translate "COURSE_MATERIALS" %}
 		</a>
@@ -43,11 +43,11 @@
 		{{ next.name|parse_localization }} <span aria-hidden="true">&raquo;</span>
 	</a>
 	{% else %}
-	<span class="pull-right disabled">
+	<span class="float-end disabled">
 		{{ next.name|parse_localization }} <span aria-hidden="true">&raquo;</span>
 		{% if is_course_staff %}
 		<a href="{{ next.link }}">
-			<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+			<i class="bi-lock" aria-hidden="true"></i>
 			{% translate "EARLY_ACCESS" %}
 		</a>
 		{% endif %}

--- a/course/templates/course/course_base.html
+++ b/course/templates/course/course_base.html
@@ -34,15 +34,15 @@
 <div data-taggings="{{ taggings|join:' ' }}" class="row">
 	{% block course_sidebar %}
 	<button
-		class="hidden hidden-xs course-sidebar-expander"
+		class="d-none course-sidebar-expander"
 		title="{% translate 'OPEN_SIDEBAR' %}"
 		aria-label="{% translate 'OPEN_SIDEBAR' %}"
 	>
-		<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+		<i class="bi-caret-right-fill" aria-hidden="true"></i>
 	</button>
-	<div class="col-sm-2 hidden-xs" id="course-sidebar">
+	<div class="col-sm-2 d-none d-sm-block" id="course-sidebar">
 		<nav class="course-menu" id="main-course-menu" aria-labelledby="course-menu-heading">
-			<ul class="nav nav-pills nav-stacked">
+			<ul class="nav nav-pills nav-stacked flex-column" aria-orientation="vertical">
 				{% include "course/_course_menu.html" %}
 			</ul>
 			{% site_advert as advert %}

--- a/course/templates/course/index.html
+++ b/course/templates/course/index.html
@@ -49,7 +49,7 @@
 								<img class="card-img-top" src="{{ advert.image }}" alt="" />
 							{% else %}
 								<div class="card-img-top">
-									<i class="glyphicon glyphicon-comment"></i>
+									<i class="bi-comment"></i>
 								</div>
 							{% endif %}
 						</div>

--- a/course/templates/course/staff/groups.html
+++ b/course/templates/course/staff/groups.html
@@ -16,7 +16,7 @@
   <p>
     {% translate "NUMBER_OF_GROUPS" %} <strong>{{ groups|length }}</strong>
     <a class="aplus-button--secondary aplus-button--xs" role="button" href="{{ instance|url:'groups-add' }}">
-      <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+      <i class="far fa-plus-sign" aria-hidden="true"></i>
       {% translate "ADD_NEW" %}
     </a>
   </p>
@@ -38,11 +38,11 @@
         <td>{{ group.timestamp }}</td>
         <td>
           <a class="aplus-button--secondary aplus-button--xs" role="button" href="{% url 'groups-edit' course_slug=course.url instance_slug=instance.url group_id=group.id %}">
-            <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+            <i class="bi-edit" aria-hidden="true"></i>
             {% translate "EDIT" %}
           </a>
           <a class="aplus-button--secondary aplus-button--xs" role="button" href="{% url 'groups-delete' course_slug=course.url instance_slug=instance.url group_id=group.id %}">
-            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+            <i class="bi-remove" aria-hidden="true"></i>
             {% translate "REMOVE" %}
           </a>
         </td>

--- a/course/templates/course/staff/participants.html
+++ b/course/templates/course/staff/participants.html
@@ -17,7 +17,7 @@
 	{% if is_teacher %}
 	<p>
 		<a class="aplus-button--secondary aplus-button--sm" role="button" href="{{ instance|url:'enroll-students' }}">
-			<span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+			<i class="bi-user" aria-hidden="true"></i>
 			{% translate "ENROLL_STUDENTS" %}
 		</a>
 	</p>
@@ -26,7 +26,7 @@
 		<small>{% trans "FILTER_USERS_BY_TAG" %}:</small>
 		{% for tag in tags %}
 		<button class="btn btn-default btn-xs filter-tag" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-tagslug="{{ tag.slug }}">
-			<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+			<i class="bi-square" aria-hidden="true"></i>
 			{{ tag.name }}
 		</button>
 		{% endfor %}
@@ -34,9 +34,9 @@
 		{% for status_code, status_label in enrollment_statuses.items %}
 		<button class="btn btn-default btn-xs filter-status" data-status="{{ status_code }}">
 			{% if status_code == 'ACTIVE' %}
-			<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+			<i class="check-square" aria-hidden="true"></i>
 			{% else %}
-			<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+			<i class="bi-square" aria-hidden="true"></i>
 			{% endif %}
 			{{ status_label }}
 		</button>

--- a/deviations/templates/deviations/list_dl.html
+++ b/deviations/templates/deviations/list_dl.html
@@ -15,15 +15,15 @@
 <div class="col-md-12">
 	<p>
 		<a class="aplus-button--default aplus-button--xs" role="button" href="{{ instance|url:'deviations-add-dl' }}">
-			<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+			<i class="bi-plus-sign" aria-hidden="true"></i>
 			{% translate "ADD_NEW_DEADLINE_DEVIATIONS" %}
 		</a>
 		<a class="aplus-button--default aplus-button--xs" href="{{ instance|url:'deviations-remove-dl' }}">
-			<span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
+			<i class="bi-minus-sign" aria-hidden="true"></i>
 			{% translate "REMOVE_DEADLINE_DEVIATIONS" %}
 		</a>
-		<a class="aplus-button--danger aplus-button--xs pull-right" id="remove-selected-button" data-toggle="modal" data-target="#remove-selected-modal" role="button">
-			<span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
+		<a class="aplus-button--danger aplus-button--xs float-end" id="remove-selected-button" data-toggle="modal" data-target="#remove-selected-modal" role="button">
+			<i class="bi-minus-sign" aria-hidden="true"></i>
 			{% translate "REMOVE_SELECTED_DEVIATIONS" %}
 		</a>
 	</p>
@@ -76,10 +76,10 @@
 						</td>
 						<td>
 							{% if deviations.0.without_late_penalty %}
-								<span class="glyphicon glyphicon-ok"></span>
+								<i class="bi-ok"></i>
 								{% translate "YES" %}
 							{% else %}
-								<span class="glyphicon glyphicon-remove"></span>
+								<i class="bi-remove"></i>
 								{% translate "NO" %}
 							{% endif %}
 						</td>
@@ -120,10 +120,10 @@
 						</td>
 						<td>
 							{% if deviation.without_late_penalty %}
-								<span class="glyphicon glyphicon-ok"></span>
+								<i class="bi-ok"></i>
 								{% translate "YES" %}
 							{% else %}
-								<span class="glyphicon glyphicon-remove"></span>
+								<i class="bi-remove"></i>
 								{% translate "NO" %}
 							{% endif %}
 						</td>

--- a/deviations/templates/deviations/list_submissions.html
+++ b/deviations/templates/deviations/list_submissions.html
@@ -15,15 +15,15 @@
 <div class="col-md-12">
 	<p>
 		<a class="aplus-button--default aplus-button--xs" href="{{ instance|url:'deviations-add-submissions' }}">
-			<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+			<i class="bi-plus-sign" aria-hidden="true"></i>
 			{% translate "ADD_NEW_SUBMISSION_DEVIATIONS" %}
 		</a>
 		<a class="aplus-button--default aplus-button--xs" href="{{ instance|url:'deviations-remove-submissions' }}">
-			<span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
+			<i class="bi-minus-sign" aria-hidden="true"></i>
 			{% translate "REMOVE_SUBMISSION_DEVIATIONS" %}
 		</a>
-		<a class="aplus-button--danger aplus-button--xs pull-right" id="remove-selected-button" data-toggle="modal" data-target="#remove-selected-modal" role="button">
-			<span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span>
+		<a class="aplus-button--danger aplus-button--xs float-end" id="remove-selected-button" data-toggle="modal" data-target="#remove-selected-modal" role="button">
+			<i class="bi-minus-sign" aria-hidden="true"></i>
 			{% translate "REMOVE_SELECTED_DEVIATIONS" %}
 		</a>
 	</p>

--- a/deviations/templates/deviations/override_dl.html
+++ b/deviations/templates/deviations/override_dl.html
@@ -73,19 +73,19 @@
 					</td>
 					<td>
 						{% if deviations.0.without_late_penalty %}
-							<span class="glyphicon glyphicon-ok"></span>
+							<i class="bi-ok"></i>
 							{% translate "YES" %}
 						{% else %}
-							<span class="glyphicon glyphicon-remove"></span>
+							<i class="bi-remove"></i>
 							{% translate "NO" %}
 						{% endif %}
 					</td>
 					<td>
 						{% if session_data.without_late_penalty %}
-							<span class="glyphicon glyphicon-ok"></span>
+							<i class="bi-ok"></i>
 							{% translate "YES" %}
 						{% else %}
-							<span class="glyphicon glyphicon-remove"></span>
+							<i class="bi-remove"></i>
 							{% translate "NO" %}
 						{% endif %}
 					</td>
@@ -112,19 +112,19 @@
 					</td>
 					<td>
 						{% if deviation.without_late_penalty %}
-							<span class="glyphicon glyphicon-ok"></span>
+							<i class="bi-ok"></i>
 							{% translate "YES" %}
 						{% else %}
-							<span class="glyphicon glyphicon-remove"></span>
+							<i class="bi-remove"></i>
 							{% translate "NO" %}
 						{% endif %}
 					</td>
 					<td>
 						{% if session_data.without_late_penalty %}
-							<span class="glyphicon glyphicon-ok"></span>
+							<i class="bi-ok"></i>
 							{% translate "YES" %}
 						{% else %}
-							<span class="glyphicon glyphicon-remove"></span>
+							<i class="bi-remove"></i>
 							{% translate "NO" %}
 						{% endif %}
 					</td>

--- a/diploma/templates/diploma/_diploma_button.html
+++ b/diploma/templates/diploma/_diploma_button.html
@@ -8,7 +8,7 @@
     </button>
     {% if grade == 0 and is_course_staff %}
     <button class="btn btn-link">
-      <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+      <i class="bi-lock" aria-hidden="true"></i>
       {% translate "OPEN_GRADE_0_DIPLOMA" %}
     </button>
     {% endif %}

--- a/diploma/templates/diploma/list.html
+++ b/diploma/templates/diploma/list.html
@@ -12,11 +12,11 @@
 <p class="filter-users">
   <small>{% translate "FILTER_USERS" %}:</small>
   <a class="btn btn-success btn-xs" href="?group=internal">
-    <span class="glyphicon glyphicon-{% if group == 'internal' %}check{% else %}unchecked{% endif %}" aria-hidden="true"></span>
+    <i class="bi-{% if group == 'internal' %}check{% else %}unchecked{% endif %}" aria-hidden="true"></i>
     {{ internal_user_label|safe }}
   </a>
   <a class="btn btn-info btn-xs" href="?group=external">
-    <span class="glyphicon glyphicon-{% if group == 'external' %}check{% else %}unchecked{% endif %}" aria-hidden="true"></span>
+    <i class="bi-{% if group == 'external' %}check{% else %}unchecked{% endif %}" aria-hidden="true"></i>
     {{ external_user_label|safe }}
   </a>
 </p>

--- a/edit_course/templates/edit_course/clone_instance.html
+++ b/edit_course/templates/edit_course/clone_instance.html
@@ -37,7 +37,7 @@
     </tbody>
   </table>
 </div>
-<form id="clone-form" method="post" class="well">
+<form id="clone-form" method="post" class="card">
     {% csrf_token %}
     <legend>{% translate "CLONE_COURSE" %}</legend>
     <p>

--- a/edit_course/templates/edit_course/edit_content.html
+++ b/edit_course/templates/edit_course/edit_content.html
@@ -10,7 +10,7 @@
 
 {% block coursecontent %}
 <br>
-<div class="well">
+<div class="card">
   <form method="post" class="form-inline" action="{{ instance|url:'course-configure' }}">
     {% csrf_token %}
     <div class="form-group">
@@ -49,12 +49,12 @@
                 </td>
                 <td>
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ category|editurl:'category' }}">
-                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+                        <i class="bi-edit" aria-hidden="true"></i>
                         {% translate "EDIT_CATEGORY" %}
                     </a>
                     {% if category.count_lobjects == 0 %}
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ category|removeurl:'category' }}" role="button">
-                    	<span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% translate "REMOVE" %}
+                    	<i class="bi-remove" aria-hidden="true"></i> {% translate "REMOVE" %}
                     </a>
                     {% endif %}
                 </td>
@@ -63,7 +63,7 @@
             <tr>
                 <th colspan="2">
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ instance|createurl:'category' }}" role="button">
-                        <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+                        <i class="bi-plus-sign" aria-hidden="true"></i>
                         {% translate "ADD_NEW_CATEGORY" %}
                     </a>
                 </th>
@@ -88,11 +88,11 @@
                 </th>
                 <td>
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ module|editurl:'module' }}" role="button">
-                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span> {% translate "EDIT_MODULE" %}
+                        <i class="bi-edit" aria-hidden="true"></i> {% translate "EDIT_MODULE" %}
                     </a>
                     {% if module.learning_objects.count == 0 %}
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ module|removeurl:'module' }}" role="button">
-                    	<span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% translate "REMOVE" %}
+                    	<i class="bi-remove" aria-hidden="true"></i> {% translate "REMOVE" %}
                     </a>
                     {% endif %}
                     <a class="btn btn-link btn-xs" href="{{ module|url }}">
@@ -110,11 +110,11 @@
                 </td>
                 <td>
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ lobject|editurl:'exercise' }}" role="button">
-                      <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+                      <i class="bi-edit" aria-hidden="true"></i>
                       {% if lobject.is_submittable %}{% translate "EDIT_EXERCISE" %}{% else %}{% translate "EDIT_CHAPTER" %}{% endif %}
                     </a>
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ lobject|removeurl:'exercise' }}" role="button">
-                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> {% translate "REMOVE" %}
+                        <i class="bi-remove" aria-hidden="true"></i> {% translate "REMOVE" %}
                     </a>
                     <a class="btn btn-link btn-xs" href="{{ lobject|url }}">
                       {% if lobject.is_submittable %}{% translate "VIEW_EXERCISE" %}{% else %}{% translate "VIEW_CHAPTER" %}{% endif %}
@@ -130,7 +130,7 @@
             <tr>
                 <td colspan="2">
                     <a class="aplus-button--secondary aplus-button--xs" data-toggle="modal" data-target="#lobject{{ module.id }}" role="button">
-                        <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+                        <i class="bi-plus-sign" aria-hidden="true"></i>
                         {% translate "ADD_NEW_LEARNING_OBJECT" %}
                     </a>
                     <div class="modal" id="lobject{{ module.id }}" tabindex="-1" role="dialog" aria-labelledby="lobject{{ module.id }}Label">
@@ -177,7 +177,7 @@
             <tr>
                 <th colspan="2">
                     <a class="aplus-button--secondary aplus-button--xs" href="{{ instance|createurl:'module' }}" role="button">
-                        <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+                        <i class="bi-plus-sign" aria-hidden="true"></i>
                         {% translate "ADD_NEW_MODULE" %}
                     </a>
                 </th>
@@ -185,7 +185,7 @@
         </tbody>
     </table>
 </div>
-<form method="post" class="well">
+<form method="post" class="card">
     {% csrf_token %}
     {{ form|bootstrap }}
     <button class="aplus-button--default aplus-button--md" type="submit" name="save">{% translate "SAVE" %}</button>

--- a/edit_course/templates/edit_course/edit_gitmanager.html
+++ b/edit_course/templates/edit_course/edit_gitmanager.html
@@ -11,7 +11,7 @@
 
 {% block coursecontent %}
 <br />
-<form id="gitmanager-form" method="post" class="well">
+<form id="gitmanager-form" method="post" class="card">
     {% csrf_token %}
     <legend>{% translate "EDIT_GITMANAGER" %}</legend>
     <a style="float: right" role="button" value="{{ gitmanager_url }}" href="javascript:;" id="gitmanager-link">

--- a/edit_course/templates/edit_course/edit_index.html
+++ b/edit_course/templates/edit_course/edit_index.html
@@ -12,7 +12,7 @@
 
 {% block coursecontent %}
 <br />
-<form method="post" class="well">
+<form method="post" class="card">
     {% csrf_token %}
     <legend>{% translate "EDIT_COURSE_INDEX" %}</legend>
     {{ form|bootstrap }}

--- a/edit_course/templates/edit_course/edit_instance.html
+++ b/edit_course/templates/edit_course/edit_instance.html
@@ -13,7 +13,7 @@
 
 {% block coursecontent %}
 <br />
-<form method="post" enctype="multipart/form-data" class="well">
+<form method="post" enctype="multipart/form-data" class="card">
     {% csrf_token %}
     <legend>{% translate "EDIT_COURSE_DETAILS" %}</legend>
     {{ form|bootstrap }}

--- a/edit_course/templates/edit_course/edit_model.html
+++ b/edit_course/templates/edit_course/edit_model.html
@@ -41,7 +41,7 @@
                 {% translate "FILL_IN_URL_AND" %}
                 <a id="fetch-metadata" class="btn btn-primary btn-xs" href="#">
                     {% translate "DOWNLOAD_POSSIBLE_METADATA" %}
-                    <span class="glyphicon glyphicon-download" aria-hidden="true"></span>
+                    <i class="bi-download" aria-hidden="true"></i>
                 </a>
             </p>
             <div id="metadata-progress" class="progress hide">

--- a/edit_course/templates/edit_course/submissiontag_list.html
+++ b/edit_course/templates/edit_course/submissiontag_list.html
@@ -15,7 +15,7 @@
 <br />
 <p>
 	<a class="aplus-button--secondary aplus-button--sm" role="button" href="{{ instance|url:'course-submission-tags-add' }}">
-		<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+		<i class="bi-plus-sign" aria-hidden="true"></i>
 		{% translate "ADD_NEW_SUBMISSION_TAG" %}
 	</a>
 </p>
@@ -38,11 +38,11 @@
 			<td>{{ tag.description }}</td>
 			<td>
 				<a href="{{ tag|url:'course-submission-tags-edit' }}" class="aplus-button--secondary aplus-button--xs" role="button">
-					<span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+					<i class="bi-edit" aria-hidden="true"></i>
 					{% translate "EDIT" %}
 				</a>
 				<a href="{{ tag|url:'course-submission-tags-remove' }}" class="aplus-button--secondary aplus-button--xs" role="button">
-					<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+					<i class="bi-remove" aria-hidden="true"></i>
 					{% translate "REMOVE" %}
 				</a>
 			</td>

--- a/edit_course/templates/edit_course/usertag_list.html
+++ b/edit_course/templates/edit_course/usertag_list.html
@@ -15,7 +15,7 @@
 <br />
 <p>
 	<a class="aplus-button--secondary aplus-button--sm" role="button" href="{{ instance|url:'course-tags-add' }}">
-		<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+		<i class="bi-plus-sign" aria-hidden="true"></i>
 		{% translate "ADD_NEW_STUDENT_TAG" %}
 	</a>
 </p>
@@ -40,15 +40,15 @@
 			<td>{% if tag.visible_to_students %}<span style="color: #00B000;">yes</span>{% else %}<span style="color: #B00000;">no</span>{% endif %}</td>
 			<td>
 				<a href="{{ tag|url:'course-tags-edit' }}" class="aplus-button--secondary aplus-button--xs" role="button">
-					<span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+					<i class="bi-edit" aria-hidden="true"></i>
 					{% translate "EDIT" %}
 				</a>
 				<a href="{{ tag|url:'course-tags-remove' }}" class="aplus-button--secondary aplus-button--xs" role="button">
-					<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+					<i class="bi-remove" aria-hidden="true"></i>
 					{% translate "REMOVE" %}
 				</a>
         <a href="{{ tag|url:'course-taggings-add' }}" class="aplus-button--secondary aplus-button--xs" role="button">
-          <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+          <i class="bi-plus-sign" aria-hidden="true"></i>
           {% translate "TAG_STUDENTS" %}
         </a>
 			</td>

--- a/exercise/templates/exercise/_category_points.html
+++ b/exercise/templates/exercise/_category_points.html
@@ -4,26 +4,30 @@
 
 {% comment "Disabled as course total points/grade calculation is unknown." %}
 {% if categories|length > 1 %}
-<div class="well">
-    <p>{% translate "TOTAL_POINTS" %}</p>
-    <p><strong class="h2">
-    	{{ course.points }}
-    	<small>/ {{ course.max_points }}</small>
-    </strong></p>
-    {% points_progress course %}
+<div class="card">
+    <div class="card-body">
+        <p>{% translate "TOTAL_POINTS" %}</p>
+        <p><strong class="h2">
+            {{ course.points }}
+            <small>/ {{ course.max_points }}</small>
+        </strong></p>
+        {% points_progress course %}
+    </div>
 </div>
 {% endif %}
 {% endcomment %}
 
 {% for entry in categories %}
 {% if entry.is_visible and entry.max_points > 0 %}
-<div class="well">
-    <p>{{ entry.name|parse_localization }}</p>
-    <p><strong class="h2">
-    	{{ entry.formatted_points }}
-    	<small>/ {{ entry.max_points }}</small>
-    </strong></p>
-    {% points_progress entry %}
+<div class="card">
+    <div class="card-body">
+        <p>{{ entry.name|parse_localization }}</p>
+        <p><strong class="h2">
+            {{ entry.formatted_points }}
+            <small>/ {{ entry.max_points }}</small>
+        </strong></p>
+        {% points_progress entry %}
+    </div>
 </div>
 {% endif %}
 {% endfor %}

--- a/exercise/templates/exercise/_children.html
+++ b/exercise/templates/exercise/_children.html
@@ -28,7 +28,7 @@
 			{{ entry.name|parse_localization }}
 			{% if is_course_staff %}
 				<a href="{{ entry.link }}">
-					<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+					<i class="bi-lock" aria-hidden="true"></i>
 					{% translate "EARLY_ACCESS" %}
 				</a>
 			{% endif %}

--- a/exercise/templates/exercise/_exercise_info.html
+++ b/exercise/templates/exercise/_exercise_info.html
@@ -2,7 +2,7 @@
 {% load course %}
 {% load exercise %}
 
-<div class="well">
+<div class="card">
     {% if exercise.category.confirm_the_level %}
     <p>{% translate "CURRENT_STATUS" %}</p>
     <p class="exercise-info-points">

--- a/exercise/templates/exercise/_file_link.html
+++ b/exercise/templates/exercise/_file_link.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 {% if file.exists %}
 	<a href="{{ file.get_absolute_url }}"{% if not file.is_passed %} class="file-modal" role="button" data-modal-title="{{ file.filename }}"{% endif %}>
-		<span class="sr-only">
+		<span class="visually-hidden">
 			{% blocktranslate trimmed with filename=file.filename %}VIEW_FILE -- {{ filename }}{% endblocktranslate %}
 		</span>
 		<span aria-hidden="true">{{ file.filename }}</span>
 	</a>
 	<a href="{{ file.get_absolute_url }}?download=yes" class="aplus-button--secondary aplus-button--xs" title="{% translate 'DOWNLOAD' %}">
-		<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
-		<span class="sr-only">
+		<i class="bi-download-alt" aria-hidden="true"></i>
+		<span class="visually-hidden">
 			{% blocktranslate trimmed with filename=file.filename %}DOWNLOAD_FILE -- {{ filename }}{% endblocktranslate %}
 		</span>
 		{{ file.file_object.size|filesizeformat }}
@@ -16,7 +16,7 @@
 {% else %}
 	<span>{{ file.filename }}</span>
 	<button class="aplus-button--secondary aplus-button--xs" disabled>
-		<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
+		<i class="bi-download-alt" aria-hidden="true"></i>
 		{% translate "FILE_NOT_FOUND" %}
 	</button>
 {% endif %}

--- a/exercise/templates/exercise/_points_progress.html
+++ b/exercise/templates/exercise/_points_progress.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% if not feedback_revealed %}
 <p class="small">
-	<i class="glyphicon glyphicon-info-sign"></i>
+	<i class="bi-info-sign"></i>
 	{% translate "RESULTS_OF_SOME_ASSIGNMENTS_ARE_CURRENTLY_HIDDEN" %}
 </p>
 {% endif %}

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -11,7 +11,7 @@
 	{% for entry in categories %}
 	{% if entry.is_listed %}
 	<button class="aplus-button--secondary aplus-button--xs" data-category="{{ entry.id }}" aria-pressed="true">
-		<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+		<i class="check-square" aria-hidden="true"></i>
 		{{ entry.name|parse_localization }}
 	</button>
 	{% endif %}
@@ -21,15 +21,15 @@
 
 <p>
 	<button id="toggle-expand-all-modules" class="aplus-button--secondary aplus-button--xs" aria-pressed="false" style="display:none">
-		<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+		<i class="bi-square" aria-hidden="true"></i>
 		{% translate "EXPAND_ALL_MODULES" %}
 	</button>
 	<button id="toggle-auto-scroll" class="aplus-button--secondary aplus-button--xs" aria-pressed="true" style="display:none">
-		<span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+		<i class="check-square" aria-hidden="true"></i>
 		{% translate "AUTO_SCROLL" %}
 	</button>
 	<button id="auto-scroll-behavior-instant" class="aplus-button--secondary aplus-button--xs" aria-pressed="false" style="display:none">
-		<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+		<i class="bi-square" aria-hidden="true"></i>
 		{% translate "AUTO_SCROLL_BEHAVIOR_INSTANT" %}
 	</button>
 </p>
@@ -44,32 +44,32 @@
 		role="button" href="#module{{ module.id }}" data-toggle="collapse"
 		aria-expanded="{% if accessible and not after_open or open %}true{% else %}false{% endif %}" aria-controls="#module{{ module.id }}">
 		<h3 class="panel-title">
-			{% points_badge module "pull-right" %}
+			{% points_badge module "float-end" %}
 			{% if not accessible %}
-			<span class="badge pull-right">
+			<span class="badge float-end">
 				{% translate "OPENS ON" %} {{ module.opening_time }}
 			</span>
 			{% elif not after_open %}
-			<span class="badge pull-right">
+			<span class="badge float-end">
 				{% translate "EXERCISES_OPEN_ON" %} {{ module.opening_time }}
 			</span>
-			<span class="badge badge-info pull-right">
+			<span class="badge badge-info float-end">
 				{% translate "OPEN_FOR_READING" %}
 			</span>
 			{% endif %}
 			{% if module|deadline_extended_exercises_open:now %}
-			<span class="badge pull-right">
+			<span class="badge float-end">
 				{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
 			</span>
 			{% endif %}
 			{% if module.requirements|length > 0 %}
-			<span class="badge pull-right">
+			<span class="badge float-end">
 				{% translate "REQUIRES" %}:
 				{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
 			</span>
 			{% endif %}
 			{% if not module.is_visible and is_teacher %}
-			<span class="label label-danger pull-right">{% translate "HIDDEN_capitalized" %}</span>
+			<span class="label label-danger float-end">{% translate "HIDDEN_capitalized" %}</span>
 			{% endif %}
 			<div class="module-name">
 				<span class="caret" aria-hidden="true"></span>
@@ -140,8 +140,8 @@
 								data-toggle="tooltip"
 								title="{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}"
 							>
-								<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-								<span class="sr-only">{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}</span>
+								<i class="bi-time" aria-hidden="true"></i>
+								<span class="visually-hidden">{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}</span>
 							</span>
 						{% endif %}
 						{% else %}
@@ -155,7 +155,7 @@
 						<a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-haspopup="true" aria-expanded="false" role="button">
 							<span class="badge">
 								{% if entry.notified %}
-								<span class="glyphicon glyphicon-comment{% if entry.unseen %} red{% endif %}"></span>
+								<i class="bi-comment{% if entry.unseen %} red{% endif %}"></i>
 								{% endif %}
 								{{ entry.submission_count }}
 								{% if entry.max_submissions > 0 %}
@@ -187,7 +187,7 @@
 						{% if entry.submissions and student.id %}
 						{% url 'submitter-inspect' course_slug=course.url instance_slug=instance.url module_slug=module.url exercise_path=entry.get_path user_id=student.id as inspect_url %}
 						<a href="{{ inspect_url }}" class="aplus-button--secondary aplus-button--xs">
-							<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+							<i class="bi-zoom-in" aria-hidden="true"></i>
 							{% translate "INSPECT" %}
 						</a>
 						{% endif %}
@@ -198,14 +198,14 @@
 					<td>
 						{% if not accessible %}
 						<a href="{{ entry.link }}">
-							<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+							<i class="bi-lock" aria-hidden="true"></i>
 							{% translate "EARLY_ACCESS" %}
 						</a>
 						{% else %}
 						{% exercise_text_stats entry.id %}
 						{% endif %}
 						<a class="aplus-button--secondary aplus-button--xs" href="{{ entry.submissions_link }}">
-							<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+							<i class="bi-list" aria-hidden="true"></i>
 							{% translate "VIEW_SUBMISSIONS" %}
 						</a>
 					</td>
@@ -229,11 +229,11 @@
 							data-toggle="tooltip"
 							title="{% translate 'MODULE_MODEL_ANSWER_NOT_VISIBLE' %}"
 						>
-							<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-							<span class="sr-only">{% translate "MODULE_MODEL_ANSWER_NOT_VISIBLE" %}</span>
+							<i class="bi-info-sign" aria-hidden="true"></i>
+							<span class="visually-hidden">{% translate "MODULE_MODEL_ANSWER_NOT_VISIBLE" %}</span>
 							{% if is_course_staff %}
 							<a href="{{ entry.link }}">
-								<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+								<i class="bi-lock" aria-hidden="true"></i>
 								{% translate "EARLY_ACCESS" %}
 							</a>
 							{% endif %}
@@ -245,7 +245,7 @@
 					<td>
 						{% if not accessible %}
 						<a href="{{ entry.link }}">
-							<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+							<i class="bi-lock" aria-hidden="true"></i>
 							{% translate "EARLY_ACCESS" %}
 						</a>
 						{% endif %}

--- a/exercise/templates/exercise/_user_toc.html
+++ b/exercise/templates/exercise/_user_toc.html
@@ -31,7 +31,7 @@
 			{{ module.name|parse_localization }}
 			{% if is_course_staff %}
 			<a href="{{ module.link }}">
-				<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+				<i class="bi-lock" aria-hidden="true"></i>
 				{% translate "EARLY_ACCESS" %}
 			</a>
 			{% endif %}

--- a/exercise/templates/exercise/exercise_base.html
+++ b/exercise/templates/exercise/exercise_base.html
@@ -51,7 +51,7 @@
 							aria-haspopup="true" aria-expanded="false">
 							{% translate "MY_SUBMISSIONS" %}
 							({{ summary.submission_count }}{% if exercise.max_submissions %}/{{ summary.personal_max_submissions|default_if_none:exercise.max_submissions }}{% endif %})
-							<span class="caret"></span>
+							
 					</a>
 					<ul class="dropdown-menu">
 							{% for submission in submissions %}
@@ -95,20 +95,20 @@
 					<p class="navbar-text navbar-btn">
 							{% if submission and not disable_staff_nav %}
 							<a href="{{ submission|url:'submission-inspect' }}" role="button" class="aplus-button--secondary aplus-button--xs">
-									<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+									<i class="bi-zoom-in" aria-hidden="true"></i>
 									{% translate "INSPECT_SUBMISSION" %}
 							</a>
 							{% elif is_teacher and not disable_staff_nav %}
 							{% load editcourse %}
 							<a href="{{ exercise|editurl:'exercise' }}" role="button" class="aplus-button--secondary aplus-button--xs">
-									<span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+									<i class="bi-edit" aria-hidden="true"></i>
 									{% translate "EDIT_EXERCISE" %}
 							</a>
 							{% endif %}
 							{% if not disable_staff_nav %}
 								{% if is_teacher or exercise.allow_assistant_viewing %}
 								<a href="{{ exercise|url:'submission-list' }}" role="button" class="aplus-button--secondary aplus-button--xs">
-										<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+										<i class="bi-list" aria-hidden="true"></i>
 										{% translate "VIEW_ALL_SUBMISSIONS" %}
 								</a>
 								{% endif %}

--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -14,7 +14,8 @@
 				integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
 				crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-		<script src="{% static 'js/bootstrap3.min.js' %}"></script>
+		<script src="{% static 'js/popper.min.js' %}"></script>
+		<script src="{% static 'js/bootstrap5.min.js' %}"></script>
 
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" rel="stylesheet"
 				integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA=="
@@ -115,14 +116,14 @@
 										<ul>
 											{% if exercise.points_to_pass > 0 %}
 												<li>
-													<span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+													<i class="bi-flag" aria-hidden="true"></i>
 													{% blocktranslate trimmed with points=exercise.points_to_pass %}
 														POINTS_REQUIRED_TO_PASS -- {{ points }}
 													{% endblocktranslate %}
 												</li>
 											{% endif %}
 											<li>
-												<span class="glyphicon glyphicon-time" aria-hidden="true"></span>
+												<i class="bi-time" aria-hidden="true"></i>
 												{% if summary.personal_deadline %}
 													{% translate "PERSONAL_EXTENDED_DEADLINE" %}
 													{{ summary.personal_deadline }}
@@ -142,7 +143,7 @@
 												{% endif %}
 											</li>
 											<li>
-												<span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+												<i class="bi-user" aria-hidden="true"></i>
 												{% if exercise.min_group_size == 1 %}
 													{% if exercise.max_group_size == 1 %}
 														{% translate "TO_BE_SUBMITTED_ALONE" %}
@@ -168,7 +169,7 @@
 							{% endcomment %}
 							{% if exercise.model_answers %}
 								<a class="aplus-button--secondary aplus-button--md page-modal exercise-nav-button" role="button" href="{{ exercise|url:'exercise-model' }}">
-									<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+									<i class="bi-file" aria-hidden="true"></i>
 									{% translate "SHOW_MODEL_ANSWER" %}
 								</a>
 							{% endif %}
@@ -176,14 +177,14 @@
 						{% if is_course_staff or is_student %}
 							{% if exercise.templates %}
 								<a class="aplus-button--secondary aplus-button--md page-modal exercise-nav-button" role="button" href="{{ exercise|url:'exercise-template' }}">
-									<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+									<i class="bi-file" aria-hidden="true"></i>
 									{% translate "SHOW_EXERCISE_TEMPLATE" %}
 								</a>
 							{% endif %}
 						{% endif %}
 						{% if is_course_staff %}
 							<a class="aplus-button--secondary aplus-button--md page-modal exercise-nav-button" role="button" href="{{ exercise|url:'submission-list' }}">
-								<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
+								<i class="bi-list" aria-hidden="true"></i>
 								{% translate "VIEW_ALL_SUBMISSIONS" %}
 							</a>
 						{% endif %}

--- a/exercise/templates/exercise/staff/_assessment_panel.html
+++ b/exercise/templates/exercise/staff/_assessment_panel.html
@@ -11,7 +11,7 @@
 		<div class="assessment-bar assessment-toggle{% if form.errors %} hidden{% endif %}">
 			<div class="assessment-bar-fill assessment-bar-text">
 				{% if submission.grader %}
-				<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+				<i class="bi-ok" aria-hidden="true"></i>
 				{% if not pseudonymize %}
 					{% blocktranslate trimmed with user=submission.grader.user.get_full_name time=submission.grading_time %}
 					ASSESSED_BY -- {{ user }}, {{ time }}
@@ -20,7 +20,7 @@
 					{% translate 'ASSESSED_BY' %} -- {% translate 'SOMEBODY' %}, {{ submission.grading_time }}
 				{% endif %}
 				{% else %}
-				<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+				<i class="bi-remove" aria-hidden="true"></i>
 				{% translate 'NOT_ASSESSED_MANUALLY' %}
 				{% endif %}
 			</div>
@@ -31,7 +31,7 @@
 				  <form method="post" action="{% url 'remove-tag-from-submissions' course_slug=course.url instance_slug=instance.url module_slug=module.url exercise_path=exercise.get_path submission_id=submission.id subtag_id=tag.tag.id %}">
 					{% csrf_token %}
 					{{tag.tag|colortag}}
-					<button type="submit" class="aplus-button--danger aplus-button--secondary aplus-button--xs"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></button>
+					<button type="submit" class="aplus-button--danger aplus-button--secondary aplus-button--xs"><i class="bi-remove" aria-hidden="true"></i></button>
 				  </form>
 				</div>
 				{% endfor %}
@@ -40,7 +40,7 @@
 
 				<div class="dropdown">
 				  <button class="aplus-button--secondary aplus-button--sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-					{% translate 'ADD_TAGGING' %} <span class="caret"></span>
+					{% translate 'ADD_TAGGING' %} 
 				  </button>
 				  <ul id="submissionTagsList" class="dropdown-menu" aria-labelledby="dropdownMenuButton">
 					{% for subtag in instance.submissiontags.all %}

--- a/exercise/templates/exercise/staff/_deviationslink.html
+++ b/exercise/templates/exercise/staff/_deviationslink.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load course %}
 <a class="deviations-link aplus-button--secondary aplus-button--xs" href="{{ instance|url:'deviations-add-dl' }}?module={{module.id}}&exercise={{exercise.id}}&submitter={{submitters}}">
-	<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+	<i class="bi-plus-sign" aria-hidden="true"></i>
 	{% translate "ADD_DEADLINE_DEVIATIONS" %}
 </a>

--- a/exercise/templates/exercise/staff/_submissions_table.html
+++ b/exercise/templates/exercise/staff/_submissions_table.html
@@ -5,7 +5,7 @@
 {% load colortag %}
 
 <div class="clearfix">
-	<div class="pull-right">
+	<div class="float-end">
 		{% if allow_regrade %}
 			<button type="button" class="aplus-button--secondary aplus-button--xs" data-toggle="modal" data-target="#regrade-modal">
 				{{ regrade_button }}
@@ -13,11 +13,11 @@
 		{% endif %}
 
 		<a class="aplus-button--secondary aplus-button--xs" href="{{ exercise|url:'submission-next-unassessed' }}">
-			<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+			<i class="bi-ok" aria-hidden="true"></i>
 			{% translate "START_MANUAL_ASSESSMENT" %}
 		</a>
 		<a class="aplus-button--secondary aplus-button--xs" href="{{ exercise|url:'submission-summary' }}">
-			<span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+			<i class="bi-bar-chart-fill" aria-hidden="true"></i>
 			{% translate "SUMMARY" %}
 		</a>
 		<span class="dropdown">
@@ -27,7 +27,7 @@
 				data-toggle="dropdown"
 				id="download-data"
 			>
-				{% translate "DOWNLOAD" %} <span class="caret"></span>
+				{% translate "DOWNLOAD" %} 
 			</button>
 			<ul class="dropdown-menu dropdown-menu-right" aria-labeledby="download-data">
 				{% get_format_info_list "json csv excel.csv" as formats %}
@@ -65,7 +65,7 @@
 	<small>{% trans "FILTER_SUBMISSIONS_BY_TAG" %}:</small>
 	{% for tag in instance.submissiontags.all %}
 	<button class="btn btn-default btn-xs filter-tag" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-tagslug="{{ tag.slug }};" data-status="{{ tag.status }}">
-		<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+		<i class="bi-square" aria-hidden="true"></i>
 		{{ tag.name }}
 	</button>
 	{% endfor %}
@@ -117,16 +117,16 @@
 						</td>
 						<td>
 								{% if submission.grader %}
-										<span class="glyphicon glyphicon-ok"></span>
+										<i class="bi-ok"></i>
 										{% translate "YES" %}
 								{% else %}
-										<span class="glyphicon glyphicon-remove"></span>
+										<i class="bi-remove"></i>
 										{% translate "NO" %}
 								{% endif %}
 						</td>
 						<td>
 								<a href="{{ submission|url:'submission-inspect' }}" class="aplus-button--secondary aplus-button--xs">
-										<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+										<i class="bi-zoom-in" aria-hidden="true"></i>
 										{% translate "INSPECT" %}
 								</a>
 						</td>

--- a/exercise/templates/exercise/staff/_submissions_table_compact.html
+++ b/exercise/templates/exercise/staff/_submissions_table_compact.html
@@ -64,7 +64,7 @@
 					>{% translate 'FINAL' %}</span>
 					{% else %}
 					<span
-						class="glyphicon glyphicon-star"
+						class="bi-star"
 						data-toggle="tooltip"
 						title="{% translate 'SUBMISSION_CHOSEN_TOOLTIP' %}"
 					></span>

--- a/exercise/templates/exercise/staff/_submitters_table.html
+++ b/exercise/templates/exercise/staff/_submitters_table.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 <div class="clearfix">
-	<div class="pull-right">
+	<div class="float-end">
 		{% if allow_regrade %}
 			<button type="button" class="aplus-button--secondary aplus-button--xs" data-toggle="modal" data-target="#regrade-modal">
 				{{ regrade_button }}
@@ -12,11 +12,11 @@
 		{% endif %}
 
 		<a class="aplus-button--secondary aplus-button--xs" href="{{ exercise|url:'submission-next-unassessed' }}">
-			<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+			<i class="bi-ok" aria-hidden="true"></i>
 			{% translate "START_MANUAL_ASSESSMENT" %}
 		</a>
 		<a class="aplus-button--secondary aplus-button--xs" href="{{ exercise|url:'submission-summary' }}">
-			<span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+			<i class="bi-bar-chart-fill" aria-hidden="true"></i>
 			{% translate "SUMMARY" %}
 		</a>
 		<span class="dropdown">
@@ -26,7 +26,7 @@
 				data-toggle="dropdown"
 				id="download-data"
 			>
-				{% translate "DOWNLOAD" %} <span class="caret"></span>
+				{% translate "DOWNLOAD" %} 
 			</button>
 			<ul class="dropdown-menu dropdown-menu-right" aria-labeledby="download-data">
 				{% get_format_info_list "json csv excel.csv" as formats %}
@@ -83,16 +83,16 @@
 			</td>
 			<td>
 				{% if submitter.count_assessed > 0 %}
-					<span class="glyphicon glyphicon-ok"></span>
+					<i class="bi-ok"></i>
 					{% translate "YES" %}
 				{% else %}
-					<span class="glyphicon glyphicon-remove"></span>
+					<i class="bi-remove"></i>
 					{% translate "NO" %}
 				{% endif %}
 			</td>
 			<td>
 				<a href="{{ inspect_url }}" class="aplus-button--secondary aplus-button--xs">
-					<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+					<i class="bi-zoom-in" aria-hidden="true"></i>
 					{% translate "INSPECT" %}
 				</a>
 			</td>

--- a/exercise/templates/exercise/staff/analytics.html
+++ b/exercise/templates/exercise/staff/analytics.html
@@ -47,16 +47,16 @@
 
 	<p id="llama-filter-tags">
 		<button class="btn btn-success btn-xs" data-id="aalto">
-			<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+			<i class="bi-square" aria-hidden="true"></i>
 			{{ internal_user_label|safe }}
 		</button>
 		<button class="btn btn-info btn-xs" data-id="mooc">
-			<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+			<i class="bi-square" aria-hidden="true"></i>
 			{{ external_user_label|safe }}
 		</button>
 		{% for tag in tags %}
 		<button class="btn btn-default btn-xs" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-id="{{ tag.id }}">
-			<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+			<i class="bi-square" aria-hidden="true"></i>
 			{{ tag.name }}
 		</button>
 		{% endfor %}
@@ -76,12 +76,12 @@
 	<div id="llama-view-table">
 		<div class="btn-group">
 			<a class="btn btn-default btn-sm" href="#">
-				<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
+				<i class="bi-download-alt" aria-hidden="true"></i>
 				{% translate "DOWNLOAD_CSV" %}
 			</a>
 			<button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				<span class="caret"></span>
-				<span class="sr-only">{% translate "TOGGLE_DROPDOWN" %}</span>
+				
+				<span class="visually-hidden">{% translate "TOGGLE_DROPDOWN" %}</span>
 			</button>
 			<ul class="dropdown-menu">
 				<li><a href="#">{% translate "OPEN_API" %}</a></li>

--- a/exercise/templates/exercise/staff/inspect_submission.html
+++ b/exercise/templates/exercise/staff/inspect_submission.html
@@ -56,7 +56,7 @@
 		<div class="col-md-9">
 			<div>
 				{% with prev_id=submission.submitters.all.0.id %}
-				<a href="{{ exercise|url:'submission-next-unassessed' }}?prev={{ prev_id }}" class="pull-right">
+				<a href="{{ exercise|url:'submission-next-unassessed' }}?prev={{ prev_id }}" class="float-end">
 					{% translate "ASSESS_NEXT_SUBMITTER_MANUALLY" %}
 					{{ request.session.manually_assessed_counter }}
 					<span aria-hidden="true">&raquo;</span>

--- a/exercise/templates/exercise/staff/results.html
+++ b/exercise/templates/exercise/staff/results.html
@@ -106,7 +106,7 @@ that includes the correct DataTables extensions. -->
 				<br>
 				{% for tag in tags %}
 				<button class="btn btn-default btn-xs tag-button" style="background-color:{{ tag.color }};color:{{ tag.font_color }};" data-tag-slug="{{ tag.slug }}" data-tag-name="{{ tag.name }}">
-					<span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+					<i class="bi-square" aria-hidden="true"></i>
 					{{ tag.name }}
 				</button>
 				{% endfor %}

--- a/exercise/templates/exercise/submission.html
+++ b/exercise/templates/exercise/submission.html
@@ -16,7 +16,7 @@
 	<ul class="list-unstyled">
 		{% for file in submission.files.all %}
 		<li>
-			<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+			<i class="bi-file" aria-hidden="true"></i>
 			{% include "exercise/_file_link.html" %}
 		</li>
 		{% endfor %}

--- a/exercise/templates/exercise/submission_plain.html
+++ b/exercise/templates/exercise/submission_plain.html
@@ -14,7 +14,8 @@
 				integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
 				crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-		<script src="{% static 'js/bootstrap3.min.js' %}"></script>
+		<script src="{% static 'js/popper.min.js' %}"></script>
+		<script src="{% static 'js/bootstrap5.min.js' %}"></script>
 
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" rel="stylesheet"
 				integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA=="
@@ -75,7 +76,7 @@
 					<ul class="list-unstyled">
 					{% for file in submission.files.all %}
 						<li>
-							<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+							<i class="bi-file" aria-hidden="true"></i>
 							{% include "exercise/_file_link.html" %}
 						</li>
 					{% endfor %}
@@ -85,7 +86,7 @@
 				{% if is_course_staff %}
 				<td>
 					<a href="{{ submission|url:'submission-inspect' }}" class="aplus-button--secondary aplus-button--md" role="button">
-						<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+						<i class="bi-zoom-in" aria-hidden="true"></i>
 						{% translate "INSPECT" %}
 					</a>
 				</td>

--- a/external_services/templates/external_services/_launch.html
+++ b/external_services/templates/external_services/_launch.html
@@ -29,7 +29,7 @@ E.g. {% static 'js/external_launcher.js' ‰}
 		{% else %}
 			<h4>{% blocktranslate trimmed with name=service_label|parse_localization %}EXTERNAL_SERVICE_LAUNCH_EXERCISE_HOSTED_ON -- {{ name }}{% endblocktranslate %}</h4>
 		{% endif %}
-		<div class="well">
+		<div class="card">
 			{% include "external_services/_privacy.html" %}
 		</div>
 		<p class="external-service-auto">

--- a/external_services/templates/external_services/_privacy.html
+++ b/external_services/templates/external_services/_privacy.html
@@ -18,7 +18,7 @@
 		</p>
 	{% else %}
 		{% if service.destination_region > service.DESTINATION_REGION.ORGANIZATION %}
-			<p class="alert alert-warning"><i class="glyphicon glyphicon-exclamation-sign"></i><span>
+			<p class="alert alert-warning"><i class="bi-exclamation-sign"></i><span>
 		{% else %}
 			<p><span>
 		{% endif %}
@@ -36,7 +36,7 @@
 		{% if is_course_staff %}
 			{% if service.destination_region > service.DESTINATION_REGION.INTERNAL %}
 				<p class="alert alert-{% if service.destination_region > service.DESTINATION_REGION.ORGANIZATION %}warning{% else %}info{% endif %}">
-				<i class="glyphicon glyphicon-exclamation-sign"></i>
+				<i class="bi-exclamation-sign"></i>
 				<span>
 			{% else %}
 				<p><span>
@@ -46,7 +46,7 @@
 			{% endblocktranslate %}
 			</span></p>
 		{% else %}
-			<p class="alert alert-danger"><i class="glyphicon glyphicon-exclamation-sign"></i><span>
+			<p class="alert alert-danger"><i class="bi-exclamation-sign"></i><span>
 				{% blocktranslate trimmed with brand=brand %}
 					EXTERNAL_SERVICE_SENT_ACCESS_TOKEN_STUDENT -- {{ brand }}
 				{% endblocktranslate %}
@@ -69,7 +69,7 @@
 	{% endblocktranslate %}
 {% elif service.destination_region == service.DESTINATION_REGION.EEA %}
 	{% if service.sends_user_info and not service.is_anonymous %}
-		<p class="alert alert-info"><i class="glyphicon glyphicon-exclamation-sign"></i><span>
+		<p class="alert alert-info"><i class="bi-exclamation-sign"></i><span>
 	{% else %}
 		<p><span>
 	{% endif %}
@@ -79,7 +79,7 @@
 {% elif service.destination_region == service.DESTINATION_REGION.PRIVACYSHIELD %}
 	{% if service.sends_user_info %}
 		<p class="alert alert-{{service.is_anonymous|yesno:'info,warning' }}">
-		<i class="glyphicon glyphicon-exclamation-sign"></i><span>
+		<i class="bi-exclamation-sign"></i><span>
 	{% else %}
 		<p><span>
 	{% endif %}
@@ -89,7 +89,7 @@
 {% else %}{# global #}
 	{% if service.sends_user_info %}
 		<p class="alert alert-{{service.is_anonymous|yesno:'info,warning' }}">
-		<i class="glyphicon glyphicon-exclamation-sign"></i><span>
+		<i class="bi-exclamation-sign"></i><span>
 	{% else %}
 		<p><span>
 	{% endif %}

--- a/external_services/templates/external_services/list_menu.html
+++ b/external_services/templates/external_services/list_menu.html
@@ -29,7 +29,7 @@
 		<td>
 			<a href="{{ menu.url }}">
 				{% if menu.icon_class %}
-				<span class="glyphicon glyphicon-{{ menu.icon_class }}" aria-hidden="true"></span>
+				<i class="bi-{{ menu.icon_class }}" aria-hidden="true"></i>
 				{% endif %}
 				{{ menu.label }}
 			</a>
@@ -56,7 +56,7 @@
 		</td>
 		<td>
 			<a href="{{ menu|url:'external-services-edit-menu' }}" role="button" class="aplus-button--secondary aplus-button--xs">
-				<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+				<i class="bi-pencil" aria-hidden="true"></i>
 				{% translate "EDIT" %}
 			</a>
 		</td>
@@ -64,7 +64,7 @@
 			<form method="post" action="{{ menu|url:'external-services-remove-menu' }}">
 				{% csrf_token %}
 				<button type="submit" class="aplus-button--danger aplus-button--xs">
-					<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+					<i class="bi-remove" aria-hidden="true"></i>
 					{% translate "REMOVE" %}
 				</button>
 			</form>
@@ -75,7 +75,7 @@
 <br />
 <p>
 	<a class="btn btn-primary btn-xs" href="{{ instance|url:'external-services-add-menu' }}">
-		<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+		<i class="bi-plus-sign" aria-hidden="true"></i>
 		{% translate "ADD_NEW_MENU_ITEM" %}
 	</a>
 </p>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4820,8 +4820,8 @@ msgstr "Files"
 msgid "PERSONAL_EXTENDED_DEADLINE_PLURAL -- {count}"
 msgstr ""
 "<span data-toggle=\"tooltip\" title=\"Personal extended deadlines: "
-"{count}\"><span class=\"glyphicon glyphicon-time\" aria-hidden=\"true\"></"
-"span><span class=\"sr-only\">Personal extended deadlines: {count}</span></"
+"{count}\"><span class=\"bi-time\" aria-hidden=\"true\"></"
+"span><span class=\"visually-hidden\">Personal extended deadlines: {count}</span></"
 "span>"
 
 #: exercise/templatetags/exercise.py

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4834,8 +4834,8 @@ msgstr "Tiedostot"
 msgid "PERSONAL_EXTENDED_DEADLINE_PLURAL -- {count}"
 msgstr ""
 "<span data-toggle=\"tooltip\" title=\"Henkilökohtaiset pidennetyt määräajat: "
-"{count}\"><span class=\"glyphicon glyphicon-time\" aria-hidden=\"true\"></"
-"span><span class=\"sr-only\">Henkilökohtaiset pidennetyt määräajat: {count}</"
+"{count}\"><span class=\"bi-time\" aria-hidden=\"true\"></"
+"span><span class=\"visually-hidden\">Henkilökohtaiset pidennetyt määräajat: {count}</"
 "span></span>"
 
 #: exercise/templatetags/exercise.py

--- a/lti_tool/templates/lti_tool/lti_course.html
+++ b/lti_tool/templates/lti_tool/lti_course.html
@@ -46,7 +46,7 @@
 			{{ module.name|parse_localization }}
 			{% if is_course_staff %}
 			<a href="{{ module.link }}">
-				<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+				<i class="bi-lock" aria-hidden="true"></i>
 				{% translate "EARLY_ACCESS" %}
 			</a>
 			{% endif %}

--- a/news/templates/news/list.html
+++ b/news/templates/news/list.html
@@ -32,7 +32,7 @@
 
 		<td>
 			{% if item.pin %}
-			<span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+			<i class="bi-pushpin" aria-hidden="true"></i>
 			{% endif %}
 			{{ item.publish }}
 		</td>
@@ -48,13 +48,13 @@
 
 		<td>
 			<a href="{{ item|url:'news-edit' }}" role="button" class="aplus-button--secondary aplus-button--xs">
-				<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+				<i class="bi-pencil" aria-hidden="true"></i>
 				{% translate "EDIT" %}
 			</a>
 		</td>
 		<td>
 			<button id="remove-btn-{{item.id}}" role="button" class="aplus-button--danger aplus-button--xs" value="{{item.id}}">
-				<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+				<i class="bi-remove" aria-hidden="true"></i>
 				{% translate "REMOVE" %}
 			</button>
 		</td>
@@ -62,7 +62,7 @@
 	{% endfor %}
 	{% csrf_token %}
 	<button type="submit" class="aplus-button--danger aplus-button--sm">
-		<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+		<i class="bi-remove" aria-hidden="true"></i>
 		{% translate "REMOVE_SELECTED_NEWS_ITEMS" %}
 	</button>
 	</form>
@@ -72,7 +72,7 @@
 <br />
 <p>
 	<a class="aplus-button--default aplus-button--sm" href="{{ instance|url:'news-add' }}">
-		<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+		<i class="bi-plus-sign" aria-hidden="true"></i>
 		{% translate "ADD_NEWS_ITEM" %}
 	</a>
 </p>

--- a/news/templates/news/user_news.html
+++ b/news/templates/news/user_news.html
@@ -11,7 +11,7 @@
 			{% for item in language_news %}
 					<div class="{% if item.pin %}pinned-{% endif %}list-group-item">
 						{% if item.pin %}
-							<span class="sr-only">{% translate "NEWS_ITEM_PINNED_SR_TEXT" %}</span>
+							<span class="visually-hidden">{% translate "NEWS_ITEM_PINNED_SR_TEXT" %}</span>
 						{% endif %}
 						<div class="list-group-item-heading">
 							<h4 class="list-group-item-title">
@@ -27,7 +27,7 @@
 									<span class="label label-primary">{{ item.audience|news_audience }}</span>
 								{% endif %}
 								{% if item.pin %}
-									<span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+									<i class="bi-pushpin" aria-hidden="true"></i>
 								{% endif %}
 							</div>
 						</div>
@@ -38,7 +38,7 @@
 				{# If a limit for folding news (more) is set, this creates the folding section #}
 				{% if forloop.counter == more and language_news|length > more and more > 0 %}
 					<a class="folding-list-group-item collapsed" href="#more-news" data-toggle="collapse" role="button" aria-controls="more-news" aria-expanded="false">
-						{% translate "SHOW_OLDER" %} <span class="caret"></span>
+						{% translate "SHOW_OLDER" %} 
 					</a>
 					<div class="collapse" id="more-news">{# start of collapse.div #}
 				{% endif %}

--- a/notification/templates/notification/_notification_menu.html
+++ b/notification/templates/notification/_notification_menu.html
@@ -2,7 +2,7 @@
 {% if count > 0 %}
 <li role="presentation" class="menu-notification dropdown" id="notification-alert">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+    <i class="bi-envelope" aria-hidden="true"></i>
     <span class="badge badge-danger">{{ count }}</span> {{ unread_message }}
     <span class="caret" aria-hidden="true"></span>
   </a>

--- a/notification/templates/notification/_notification_messages.html
+++ b/notification/templates/notification/_notification_messages.html
@@ -1,8 +1,8 @@
 {% load course %}
 {% load i18n %}
 {% if count > 0 %}
-<div class="alert alert-danger visible-xs">
-    <span class="glyphicon glyphicon-envelope pull-left" aria-hidden="true"></span>
+<div class="alert alert-danger d-block d-sm-none">
+    <i class="bi-envelope pull-left" aria-hidden="true"></i>
     <p>
         {% translate "YOU_HAVE" %} {{ count }} {{ unread_message }}
         <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Usage: pip install -r requirements.txt
 beautifulsoup4 ~= 4.9.3
 Django ~= 4.2.3
-django-bootstrap-form ~= 3.4
+#django-bootstrap-form ~= 3.4
+django-bootstrap5 >= 24.2
 django-html5-colorfield >= 2.0, < 3
 django-settingsdict ~= 1.1.1
 djangorestframework ~= 3.14.0

--- a/templates/404.html
+++ b/templates/404.html
@@ -15,13 +15,13 @@
 			</div>
 			{% if url_without_language %}
 			<div class="alert alert-danger">
-				<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+				<i class="bi-warning-sign" aria-hidden="true"></i>
 				{% translate "PAGE_NOT_AVAILABLE_IN_LANGUAGE" %}
 				<a href="{{ url_without_language }}">{% translate "OPEN_PAGE_IN_DEFAULT_LANGUAGE" %}</a>
 			</div>
 			{% elif languages %}
 			<div class="alert alert-danger">
-				<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+				<i class="bi-warning-sign" aria-hidden="true"></i>
 				{% blocktranslate trimmed %}
 				PAGE_NOT_AVAILABLE_IN_LANGUAGE_BUT_AVAILABLE_IN_THESE
 				{% endblocktranslate %}
@@ -31,7 +31,7 @@
 			</div>
 			{% else %}
 			<div class="alert alert-danger">
-				<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+				<i class="bi-warning-sign" aria-hidden="true"></i>
 				{% translate "PAGE_DOES_NOT_EXIST" %}
 			</div>
 			{% endif %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -14,7 +14,7 @@
 				</h1>
 			</div>
 			<div class="alert alert-danger">
-				<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+				<i class="bi-warning-sign" aria-hidden="true"></i>
 				{% translate "SOMETHING_WENT_WRONG" %}
 			</div>
 		</div>

--- a/templates/_messages.html
+++ b/templates/_messages.html
@@ -2,7 +2,7 @@
 	<div class="site-messages">
 		{% for message in messages %}
 			<div class="alert alert-{% if message.level == 10 %}success{% elif message.level == 40 %}danger{% else %}{{ message.tags }}{% endif %} clearfix site-message" role="alert">
-				<span class="glyphicon glyphicon-{% if message.level == 25 %}check{% else %}warning-sign{% endif %}" aria-hidden="true"></span>
+				<i class="bi-{% if message.level == 25 %}check{% else %}warning-sign{% endif %}" aria-hidden="true"></i>
 				<div class="message">{{ message|safe }}</div>
 			</div>
 		{% endfor %}

--- a/templates/ajax_search_select.html
+++ b/templates/ajax_search_select.html
@@ -14,7 +14,7 @@
 		<div class="input-group-btn search-button">
 			<div class="btn-group">
 				<button class="btn btn-default dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown" type="button" aria-label="{% translate 'SEARCH' %}">
-					<span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+					<i class="bi-search" aria-hidden="true"></i>
 				</button>
 				<ul class="dropdown-menu search-options" role="menu">
 					{% if clipboard_options %}
@@ -58,7 +58,7 @@
 					class="btn btn-default copy-option" data-clipboard-target="#{{ widget.attrs.id }} input"
 					{% endif %}
 				>
-					<span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+					<i class="bi-copy" aria-hidden="true"></i>
 				</button>
 				{% if clipboard_options %}
 				<ul class="dropdown-menu dropdown-menu-right" role="menu">

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,14 +25,16 @@
 			integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
 			crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-	<script src="{% static 'js/bootstrap3.min.js' %}"></script>
+	<script src="{% static 'js/popper.min.js' %}"></script>
+	<script src="{% static 'js/bootstrap5.min.js' %}"></script>
 
-	<link href="https://use.fontawesome.com/releases/v5.15.4/css/solid.css" rel="stylesheet"
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+	<!--<link href="https://use.fontawesome.com/releases/v5.15.4/css/solid.css" rel="stylesheet"
 			integrity="sha384-Tv5i09RULyHKMwX0E8wJUqSOaXlyu3SQxORObAI08iUwIalMmN5L6AvlPX2LMoSE"
 			crossorigin="anonymous" referrerpolicy="no-referrer" />
 	<link href="https://use.fontawesome.com/releases/v5.15.4/css/regular.css" rel="stylesheet"
 			integrity="sha384-e7wK18mMVsIpE/BDLrCQ99c7gROAxr9czDzslePcAHgCLGCRidxq1mrNCLVF2oaj"
-			crossorigin="anonymous" referrerpolicy="no-referrer" />
+			crossorigin="anonymous" referrerpolicy="no-referrer" />-->
 
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" rel="stylesheet"
 			integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA=="
@@ -113,15 +115,14 @@
 	<div class="page-wrap">
 		{% block header %}
 		<header>
-			<nav class="topbar navbar navbar-inverse navbar-static-top" aria-label="{% translate 'MAIN' %}">
+			<nav class="topbar navbar sticky-top visible-xs" aria-label="{% translate 'MAIN' %}">
 				<div class="container-fluid">
-					<div class="navbar-header">
+					<div style="display: flex; max-width: 500px">
 						<a class="navbar-brand" href="{% url 'home' %}">{% brand_name %}</a>
-						<p class="navbar-text">{{ APLUS_VERSION }}</p>
-						<ul class="nav navbar-dropdown">
-							<li role="separator" class="divider"></li>
-							<li role="presentation" class="dropdown">
-								<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
+						<span class="navbar-brand">{{ APLUS_VERSION }}</span>
+						<ul class="navbar-dropdown">
+							<li role="presentation" class="nav-item dropdown">
+								<a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button"
 									aria-haspopup="true" aria-expanded="false">
 									{% if instance %}
 									{{ course|parse_localization }}
@@ -131,59 +132,56 @@
 									{% else %}
 									{% translate "SELECT_COURSE" %}
 									{% endif %}
-									<span class="caret"></span>
+									
 								</a>
 								{% course_menu %}
 							</li>
 						</ul>
-						<button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
-							data-target="#bs-navbar-collapse" aria-expanded="false">
-							<span class="sr-only">{% translate "TOGGLE_NAVIGATION" %}</span>
-							{% notification_count as n_count %}
-							{% if n_count > 0 %}
-							<span class="badge badge-danger pull-right">{{ n_count }}</span>
-							{% endif %}
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
 					</div>
+					<ul class="navbar-dropdown user-menu d-none d-sm-block">
+						{% if user.is_authenticated %}
+						{% group_select %}
+						{% notification_menu %}
+						<li role="presentation" class="profile-menu nav-item dropdown">
+							<a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button"
+								aria-haspopup="true" aria-expanded="false">
+								<i class="bi-person-fill" aria-hidden="true"></i>
+								{{ user.first_name }} {{ user.last_name }} 
+							</a>
+							<ul class="dropdown-menu">
+								<li role="presentation">
+									<a class="nav-link" href="{% url 'profile' %}">{% translate "PROFILE" %}</a>
+								</li>
+								<li role="separator" class="divider"></li>
+								<li role="presentation">
+									<a class="nav-link" href="{% url 'logout' %}">
+										<i class="bi-caret-left-fill" aria-hidden="true"></i>
+										{% translate "LOG_OUT"%}
+									</a>
+								</li>
+							</ul>
+						</li>
+						{% else %}
+						<li role="presentation">
+							<a href="{% url 'login' %}{% login_next %}">
+								<i class="bi-box-arrow-in-right" aria-hidden="true"></i>
+								{% translate "LOG_IN"%}
+							</a>
+						</li>
+						{% endif %}
+					</ul>
+					<button type="button" class="navbar-toggler collapsed d-block d-sm-none" data-bs-toggle="collapse"
+						data-bs-target="#bs-navbar-collapse" aria-expanded="false">
+						<span class="visually-hidden">{% translate "TOGGLE_NAVIGATION" %}</span>
+						{% notification_count as n_count %}
+						{% if n_count > 0 %}
+						<span class="badge badge-danger float-end">{{ n_count }}</span>
+						{% endif %}
+					</button>
 					<div class="collapse navbar-collapse" id="bs-navbar-collapse">
-						<ul class="user-menu nav navbar-nav navbar-right hidden-xs">
-							{% if user.is_authenticated %}
-							{% group_select %}
-							{% notification_menu %}
-							<li role="presentation" class="profile-menu dropdown">
-								<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
-									aria-haspopup="true" aria-expanded="false">
-									<span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-									{{ user.first_name }} {{ user.last_name }} <span class="caret"></span>
-								</a>
-								<ul class="dropdown-menu">
-									<li role="presentation">
-										<a href="{% url 'profile' %}">{% translate "PROFILE" %}</a>
-									</li>
-									<li role="separator" class="divider"></li>
-									<li role="presentation">
-										<a href="{% url 'logout' %}">
-											<span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
-											{% translate "LOG_OUT"%}
-										</a>
-									</li>
-								</ul>
-							</li>
-							{% else %}
-							<li role="presentation">
-								<a href="{% url 'login' %}{% login_next %}">
-									<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
-									{% translate "LOG_IN"%}
-								</a>
-							</li>
-							{% endif %}
-						</ul>
 
 						{# Separate menu optimized for mobile users #}
-						<ul class="nav navbar-nav visible-xs">
+						<ul class="nav navbar-nav d-block d-sm-none">
 							{% notification_count as n_count %}
 							{% if n_count > 0 %}
 								<li class="header">
@@ -197,29 +195,29 @@
 								<h4>{% translate "SITE" %}</h4>
 							</li>
 							<li>
-								<a href="{% url 'home' %}">
-									<span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+								<a class="nav-link" href="{% url 'home' %}">
+									<i class="bi-house-door-fill" aria-hidden="true"></i>
 									{% translate "HOME" %}
 								</a>
 							</li>
 							{% course_menu %}
 							{% if user.is_authenticated %}
-							<li>
-								<a href="{% url 'profile' %}">
-									<span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'profile' %}">
+									<i class="bi-user" aria-hidden="true"></i>
 									{{ user.first_name }} {{ user.last_name }}
 								</a>
 							</li>
-							<li>
-								<a href="{% url 'logout' %}">
-									<span class="glyphicon glyphicon-log-out" aria-hidden="true"></span>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'logout' %}">
+									<i class="bi-caret-left" aria-hidden="true"></i>
 									{% translate "LOG_OUT"%}
 								</a>
 							</li>
 							{% else %}
-							<li>
-								<a href="{% url 'login' %}{% login_next %}">
-									<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'login' %}{% login_next %}">
+									<i class="bi-box-arrow-in-right" aria-hidden="true"></i>
 									{% translate "LOG_IN" %}
 								</a>
 							</li>
@@ -246,19 +244,19 @@
 		{% endblock %}
 
 		{% block footer %}
-		<footer role="contentinfo">
-			<div class="site-footer navbar navbar-default navbar-fixed-bottom" role="presentation">
+		<footer class="footer mt-auto" role="contentinfo">
+			<nav class="navbar navbar-expand sticky-bottom bg-body-tertiary" role="presentation">
 				<div class="container-fluid">
 					<ul class="nav navbar-nav">
 						{% block footercontent %}{% endblock %}
-						<li><a href="{% url 'privacy_notice' %}">{% translate "PRIVACY_NOTICE" %}</a></li>
-						<li><a href="{% url 'accessibility_statement' %}">{% translate "ACCESSIBILITY_STATEMENT" %}</a></li>
-						<li><a href="{% url 'support_channels' %}">{% translate "SUPPORT" %}</a></li>
-						<li><a href="https://link.webropol.com/s/aplus-feedback" target="_blank">{% translate "FEEDBACK" %}</a></li>
-						<li><p class="navbar-text">{% brand_name %} {{ APLUS_VERSION }}</p></li>
+						<li class="nav-item"><a class="nav-link" href="{% url 'privacy_notice' %}">{% translate "PRIVACY_NOTICE" %}</a></li>
+						<li class="nav-item"><a class="nav-link" href="{% url 'accessibility_statement' %}">{% translate "ACCESSIBILITY_STATEMENT" %}</a></li>
+						<li class="nav-item"><a class="nav-link" href="{% url 'support_channels' %}">{% translate "SUPPORT" %}</a></li>
+						<li class="nav-item"><a class="nav-link" href="https://link.webropol.com/s/aplus-feedback" target="_blank">{% translate "FEEDBACK" %}</a></li>
+						<li class="nav-item"><p class="navbar-text">{% brand_name %} {{ APLUS_VERSION }}</p></li>
 					</ul>
 				</div>
-			</div>
+			</nav>
 		</footer>
 		{% endblock %}
 	</div>

--- a/userprofile/static/userprofile/local_storage_external_services.js
+++ b/userprofile/static/userprofile/local_storage_external_services.js
@@ -78,7 +78,7 @@
         );
         li.addClass("list-group-item clearfix");
         const btn = $(
-          `<button aria-label="${ariaLabelPrefix}" class="aplus-button--danger aplus-button--sm pull-right"><span class="glyphicon glyphicon-remove"></span>${btnText}</button>`
+          `<button aria-label="${ariaLabelPrefix}" class="aplus-button--danger aplus-button--sm float-end"><i class="bi-remove"></i>${btnText}</button>`
         );
         btn.on("click", function () {
           li.remove();

--- a/userprofile/templates/userprofile/login.html
+++ b/userprofile/templates/userprofile/login.html
@@ -156,8 +156,8 @@
 				aria-label="{% translate 'SHOW_MORE_LOGIN_OPTIONS' %}"
 				title="{% translate 'SHOW_MORE_LOGIN_OPTIONS' %}"
 			>
-				<i class="glyphicon glyphicon-chevron-right hidden-xs" focusable="false"></i>
-				<i class="glyphicon glyphicon-chevron-down visible-xs-inline" focusable="false"></i>
+				<i class="bi-caret-right-fill d-none d-sm-block" focusable="false"></i>
+				<i class="bi-caret-down-fill d-block d-sm-none-inline" focusable="false"></i>
 			</button>
 		</div>
 	</div>

--- a/userprofile/templates/userprofile/profile.html
+++ b/userprofile/templates/userprofile/profile.html
@@ -79,7 +79,7 @@
 				<button data-toggle="tooltip" data-placement="bottom"
 					title="{% translate 'COPY_API_ACCESS_TOKEN' %}" aria-label="{% translate 'COPY_API_ACCESS_TOKEN' %}"
 					class="aplus-button--secondary aplus-button--md js-copy" type="button"><span
-						class="glyphicon glyphicon-copy" aria-hidden="true"></span><span class="">{% translate "COPY" %}</span></button>
+						class="bi-copy" aria-hidden="true"></span><span class="">{% translate "COPY" %}</span></button>
 			</span>
 		</div>
 		<div>
@@ -88,7 +88,7 @@
 					<button type="submit" data-toggle="tooltip" data-placement="bottom"
 						title="{% translate 'REGENERATE_API_ACCESS_TOKEN' %}" aria-label="{% translate 'REGENERATE_API_ACCESS_TOKEN' %}"
 						class="aplus-button--secondary aplus-button--md"><span
-							class="glyphicon glyphicon-refresh" aria-hidden="true"></span><span class="">{% translate "REGENERATE" %}</span></button>
+							class="bi-refresh" aria-hidden="true"></span><span class="">{% translate "REGENERATE" %}</span></button>
 				</div>
 			</form>
 		</div>


### PR DESCRIPTION
# Description

**What?**

Investigating what's needed for moving A-plus from Bootstrap 3 to 5. This PR is mostly just a work-in-progress-dump of where I got before heading for holidays.

![SCR-20240620-msux](https://github.com/apluslms/a-plus/assets/25493530/1251881d-0810-4441-969b-77cc4888a778)

Major changes done/required:
- Glyphicons are no longer supported, so tried using the Bootstrap icon font, currently via CDN. Many of the Glyphicons are not yet mapped to BS icon names.
- The django-bootstrap-form library is BS3 only and apparently dead, so it has been replaced with django-bootstrap5. Haven't had time to play with this yet.
- The All results page uses DataTables (https://datatables.net), which currently uses BS3-based styling, and needs to be updated.
- The All results page is using bootstrap-multiselect jQuery plugin (https://github.com/davidstutz/bootstrap-multiselect), which may or may not work with BS5. An alternative may need to be found/implemented.
- There is a bunch of old css definitions in main.scss just to get the thing compiled. These are mostly related to breakpoints, which need to be carefully re-checked anyway.

The most apparent issues so far:
- Navbar is constructed differently in BS5, and couldn't yet figure out how to implement the kind of mobile menu there is in the current BS3-based version. The mobile menu toggle does not show up at all. Also opening the menus cause the navbar to expand.
- Have not yet figured out why the "sticky-bottom" in bottom navbar does not work (see the Form a group page, screenshot below, for an example). For some reason, margin-top: auto always results in 0px, even though the parent element's height extends to the full page.

![SCR-20240620-mtue](https://github.com/apluslms/a-plus/assets/25493530/634af18c-e3ab-421d-9112-89ede102cde1)

**Why?**

Bootstrap 3 is no longer supported.

**How?**

You may need to run this script manually if the BS5 assets do not get automatically compiled:
`./dev_assets_run_npm.sh bootstrap5 install`

Before making changes to scss files, run this to get the css files compiled automatically:
`./dev_assets_watch_sass.sh`

Fixes #<issue number>


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [ ] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
