### PR TITLE
Open menu links to external websites in a new tab

### DIFF
--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -110,7 +110,8 @@
 {% for entry in group.items %}
 {% if entry.enabled %}
 <li>
-	<a href="{{ entry.url }}" {% if entry.blank %} target="_blank" {% endif %}>
+	{% is_external_menu_url entry.url as is_external_menu_url_flag %}
+	<a href="{{ entry.url }}" {% if is_external_menu_url_flag or entry.blank %} target="_blank" {% endif %}>
 		{% if entry.icon_class %}
 		<span class="glyphicon glyphicon-{{ entry.icon_class }}" aria-hidden="true"></span>
 		{% endif %}

--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from django import template
 from django.db import models
@@ -137,6 +137,13 @@ def profiles(
 def tags(profile, instance):
     tags = UserTagging.objects.get_all(profile, instance)
     return mark_safe(' '.join(tag.html_label for tag in tags))
+
+
+@register.simple_tag
+def is_external_menu_url(url: Optional[str]) -> bool:
+    if url and '://' in url:
+        return True
+    return False
 
 
 @register.filter

--- a/external_services/models.py
+++ b/external_services/models.py
@@ -335,7 +335,6 @@ class MenuItem(UrlMixin, models.Model):
             }
             return self.service.as_leaf_class().get_url(replace=self.menu_url, kwargs=kwargs)
         if '://' in self.menu_url:
-            # Deprecated, but DB can have old urls
             return self.menu_url
         return urljoin(self.course_instance.get_absolute_url(), self.menu_url)
 


### PR DESCRIPTION
# Description

**What?**

Open menu links to external websites, such as https://google.com in a new tab, instead of in the current tab.

**Why?**

This problem was pointed out by a teacher.

Fixes #1392