### PR TITLE
Add limit for maximum number of retries for automatic regrading, and …

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -280,6 +280,9 @@ SUBMISSION_EXPIRY_TIMEOUT = 30 * 60
 # Network location is sufficient, e.g. "localhost:8080" or "grader.cs.aalto.fi"
 SUBMISSION_RETRY_SERVICES = []
 
+# Maximum number of retries to automatically grade a given submission
+SUBMISSION_RETRY_LIMIT = 3
+
 # Number of unresponded retries beyond which we move to recovery state.
 # In recovery state there likely is more persistent problem with the grader
 # or network that needs fixing.

--- a/exercise/templates/exercise/submission_plain.html
+++ b/exercise/templates/exercise/submission_plain.html
@@ -94,7 +94,14 @@
 		</table>
 
 		<div id="exercise-all">
-
+		{% if pending.num_retries > 0 %}
+		<div class="alert alert-warning">
+			{% blocktranslate trimmed with num_retries=pending.num_retries max_retries=pending.max_retries %}
+				SUBMISSION_GRADING_RETRIED -- {{ num_retries }}, {{ max_retries }}
+			{% endblocktranslate %}
+		</div>
+		{% endif %}
+	
 		{% if feedback_revealed and submission.assistant_feedback %}
 		<h4>{% translate "ASSISTANT_FEEDBACK" %}</h4>
 		<blockquote>{{ submission.assistant_feedback|safe }}</blockquote>

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -12,6 +12,7 @@ from django.utils.text import format_lazy
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.db import DatabaseError
+from django.conf import settings
 
 from authorization.permissions import ACCESS
 from course.models import CourseModule, SubmissionTag
@@ -23,7 +24,7 @@ from userprofile.models import UserProfile
 from .cache.points import ExercisePoints
 from .models import BaseExercise, LearningObject, LearningObjectDisplay
 from .protocol.exercise_page import ExercisePage
-from .submission_models import SubmittedFile, Submission, SubmissionTagging
+from .submission_models import SubmittedFile, Submission, SubmissionTagging, PendingSubmission
 from .viewbase import (
     ExerciseBaseView,
     SubmissionBaseView,
@@ -478,6 +479,16 @@ class SubmissionView(SubmissionBaseView):
         super().get_common_objects()
         self.page = { "is_wait": "wait" in self.request.GET }
         self.note("page")
+        # If the submission is not in 'ready' state, check if there is a pendingSubmission
+        # object for this submission and fetch the number of retries from it, so the info
+        # can be displayed for the user. Also display the maximum retries from settings.
+        if self.submission.status != 'ready':
+            try:
+                pending = PendingSubmission.objects.get(submission__id=self.submission.id)
+                self.pending = { "num_retries": pending.num_retries, "max_retries": settings.SUBMISSION_RETRY_LIMIT }
+                self.note("pending")
+            except:
+                pass
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         if not self.feedback_revealed:

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -13,6 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.db import DatabaseError
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 from authorization.permissions import ACCESS
 from course.models import CourseModule, SubmissionTag
@@ -487,7 +488,7 @@ class SubmissionView(SubmissionBaseView):
                 pending = PendingSubmission.objects.get(submission__id=self.submission.id)
                 self.pending = { "num_retries": pending.num_retries, "max_retries": settings.SUBMISSION_RETRY_LIMIT }
                 self.note("pending")
-            except:
+            except ObjectDoesNotExist:
                 pass
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4868,6 +4868,14 @@ msgstr "Submission"
 msgid "FILES_IN_SUBMISSION"
 msgstr "Files in this submission"
 
+#: exercise/templates/exercise/submission_plain.html
+#, python-format
+msgid "SUBMISSION_GRADING_RETRIED -- %(num_retries)s, %(max_retries)s"
+msgstr ""
+"Grading this submission did not finish in time, and it has been "
+"retried %(num_retries)s time(s). Retries continue until successful, "
+"or until the limit of %(max_retries)s retries is reached."
+
 #: exercise/templates/exercise/submission.html
 #: exercise/templates/exercise/submission_plain.html
 msgid "NO_GRADER_FEEDBACK_FOR_SUBMISSION"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4882,6 +4882,14 @@ msgstr "Palautus"
 msgid "FILES_IN_SUBMISSION"
 msgstr "Tiedostot tässä palautuksessa"
 
+#: exercise/templates/exercise/submission_plain.html
+#, python-format
+msgid "SUBMISSION_GRADING_RETRIED -- %(num_retries)s, %(max_retries)s"
+msgstr ""
+"Palautuksen arvostelu ei valmistunut määräajassa, ja sitä on "
+"yritetty uudelleen %(num_retries)s kertaa. Palautusta yritetään "
+"automaattisesti enintään %(max_retries)s kertaa."
+
 #: exercise/templates/exercise/submission.html
 #: exercise/templates/exercise/submission_plain.html
 msgid "NO_GRADER_FEEDBACK_FOR_SUBMISSION"


### PR DESCRIPTION
…rotate the submission to be sent.

Fixes #1147

# Description

**What?**

Currently the automatic resubmission system always tries to poll the grader using the same submission when it notices grading to be "unstable" (i.e. when the total number of retries over all pending submissions on a course instance grows over the limit set in the GRADER_STABLE_THRESHOLD variable in settings.py). As there is no limit on how many times this submission is retried, the other pending submissions are never even tried.

This PR sets a hard limit on how many times a given submission can be automatically sent to grading before it is considered to be faulty. If the maximum number of automatic resubmission retries is reached without receiving a grade, the pending submission object is removed, and the "Error" state is set for the submission. Also when the grader is considered to be "unstable", the next submission selected for testing the grader is randomly selected from the pool of pending submissions.

When grading has been automatically retried, the user gets a notification of the current (and maximum) amount of retries in the submission status dialog.

**Why?**

Fixing the issues caused by the current regrading system requires manual intervention from the A+ sysadmins, as one faulty submission can prevent others from being retried indefinitely.

**How?**

This PR takes a simple approach to fix the most urgent issues. Ideally, we would measure the average time each autograded assignment spends in grading, and use this value to determine when a given submission should be resubmitted. Here we are just using a fixed value for all assignments, regardless if they take 10 seconds or 10 minutes on average to grade.

Another area of improvement would be in recovery mode: when a submission is successfully graded, and immediate regrading triggered (at set_ready(), see below), we could choose the next submission to be probed from within submissions of the same assignment as the successful one. This would empty the queue faster in cases where a grader for more than one assignment is faulty and one gets fixed before the other. Now the next one selected may be for a faulty assignment, which breaks the probing chain, leaving the rest waiting for new rounds even though they could be regraded immediately.

The regrading process goes as follows:

The PendingSubmissionManager has a method is_grader_stable, which tries to determine if the grader is currently having issues. It does this by counting total retries of all pending submissions of the course instance, and comparing this with the global GRADER_STABLE_THRESHOLD defined in settings.py. If the threshold is not exceeded, we are in "stable" state, and otherwise in a "recovery" state (in which the grader is probed one submission at a time). The Celery process wakes up every SUBMISSION_EXPIRY_TIMEOUT/2 seconds, and executes regrading based on the mode we are in:

1. *Stable state:* we select all pending submission objects, which have a submission time older than SUBMISSION_EXPIRY_TIMEOUT. We go through each and check, that the corresponding exercise can be regraded. Then we check if the pending submission has less than SUBMISSION_RETRY_LIMIT retries, and if not, remove it and set the submission into "Error" state. Finally we check, that the submission is older than (number of retries * SUBMISSION_EXPIRY_TIMEOUT) seconds, which results in those submissions already retried to be resubmitted only after a longer and longer waiting period.
2. *Recovery state:* we randomly select one pending submission and check if it has more than SUBMISSION_RETRY_LIMIT retries. If so, we set the submission into "Error" state, and the pending submission object is deleted. If not, and if the exercise can be regraded, we send the submission for regrading. Note, that if grading is successful while in recovery state, at submission_models.py > set_ready() there is a call to retry_submissions(), causing an immediate reprobe with the next randomly selected submission. If there has been only one broken assignment (grader), this should empty the whole queue quickly. But if there have been several broken ones, and only one gets fixed, it may take a while for the others to get cleared up.

Fixes #1147


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [X] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested creating submissions using the generate-submissions.sh script with the grader intentionally broken so that for some submission, it accepts the submission, but never creates a grading pod for it or returns a grade (by modifying mooc-grader/access/types/stdasync.py > _acceptSubmission() ). I tested the following conditions:
* Failed 75% of all submissions (general grader issues)
* Failed all submissions for one assignment (grader broken for one assignment)
* Failed 75% of submissions for one assignment (issues with grader for one assignment)

I also tested submitting an assignment manually. I checked that the status remained "In grading" while the submission was in the retry loop, and that the status changed into "Error" when maximum retries were exceeded. I checked that in the grading status dialog displayed a notification about the submission being retried automatically, and that the message correctly indicated the amount of tries as well as the maximum number of retries.

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [X] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

Did not find any documentation on automatic regrading.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*