### PR TITLE
Add courses where the user is an assistant to the API

### DIFF
--- a/userprofile/api/full_serializers.py
+++ b/userprofile/api/full_serializers.py
@@ -22,11 +22,15 @@ class UserSerializer(UserBriefSerializer):
     email = serializers.CharField(source='user.email')
     enrolled_courses = SerializerMethodField()
     staff_courses = SerializerMethodField()
+    teacher_courses = SerializerMethodField()
+    assistant_courses = SerializerMethodField()
 
     class Meta(UserBriefSerializer.Meta):
         fields = (
             'enrolled_courses',
             'staff_courses',
+            'teacher_courses',
+            'assistant_courses',
             'student_id',
             'full_name',
             'first_name',
@@ -40,6 +44,18 @@ class UserSerializer(UserBriefSerializer):
         return serializer.data
 
     def get_staff_courses(self, obj):
-        staff_courses = CourseInstance.objects.get_teaching(obj)
+        teacher_courses = CourseInstance.objects.get_teaching(obj)
+        assistant_courses = CourseInstance.objects.get_assisting(obj)
+        staff_courses = teacher_courses | assistant_courses
         serializer = CourseBriefSerializer(instance=staff_courses, many=True, context=self.context)
+        return serializer.data
+
+    def get_teacher_courses(self, obj):
+        teacher_courses = CourseInstance.objects.get_teaching(obj)
+        serializer = CourseBriefSerializer(instance=teacher_courses, many=True, context=self.context)
+        return serializer.data
+
+    def get_assistant_courses(self, obj):
+        assistant_courses = CourseInstance.objects.get_assisting(obj)
+        serializer = CourseBriefSerializer(instance=assistant_courses, many=True, context=self.context)
         return serializer.data

--- a/userprofile/api/tests.py
+++ b/userprofile/api/tests.py
@@ -82,10 +82,13 @@ class UserProfileAPITest(UserProfileTestCase):
             'is_external': False,
             'enrolled_courses': [],
             'staff_courses': [],
+            'teacher_courses': [],
+            'assistant_courses': [],
             'full_name':'Superb Student',
             'first_name':'Superb',
             'last_name':'Student',
-            'email':'test@aplus.com'})
+            'email':'test@aplus.com',
+        })
 
     def test_field_values_filter(self):
         client = APIClient()


### PR DESCRIPTION
# Description

**What?**

Add courses where the user is an assistant to the API.
Previously, only the courses where the user is a teacher were listed in the API.

**Why?**

This was requested by a course.

Fixes #1397