### PR TITLE
fix: move menu items with an empty group label under Course section

### DIFF
--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -100,13 +100,8 @@
 </li>
 {% endif %}
 
-
 {% for group in course_menu.student_link_groups %}
-{% if group.label %}
-<li class="header">
-	<h4>{{ group.label|parse_localization }}</h4>
-</li>
-{% endif %}
+{% if group.label == '' %}
 {% for entry in group.items %}
 {% if entry.enabled %}
 <li>
@@ -120,6 +115,28 @@
 </li>
 {% endif %}
 {% endfor %}
+{% endif %}
+{% endfor %}
+
+{% for group in course_menu.student_link_groups %}
+{% if group.label != '' %}
+<li class="header">
+	<h4>{{ group.label|parse_localization }}</h4>
+</li>
+{% for entry in group.items %}
+{% if entry.enabled %}
+<li>
+	{% is_external_menu_url entry.url as is_external_menu_url_flag %}
+	<a href="{{ entry.url }}" {% if is_external_menu_url_flag or entry.blank %} target="_blank" {% endif %}>
+		{% if entry.icon_class %}
+		<span class="glyphicon glyphicon-{{ entry.icon_class }}" aria-hidden="true"></span>
+		{% endif %}
+		{{ entry.label|parse_localization }}
+	</a>
+</li>
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 
 {% for tab in instance.tabs.all %}


### PR DESCRIPTION
# Description

**What?**

All the menu items that have being set an empty menu group label will automatically categorized to lastest added menu group on the sidebar menu.

**How?**

~~1. Adding a `student_groups_without_label` group in `CachedCourseMenu` View and append it always at the beginning of the `student_link_groups`. As a result they will always appear on the top of list.
2. Fixing the rendering logic of the corresponding template.~~

1. Show the menu items without labels before any other labels. As a result, the menu items without a label are rendered directly under the `Course` heading.

Fixes #1411 

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)

**What type of test did you run?**

- [x] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [x] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

Steps:

- create a menu item with group label `label1` and the label `labelitem1`
- create a menu item with empty group label and the label `nonlabelitem1`
- create a menu item with group label `label2` and the label `labelitem2`
- repeat these steps with the same pattern randomly
- ...
- everything else default

Result:

![image](https://github.com/user-attachments/assets/1ca4d726-818f-4b34-9262-6870ad0a86a0)
***Screenshot of the result***

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [x] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
