### PR TITLE
Fix overriding deadline deviations around daylight savings border

### DIFF
--- a/deviations/templates/deviations/override_dl.html
+++ b/deviations/templates/deviations/override_dl.html
@@ -142,10 +142,20 @@
 			</table>
 		</div>
 		<div class="form-group">
+			<input type="hidden" id="timezone_string" name="timezone_string" value="">
+		</div>
+		<div class="form-group">
 			<div class="col-sm-10">
 				<button type="submit" class="aplus-button--default aplus-button--md">{% translate "SAVE" %}</button>
 			</div>
 		</div>
 	</form>
 </div>
+
+<script>
+	// Get the user's timezone
+	const timezoneString = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	// Set the hidden input field value to the timezone string
+	document.getElementById('timezone_string').value = timezoneString;
+</script>
 {% endblock %}

--- a/deviations/views.py
+++ b/deviations/views.py
@@ -46,6 +46,7 @@ class AddDeadlinesView(AddDeviationsView):
             'seconds': form_data['seconds'],
             'new_date': str(form_data['new_date']) if form_data['new_date'] else None,
             'without_late_penalty': form_data['without_late_penalty'],
+            'timezone_string': form_data['timezone_string'],
         })
         return result
 
@@ -69,8 +70,14 @@ class OverrideDeadlinesView(OverrideDeviationsView):
             'seconds': session_data['seconds'],
             'new_date': parse_datetime(session_data['new_date']) if session_data['new_date'] else None,
             'without_late_penalty': session_data['without_late_penalty'],
+            'timezone_string': session_data['timezone_string'],
         })
         return result
+
+    def form_valid(self, form):
+        timezone_string = self.request.POST.get('timezone_string')
+        form.cleaned_data['timezone_string'] = timezone_string
+        return super().form_valid(form)
 
 
 class RemoveDeadlinesByIDView(RemoveDeviationsByIDView):


### PR DESCRIPTION
# Description

**What?**

PR #1346 did not apply daylight savings time consideration when overriding previous deadline deviations, but only when creating entirely new deadline deviations.

After these changes, daylight savings time consideration is applied also when overriding old deadline deviations.

Fixes #1287