### PR TITLE
Fix external links sometimes missing URL fragments

### DIFF
--- a/external_services/views.py
+++ b/external_services/views.py
@@ -60,7 +60,7 @@ class ExternalLinkView(CourseInstanceBaseView):
         self.service = service = self.menu_item.service # pylint: disable=unused-variable
         self.service_label = self.menu_item.label
         url = urlsplit(self.menu_item.final_url)
-        self.url = url._replace(query='', fragment='').geturl()
+        self.url = url._replace(query='').geturl()
         self.site = site = '/'.join(self.url.split('/')[:3])
         self.parameters = parse_qsl(url.query)
         self.parameters_hash = site


### PR DESCRIPTION
# Description

**What?**

Fix external links missing URL fragments if accessed by `http://localhost:8000/def/current/external-link/<menu_id>`.

The URL fragments were intact if the link was accessed through `http://localhost:8000/def/current/lti-login/<menu_id>` or by clicking the link in the menu. Therefore, the issue #873 has been mostly fixed for a while now.

Closes #873
