### PR TITLE
Add student email to 'All results' page's CSV, Copy, and Excel downloads

### DIFF
--- a/exercise/static/exercise/results_staff.js
+++ b/exercise/static/exercise/results_staff.js
@@ -1180,7 +1180,7 @@
 
             let columns = [
                 {data: "UserID", title: "UserID", class: "always-hidden col-0", type: "num", searchable: false},
-                {data: "Email", title: "Email", class: "always-hidden col-1", type: "string", searchable: true},
+                {data: "Email", name: "Email", title: "Email", class: "always-hidden col-1", type: "string", searchable: true},
                 {data: "StudentID", title: _("Student ID"), type: "string", class: "student-id stick-on-scroll col-2", render: renderParticipantLink},
                 {data: "Name", title: _("Student name"), class: "student-name stick-on-scroll col-3", type: "html", render: renderParticipantLink},
                 {data: "Tags", title: _("Tags"), class: "tags col-4", render: function(data) { return userTagsToHTML(data); }, type: "html" },
@@ -1341,7 +1341,7 @@
              */
             var buttonCommon = {
                 exportOptions: {
-                    columns: ':visible',
+                    columns: ['Email:name', ':visible'],
                     format: {
                         body: removeHtmlFromColumns
                     }


### PR DESCRIPTION
# Description

Added the email field in "All results" pages CSV and other exports.

**Why?**

Requested by teachers.

Fixes #1428

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Downloaded the CSV export and checked the students' emails were there. Also tested that an empty email address doesn't break the export.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.