### PR TITLE
Clarify times and time zones related to course updates and builds

### DIFF
--- a/edit_course/templates/edit_course/build_log.html
+++ b/edit_course/templates/edit_course/build_log.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load editcourse %}
 
 {% if error %}
   <div class="alert clearfix alert-danger" role="alert">{{ error }}</div>
@@ -11,7 +12,7 @@
       </tr>
       <tr>
         <td>{% translate "BUILD_INITIATED_AT" %}</td>
-        <td>{{ request_time }}</td>
+        <td>{{ request_time|make_timezone_aware }}</td>
       </tr>
       {% if not updated %}
         <tr class="warning">
@@ -21,7 +22,7 @@
       {% else %}
         <tr>
           <td>{% translate "BUILD_FINISHED" %}</td>
-          <td>{{ updated_time }}</td>
+          <td>{{ updated_time|make_timezone_aware }}</td>
         </tr>
       {% endif %}
     </tbody>

--- a/edit_course/templatetags/editcourse.py
+++ b/edit_course/templatetags/editcourse.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+
 from django import template
 from django.urls import reverse
+from django.utils import timezone
 
 from course.models import CourseInstance
 
@@ -56,3 +59,15 @@ def createurl(model_object, model_name):
         model_name,
         parent_id=model_object.id,
     ))
+
+
+@register.filter
+def make_timezone_aware(utc_time_str):
+    try:
+        # Parse the Zulu date and time string into a naive datetime object
+        naive_datetime = datetime.strptime(utc_time_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+        # Convert it to a timezone-aware datetime object
+        aware_datetime = timezone.make_aware(naive_datetime, timezone.utc)
+        return aware_datetime
+    except ValueError:
+        return utc_time_str # Return the original string if parsing fails

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2601,11 +2601,11 @@ msgstr ""
 
 #: edit_course/templates/edit_course/build_log.html
 msgid "BUILD_INITIATED_BY"
-msgstr "Build initated by"
+msgstr "Build initiated by"
 
 #: edit_course/templates/edit_course/build_log.html
 msgid "BUILD_INITIATED_AT"
-msgstr "Build initated at"
+msgstr "Build initiated at"
 
 #: edit_course/templates/edit_course/build_log.html
 msgid "BUILD_FINISHED"
@@ -2678,7 +2678,7 @@ msgstr "Retrieve latest build log"
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "PREV_MODIFICATION_OF_COURSE_INSTANCE_TIME"
-msgstr "Previous modification of this course instance took place at"
+msgstr "This course was previously built or the course settings were modified on"
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "EXERCISE_CATEGORIES"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2695,7 +2695,7 @@ msgstr "Hae uusin käännösloki"
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "PREV_MODIFICATION_OF_COURSE_INSTANCE_TIME"
-msgstr "Kurssia on viimeksi muokattu"
+msgstr "Tämä kurssi on viimeksi käännetty tai kurssin asetuksia on muokattu"
 
 #: edit_course/templates/edit_course/edit_content.html
 msgid "EXERCISE_CATEGORIES"


### PR DESCRIPTION
# Description

**What?**

Clarify times and time zones related to course updates and builds, by making the strings more clear and matching time zones between A+ and Git manager.

**OLD**:
![image](https://github.com/user-attachments/assets/4131313d-edbc-49fc-a675-e118b4b0f006)
![image](https://github.com/user-attachments/assets/f68ad6dd-7884-4de6-97db-b0b70132aa92)

**NEW**:
![image](https://github.com/user-attachments/assets/d9d668e3-124a-40ab-8062-afde7ee17059)
![image](https://github.com/user-attachments/assets/b12c7aa6-e5ab-4a29-93d4-b6fc7789e0b1)

**Why?**

Unclear string and Git manager using UTC time has caused confusion before.

Fixes #1128
