### PR TITLE
Fix 'Continue where you left off' exercise name HTML escape

### DIFF
--- a/course/templates/course/course.html
+++ b/course/templates/course/course.html
@@ -30,7 +30,7 @@
 				// Add link child
 				const link = $("<a></a>");
 				link.attr("href", escapeHtml(lastVisited.url));
-				link.text(escapeHtml(lastVisited.title));
+				link.text(lastVisited.title);
 				alert.append(link);
 			}
 		}


### PR DESCRIPTION
# Description

**What?**

Fix 'Continue where you left off' exercise name HTML escape.

![image](https://github.com/user-attachments/assets/0ef583e4-1625-43ab-977d-ad1b18664436)

**Why?**

This broke, for example, apostrophes in exercise names.

**How?**

Use django's `|safe` filter instead of a javascript function for escape.

Fixes #1432