### PR TITLE
Fix mangled code when comparing submission with model answer

### DIFF
--- a/exercise/views.py
+++ b/exercise/views.py
@@ -586,6 +586,9 @@ class SubmittedFileView(SubmissionMixin, BaseView):
                 else self.get_compared_submission_file_data(compare_to)
             )
             submitted_data = bytedata.decode('utf-8', 'ignore')
+            # Ensure that both files end with a newline, otherwise the diff output might be mangled
+            submitted_data += '\n' if not submitted_data.endswith('\n') else ''
+            compared_data += '\n' if not compared_data.endswith('\n') else ''
             diff = ndiff(compared_data.splitlines(keepends=True), submitted_data.splitlines(keepends=True))
             diff_text = ''.join([line for line in diff if line[0] != '?'])
             bytedata = diff_text.encode('utf-8')


### PR DESCRIPTION
# Description

**What?**

Fix mangled code when comparing submission with model answer

Before:

![image](https://github.com/user-attachments/assets/93406c29-711b-4ee2-a1bc-20eca8bc5548)

After:

![image](https://github.com/user-attachments/assets/7bfdebb5-fb76-48aa-a6b0-2a50e5e79a13)

Fixes #1433
