### PR TITLE
Improve performance of "All submissions" view

### DIFF
--- a/course/templates/course/_course_menu.html
+++ b/course/templates/course/_course_menu.html
@@ -239,7 +239,7 @@
 	</a>
 </li>
 <li class="menu-all-submissions">
-	<a href="{{ instance|url:'all-submissions' }}">
+	<a href="{{ instance|url:'all-submissions' }}?limited=true">
 		<span class="glyphicon glyphicon-list" aria-hidden="true"></span>
 		{% translate "ALL_SUBMISSIONS" %}
 	</a>

--- a/course/templates/course/staff/all_submissions_table.html
+++ b/course/templates/course/staff/all_submissions_table.html
@@ -53,63 +53,63 @@
 					<th>{% translate "TAGS" %}</th>
 
 					<th
-						data-filter-type="options"
-						data-filter-options="{% translate 'YES' %}|{% translate 'NO' %}"
-						data-order-disable="true"
+					data-filter-type="options"
+					data-filter-options="{% translate 'YES' %}|{% translate 'NO' %}"
+					data-order-disable="true"
 					>
-						{% translate "ASSESSED_MANUALLY" %}
-					</th>
-					<th data-filter-type="none" data-order-disable="true">{% translate "INSPECT" %}</th>
-					<th>{% translate "EXERCISE" %}</th>
-				</tr>
+					{% translate "ASSESSED_MANUALLY" %}
+				</th>
+				<th data-filter-type="none" data-order-disable="true">{% translate "INSPECT" %}</th>
+				<th>{% translate "EXERCISE" %}</th>
+			</tr>
 		</thead>
 		<tbody>
 			{% for summary in submission_data %}
 			<tr id="summary.submission-{{ summary.submission.id }}">
-					<td>
-						{% profiles summary.submitters instance summary.is_teacher %}
-					</td>
-					<td data-datetime="{{ summary.submission.submission_time|date:'Y-m-d H:i:s' }}">
-							{{ summary.submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}
-							{% if summary.submission.late_penalty_applied %}
-							<span class="label label-warning">
-									{% blocktranslate trimmed with percent=summary.submission.late_penalty_applied|percent %}
-										LATE_W_PENALTY -- {{ percent }}
-									{% endblocktranslate %}
-							</span>
-							{% endif %}
-					</td>
-					<td>
-						{{ summary.submission.status|submission_status }}
-					</td>
-					<td>
-						{% format_points summary.submission.grade True True %}
-					</td>
-					<td id="submission_tags">
-						{% for tagging in summary.submission.submission_taggings.all %}
-							{{ tagging.tag|colortag }}
-						{% endfor %}
-					</td>
-					<td>
-						{% if summary.submission.grader %}
-								<span class="glyphicon glyphicon-ok"></span>
-								{% translate "YES" %}
-						{% else %}
-								<span class="glyphicon glyphicon-remove"></span>
-								{% translate "NO" %}
-						{% endif %}
-					</td>
-					<td>
-						<a href="{{ summary.submission|url:'submission-inspect' }}" class="aplus-button--secondary aplus-button--xs">
-							<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
-							{% translate "INSPECT" %}
-						</a>
-					</td>
-					<td>
-						<a href="{{ summary.exercise|url }}">
-							{{ summary.exercise | parse_localization }}
-						</a>
-					</td>
+				<td>
+					{% profiles summary.submitters instance summary.is_teacher %}
+				</td>
+				<td data-datetime="{{ summary.submission.submission_time|date:'Y-m-d H:i:s' }}">
+					{{ summary.submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}
+					{% if summary.submission.late_penalty_applied %}
+					<span class="label label-warning">
+						{% blocktranslate trimmed with percent=summary.submission.late_penalty_applied|percent %}
+						LATE_W_PENALTY -- {{ percent }}
+						{% endblocktranslate %}
+					</span>
+					{% endif %}
+				</td>
+				<td>
+					{{ summary.submission.status|submission_status }}
+				</td>
+				<td>
+					{% format_points summary.submission.grade True True %}
+				</td>
+				<td id="submission_tags">
+					{% for tagging in summary.submission.submission_taggings.all %}
+					{{ tagging.tag|colortag }}
+					{% endfor %}
+				</td>
+				<td>
+					{% if summary.submission.grader %}
+					<span class="glyphicon glyphicon-ok"></span>
+					{% translate "YES" %}
+					{% else %}
+					<span class="glyphicon glyphicon-remove"></span>
+					{% translate "NO" %}
+					{% endif %}
+				</td>
+				<td>
+				<a href="{{ summary.submission|url:'submission-inspect' }}" class="aplus-button--secondary aplus-button--xs">
+					<span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
+					{% translate "INSPECT" %}
+				</a>
+				</td>
+				<td>
+					<a href="{{ summary.exercise|url }}">
+						{{ summary.exercise | parse_localization }}
+					</a>
+				</td>
 			</tr>
 			{% empty %}
 			<tr>

--- a/course/templates/course/staff/all_submissions_table.html
+++ b/course/templates/course/staff/all_submissions_table.html
@@ -67,7 +67,7 @@
 			{% for summary in submission_data %}
 			<tr id="summary.submission-{{ summary.submission.id }}">
 				<td>
-					{% profiles summary.submitters instance summary.is_teacher %}
+					{% profiles summary.submission.submitters.all instance summary.is_teacher %}
 				</td>
 				<td data-datetime="{{ summary.submission.submission_time|date:'Y-m-d H:i:s' }}">
 					{{ summary.submission.submission_time|date:'DATETIME_SECONDS_FORMAT' }}

--- a/course/views.py
+++ b/course/views.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.db.models import Prefetch
 from django.http import Http404
 from django.http.response import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -22,6 +23,7 @@ from exercise.models import LearningObject
 from exercise.submission_models import Submission
 from lib.helpers import settings_text, remove_query_param_from_url, is_ajax
 from lib.viewbase import BaseTemplateView, BaseRedirectMixin, BaseFormView, BaseView, BaseRedirectView
+from userprofile.models import UserProfile
 from userprofile.viewbase import UserProfileView
 from .forms import GroupsForm, GroupSelectForm
 from .models import Course, CourseInstance, CourseModule, Enrollment
@@ -391,8 +393,9 @@ class AllSubmissionsView(CourseInstanceBaseView):
 
         submissions_data = Submission.objects.filter(
             exercise__course_module__course_instance=self.instance.id,
-        ).select_related(
-            'exercise',
+        ).prefetch_related(None).prefetch_related(
+            Prefetch('submitters', UserProfile.objects.prefetch_tags(self.instance)),
+            'exercise', 'submission_taggings'
         )
 
         is_teacher = self.instance.is_teacher(self.request.user)
@@ -401,7 +404,6 @@ class AllSubmissionsView(CourseInstanceBaseView):
             row_data.append({
                 'submission': submission,
                 'exercise': submission.exercise,
-                'submitters': submission.submitters.all(),
                 'is_teacher': is_teacher,
             })
 

--- a/course/views.py
+++ b/course/views.py
@@ -389,14 +389,20 @@ class AllSubmissionsView(CourseInstanceBaseView):
         super().get_common_objects()
         row_data = []
 
-        submissions_data = Submission.objects.filter(exercise__course_module__course_instance=self.instance.id)
+        submissions_data = Submission.objects.filter(
+            exercise__course_module__course_instance=self.instance.id,
+        ).select_related(
+            'exercise',
+        )
+
+        is_teacher = self.instance.is_teacher(self.request.user)
 
         for submission in submissions_data:
             row_data.append({
                 'submission': submission,
                 'exercise': submission.exercise,
                 'submitters': submission.submitters.all(),
-                'is_teacher': self.instance.is_teacher(self.request.user),
+                'is_teacher': is_teacher,
             })
 
         self.tags = self.instance.submissiontags.all()


### PR DESCRIPTION
# Description

**What?**

* Limit the table rows to 50 by default and fetch exercise objects in the same query with the submissions.
* Pagination should be added to the page later.

Adding `select_related('exercise')` improved the performance, when loading the page limited to 50 table rows.
In local testing it loaded ~2x faster with around 100 submissions with `select_related`, vs. without it.

Part of #1448
