### PR TITLE
Fix incorrect url for 'visit without sending data' in lti1.3 services

### DIFF
--- a/exercise/exercise_models.py
+++ b/exercise/exercise_models.py
@@ -1376,8 +1376,6 @@ class LTI1p3Exercise(BaseExercise):
         if not students:
             return ExercisePage(self)
 
-        language = get_language()
-        url = self.get_service_url(language)
         parameters = prepare_lti1p3_initiate_login(self.lti_service, students[0].user, self.course_instance, self)
 
         # Render launch button.
@@ -1391,7 +1389,7 @@ class LTI1p3Exercise(BaseExercise):
             'parameters': parameters,
             'exercise': self,
             'is_course_staff': self.course_instance.is_course_staff(request.user),
-            'site': '/'.join(url.split('/')[:3]),
+            'site': '/'.join(self.lti_service.url.split('/')[:3]),
         })
         return page
 


### PR DESCRIPTION
# Description

The "Visit site without sending data" link directed to the wrong page (the exercise's page itself on A+) due to copy-pasted code. This fixes that.

Fixes #1447 

# Testing

**What type of test did you run?**

- [X] Manual testing.

Made an LTI1.3 exercise and checked the link pointed to a sensible place.