### PR TITLE
Add API endpoints for adding and deleting submission taggings

### DIFF
--- a/course/admin.py
+++ b/course/admin.py
@@ -11,6 +11,7 @@ from course.models import (
     LearningObjectCategory,
     UserTag,
     UserTagging,
+    SubmissionTag,
 )
 from lib.admin_helpers import RecentCourseInstanceListFilter
 
@@ -237,6 +238,32 @@ class UserTaggingAdmin(admin.ModelAdmin):
     )
 
 
+class SubmissionTagAdmin(admin.ModelAdmin):
+    search_fields = (
+        'name',
+        'slug',
+        'course_instance__instance_name',
+        'course_instance__course__name',
+        'course_instance__course__code',
+    )
+    list_display = (
+        'course_instance',
+        'name',
+        'slug',
+        'visible_to_students',
+    )
+    list_display_links = (
+        'name',
+        'slug',
+    )
+    list_filter = (
+        RecentCourseInstanceListFilter,
+    )
+    raw_id_fields = (
+        'course_instance',
+    )
+
+
 class CourseHookAdmin(admin.ModelAdmin):
     search_fields = (
         'hook_url',
@@ -256,3 +283,4 @@ admin.site.register(CourseModule, CourseModuleAdmin)
 admin.site.register(LearningObjectCategory, LearningObjectCategoryAdmin)
 admin.site.register(UserTag, UserTagAdmin)
 admin.site.register(UserTagging, UserTaggingAdmin)
+admin.site.register(SubmissionTag, SubmissionTagAdmin)

--- a/exercise/admin.py
+++ b/exercise/admin.py
@@ -14,6 +14,7 @@ from exercise.models import (
     LTI1p3Exercise,
     Submission,
     SubmissionDraft,
+    SubmissionTagging,
     SubmittedFile,
     RevealRule,
     ExerciseTask,
@@ -237,6 +238,48 @@ class SubmissionDraftAdmin(admin.ModelAdmin):
             .defer('submission_data')
             .prefetch_related('exercise', 'submitter')
         )
+
+
+class SubmissionTaggingAdmin(admin.ModelAdmin):
+    search_fields = (
+        'tag__name',
+        'tag__slug',
+        'tag__course_instance__instance_name',
+        'tag__course_instance__course__name',
+        'tag__course_instance__course__code',
+        'submission__id',
+        'submission__exercise__name',
+        'submission__submitters__student_id',
+        'submission__submitters__user__username',
+        'submission__submitters__user__first_name',
+        'submission__submitters__user__last_name',
+        'submission__submitters__user__email',
+    )
+    list_display = (
+        'get_course_instance',
+        'tag',
+        'submission',
+        'get_submitters',
+    )
+    list_display_links = (
+        'tag',
+        'submission',
+    )
+    list_filter = (
+        SubmissionRecentCourseInstanceListFilter,
+    )
+    raw_id_fields = (
+        'tag',
+        'submission',
+    )
+
+    @admin.display(description=_('LABEL_COURSE_INSTANCE'))
+    def get_course_instance(self, obj):
+        return str(obj.submission.exercise.course_module.course_instance)
+
+    @admin.display(description=_('LABEL_SUBMITTERS'))
+    def get_submitters(self, obj):
+        return ', '.join(str(s) for s in obj.submission.submitters.all())
 
 
 class SubmittedFileAdmin(admin.ModelAdmin):
@@ -535,6 +578,7 @@ admin.site.register(LTIExercise, LTIExerciseAdmin)
 admin.site.register(LTI1p3Exercise, LTI1p3ExerciseAdmin)
 admin.site.register(Submission, SubmissionAdmin)
 admin.site.register(SubmissionDraft, SubmissionDraftAdmin)
+admin.site.register(SubmissionTagging, SubmissionTaggingAdmin)
 admin.site.register(SubmittedFile, SubmittedFileAdmin)
 admin.site.register(ExerciseCollection, ExerciseCollectionAdmin)
 admin.site.register(RevealRule, RevealRuleAdmin)


### PR DESCRIPTION
# Description

**What?**

* Add SubmissionTag and SubmissionTagging to Django admin site
* Add API endpoint for adding and deleting submission taggings

API usage:

`POST /submissions/<submission_id>/tag/`: tags a submission with a submission tag.
- Request body:
    - `tag_slug`: the slug of the tag to be added.

`DELETE /submissions/<submission_id>/tag/`: removes a submission tag from a submission.
- Request body:
    - `tag_slug`: the slug of the tag to be removed.

Fixes #1430


# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the API endpoints seem to work by sending POST and DELETE requests with Postman.