### PR TITLE
Remove duplicates from submissiondata API endpoint

### DIFF
--- a/exercise/api/csv/views.py
+++ b/exercise/api/csv/views.py
@@ -111,7 +111,7 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
         queryset = Submission.objects.filter(
             exercise_id__in=ids,
             submitters__in=profiles
-        ).prefetch_related('exercise', 'notifications', 'files')
+        ).prefetch_related('exercise', 'notifications', 'files').distinct()
         return self.serialize_submissions(request, queryset, revealed_ids, best=search_args['best'])
 
     def retrieve( # pylint: disable=arguments-differ


### PR DESCRIPTION
# Description

**What?**

Remove duplicates from submissiondata API endpoint, because group submissions caused data to be duplicated.

Tested that the duplicates are no longer present in data downloaded from a URL such as http://localhost:8000/api/v2/courses/1/submissiondata/?exercise_id=29&format=json&best=no

Fixes #1285