### PR TITLE
Added submission tags to the API path "submissiondata/me"

### DIFF
--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -64,7 +64,7 @@ with api.register(r'courses',
     courses.register(r'points',
                      exercise.api.views.CoursePointsViewSet,
                      basename='course-points')
-    courses.register(r'submissiondata',
+    courses.register(r'submissiondata', #submissiondata comes from here
                      exercise.api.csv.views.CourseSubmissionDataViewSet,
                      basename='course-submissiondata')
     courses.register(r'aggregatedata',
@@ -125,7 +125,7 @@ urlpatterns = [
     ),
 ]
 
-
+#kutsutaanko näitä ainoastaan debuggauksen aikana?
 if getattr(settings, 'API_DEBUG', False):
     # Print list of api urls
     _urls = [(url.callback.cls.__name__, url.name or '-', url.pattern) for url in api.urls if url.callback]

--- a/api/urls_v2.py
+++ b/api/urls_v2.py
@@ -64,7 +64,7 @@ with api.register(r'courses',
     courses.register(r'points',
                      exercise.api.views.CoursePointsViewSet,
                      basename='course-points')
-    courses.register(r'submissiondata', #submissiondata comes from here
+    courses.register(r'submissiondata',
                      exercise.api.csv.views.CourseSubmissionDataViewSet,
                      basename='course-submissiondata')
     courses.register(r'aggregatedata',
@@ -125,7 +125,6 @@ urlpatterns = [
     ),
 ]
 
-#kutsutaanko näitä ainoastaan debuggauksen aikana?
 if getattr(settings, 'API_DEBUG', False):
     # Print list of api urls
     _urls = [(url.callback.cls.__name__, url.name or '-', url.pattern) for url in api.urls if url.callback]

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -49,7 +49,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         submissions: Iterable[Submission],
         revealed_ids: Set[int],
         ) -> Tuple[List[Dict[str, Any]], List[str]]:
-    DEFAULT_FIELDS = [ #this serves to render fields, but not the actual data that gets put into them
+    DEFAULT_FIELDS = [
         'ExerciseID', 'Category', 'Exercise', 'SubmissionID', 'Time',
         'UserID', 'StudentID', 'Email', 'Status',
         'Grade', 'Penalty', 'Graded', 'Tags', 'GraderEmail', 'Notified', 'NSeen',

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -116,7 +116,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
-            ('Tags', [2,5,7]), #tämä ei luultavasti toimi ihan sellaisenaan
+            ('Tags', [2,5,7].mkString("|")), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -93,13 +93,6 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
 
         #extract tags from s.grading_data
         tags = []
-        if 'grading_data' in s.grading_data:
-            grader_grading_data = json.loads(s.grading_data['grading_data'])
-            if 'submission_tags' in grader_grading_data:
-                for tag_slug in grader_grading_data['submission_tags'].split(','):
-                    tag_slug = tag_slug.strip()
-                    if tag_slug:
-                        tags.append(tag_slug)
 
 
         n = s.notifications.first()
@@ -123,6 +116,14 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
+        if 'grading_data' in s.grading_data:
+            grader_grading_data = json.loads(s.grading_data['grading_data'])
+            if 'submission_tags' in grader_grading_data:
+                for tag_slug in grader_grading_data['submission_tags'].split(','):
+                    tag_slug = tag_slug.strip()
+                    if tag_slug:
+                        tags.append(tag_slug)
+
         if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -50,10 +50,10 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         submissions: Iterable[Submission],
         revealed_ids: Set[int],
         ) -> Tuple[List[Dict[str, Any]], List[str]]:
-    DEFAULT_FIELDS = [
+    DEFAULT_FIELDS = [ #this serves to render fields, but not the actual data that gets put into them
         'ExerciseID', 'Category', 'Exercise', 'SubmissionID', 'Time',
         'UserID', 'StudentID', 'Email', 'Status',
-        'Grade', 'Penalty', 'Graded', 'Tags', 'Testaus', 'GraderEmail', 'Notified', 'NSeen', # Tags as for SubmissionTags
+        'Grade', 'Penalty', 'Graded', 'Tags', 'GraderEmail', 'Notified', 'NSeen', # Tags as for SubmissionTags
     ]
     sheet = []
     fields = []
@@ -123,7 +123,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
-        if s.submission_data:
+  '''      if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:
                     if k not in fields:
@@ -131,14 +131,15 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
                     if k in row:
                         row[k] += "|" + str(v)
                     else:
-                        row[k] = str(v)
+                        row[k] = str(v) '''
         #palautusten tiedostot tulee tästä
         for f in s.files.all():
             if f.param_name not in files:
                 files.append(f.param_name)
             row[f.param_name] = url(s,f)
         #opiskelijoiden parametrit asetetaan tässä
-        for i,profile in enumerate(s.submitters.all()):
+        #ainoastaan tämä tuo dataa suoraan apiin, joten tätä pitää muokata
+        for i,profile in enumerate(s.submitters.all()): #tekee kopioita jokaista asiakasta kohden
             r = row.copy() if i > 0 else row
             r['UserID'] = profile.user.id
             r['StudentID'] = profile.student_id

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -92,14 +92,21 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             grader = t[t.find("<a href=\"mailto:")+16:t.find("\">")]
 
         #extract tags from s.grading_data
-        tags = ["testing","if","this","shows"]
+        tags = []
         if 'grading_data' in s.grading_data:
             grader_grading_data = json.loads(s.grading_data['grading_data'])
             if 'submission_tags' in grader_grading_data:
                 for tag_slug in grader_grading_data['submission_tags'].split(','):
                     tag_slug = tag_slug.strip()
                     if tag_slug:
-                        tags.append(tag_slug)
+                        try:
+                            SubmissionTag.objects.get(
+                                slug=tag_slug,
+                                course_instance=s.exercise.course_module.course_instance,
+                            )
+                            tags.append(tag_slug)
+                        except SubmissionTag.DoesNotExist:
+                            pass
 
 
         n = s.notifications.first()

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -116,7 +116,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
-            ('Tags', str("some static value")), #tämä ei luultavasti toimi ihan sellaisenaan
+            ('Tags', list(2,5,7)), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -91,7 +91,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             grader = t[t.find("<a href=\"mailto:")+16:t.find("\">")]
 
         #extract tags from s.grading_data, validate they belong to the course
-        tags = ["tag","here"]
+        tags = []
         if 'grading_data' in s.grading_data:
             grader_grading_data = json.loads(s.grading_data['grading_data'])
             if 'submission_tags' in grader_grading_data:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -123,7 +123,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
-  '''      if s.submission_data:
+        '''if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:
                     if k not in fields:
@@ -131,7 +131,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
                     if k in row:
                         row[k] += "|" + str(v)
                     else:
-                        row[k] = str(v) '''
+                        row[k] = str(v)'''
         #palautusten tiedostot tulee tästä
         for f in s.files.all():
             if f.param_name not in files:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -92,7 +92,14 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             grader = t[t.find("<a href=\"mailto:")+16:t.find("\">")]
 
         #extract tags from s.grading_data
-        tags = []
+        tags = ["testing","if","this","shows"]
+        if 'grading_data' in s.grading_data:
+            grader_grading_data = json.loads(s.grading_data['grading_data'])
+            if 'submission_tags' in grader_grading_data:
+                for tag_slug in grader_grading_data['submission_tags'].split(','):
+                    tag_slug = tag_slug.strip()
+                    if tag_slug:
+                        tags.append(tag_slug)
 
 
         n = s.notifications.first()
@@ -116,14 +123,6 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
-        if 'grading_data' in s.grading_data:
-            grader_grading_data = json.loads(s.grading_data['grading_data'])
-            if 'submission_tags' in grader_grading_data:
-                for tag_slug in grader_grading_data['submission_tags'].split(','):
-                    tag_slug = tag_slug.strip()
-                    if tag_slug:
-                        tags.append(tag_slug)
-
         if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -53,7 +53,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
     DEFAULT_FIELDS = [
         'ExerciseID', 'Category', 'Exercise', 'SubmissionID', 'Time',
         'UserID', 'StudentID', 'Email', 'Status',
-        'Grade', 'Penalty', 'Graded', 'Tags', 'GraderEmail', 'Notified', 'NSeen', # Tags as for SubmissionTags
+        'Grade', 'Penalty', 'Graded', 'Tags', 'Testaus', 'GraderEmail', 'Notified', 'NSeen', # Tags as for SubmissionTags
     ]
     sheet = []
     fields = []
@@ -120,7 +120,6 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),
-            ('WTF', 0)
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -1,3 +1,5 @@
+import json
+
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Set, Tuple
 
@@ -5,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.reverse import reverse
 
 from ...models import BaseExercise, Submission
+from course.models import SubmissionTag
 
 
 def filter_best_submissions(
@@ -41,7 +44,7 @@ def filter_best_submissions(
             filtered.append(submissions[i])
     return filtered
 
-
+#TODO: tänne pitää lisätä tunnisteet
 def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         request: Request,
         submissions: Iterable[Submission],
@@ -50,7 +53,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
     DEFAULT_FIELDS = [
         'ExerciseID', 'Category', 'Exercise', 'SubmissionID', 'Time',
         'UserID', 'StudentID', 'Email', 'Status',
-        'Grade', 'Penalty', 'Graded', 'GraderEmail', 'Notified', 'NSeen',
+        'Grade', 'Penalty', 'Graded', 'Tags', 'GraderEmail', 'Notified', 'NSeen', # Tags as for SubmissionTags
     ]
     sheet = []
     fields = []
@@ -88,8 +91,19 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
         if not grader and t and t.startswith("\n<p>\nReviewer:"):
             grader = t[t.find("<a href=\"mailto:")+16:t.find("\">")]
 
+        #extract tags from s.grading_data
+        tags = []
+        if 'grading_data' in s.grading_data:
+            grader_grading_data = json.loads(s.grading_data['grading_data'])
+            if 'submission_tags' in grader_grading_data:
+                for tag_slug in grader_grading_data['submission_tags'].split(','):
+                    tag_slug = tag_slug.strip()
+                    if tag_slug:
+                        tags.append(tag_slug)
+
+
         n = s.notifications.first()
-        row = OrderedDict([
+        row = OrderedDict([ #TODO: tänne myös polku siihen, mistä saa tunnisteita
             ('ExerciseID', exercise.id),
             ('Category', exercise.category.name),
             ('Exercise', str(exercise)),
@@ -102,11 +116,13 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
+            ('Tags', tags), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),
         ])
-
+        #kaikki parametrit asetetaan luultavasti täällä
+        #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
         if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:
@@ -116,17 +132,18 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
                         row[k] += "|" + str(v)
                     else:
                         row[k] = str(v)
-
+        #palautusten tiedostot tulee tästä
         for f in s.files.all():
             if f.param_name not in files:
                 files.append(f.param_name)
             row[f.param_name] = url(s,f)
-
+        #opiskelijoiden parametrit asetetaan tässä
         for i,profile in enumerate(s.submitters.all()):
             r = row.copy() if i > 0 else row
             r['UserID'] = profile.user.id
             r['StudentID'] = profile.student_id
             r['Email'] = profile.user.email
             sheet.append(r)
-
+#DEFAULT_FIELDS on luultavasti mistä tulee eri kenttien nimet jsoniin
+    #sheet on se, mikä oikeasti näkyy apissa
     return sheet, DEFAULT_FIELDS + fields + files

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -116,14 +116,14 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
-            ('Tags', tags), #tämä ei luultavasti toimi ihan sellaisenaan
+            ('Tags', str("some static value")), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa
-        '''if s.submission_data:
+        if s.submission_data:
             for k,v in s.submission_data:
                 if v or k not in files:
                     if k not in fields:
@@ -131,7 +131,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
                     if k in row:
                         row[k] += "|" + str(v)
                     else:
-                        row[k] = str(v)'''
+                        row[k] = str(v)
         #palautusten tiedostot tulee tästä
         for f in s.files.all():
             if f.param_name not in files:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -116,7 +116,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
-            ('Tags', [2,5,7].mkString("|")), #tämä ei luultavasti toimi ihan sellaisenaan
+            ('Tags', '|'.join(tags)), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -91,7 +91,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             grader = t[t.find("<a href=\"mailto:")+16:t.find("\">")]
 
         #extract tags from s.grading_data, validate they belong to the course
-        tags = []
+        tags = ["tag","here"]
         if 'grading_data' in s.grading_data:
             grader_grading_data = json.loads(s.grading_data['grading_data'])
             if 'submission_tags' in grader_grading_data:

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -116,7 +116,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('Grade', s.grade if exercise.id in revealed_ids else 0),
             ('Penalty', s.late_penalty_applied),
             ('Graded', str(s.grading_time)),
-            ('Tags', list(2,5,7)), #tämä ei luultavasti toimi ihan sellaisenaan
+            ('Tags', [2,5,7]), #tämä ei luultavasti toimi ihan sellaisenaan
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),

--- a/exercise/api/csv/submission_sheet.py
+++ b/exercise/api/csv/submission_sheet.py
@@ -120,6 +120,7 @@ def submissions_sheet( # pylint: disable=too-many-locals # noqa: MC0001
             ('GraderEmail', grader),
             ('Notified', n is not None),
             ('NSeen', n.seen if n else False),
+            ('WTF', 0)
         ])
         #kaikki parametrit asetetaan luultavasti täällä
         #TODO: tunnisteet ovat grading_datassa: grading_data['grading_data'], jossa on submission_tags json-muodossa

--- a/exercise/api/csv/views.py
+++ b/exercise/api/csv/views.py
@@ -83,7 +83,7 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
             return self.instance.students
         return self.instance.course_staff_and_students
 
-    def get_search_args(self, request):
+    def get_search_args(self, request): #tämä on suodatus, joka on mainittu ViewSetin lisäselityksessä
         return {
             'number': request.GET.get('filter'),
             'category_id': int_or_none(request.GET.get('category_id')),
@@ -131,7 +131,7 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
         ).prefetch_related('exercise', 'notifications', 'files')
         return self.serialize_submissions(request, queryset, revealed_ids)
 
-    def serialize_submissions(
+    def serialize_submissions( #tämä muuntaa palautusten tiedot jsoniksi
             self,
             request: Request,
             queryset: QuerySet[Submission],
@@ -143,22 +143,22 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
             submissions = filter_best_submissions(submissions, revealed_ids)
 
         # Pick out a single field.
-        field = request.GET.get('field')
+        field = request.GET.get('field') #miten tämä valitsee vain tiettyjä parametreja? tai toimiiko se edes näin?
         if field:
-            def submitted_field(submission, name):
+            def submitted_field(submission, name): #valitseeko name vain tiettyjä paramentreja kaikista palautuksen tiedoista?
                 for key,val in (submission.submission_data or []):
                     if key == name:
                         return val
                 return ""
             vals = [submitted_field(s, field) for s in submissions]
             return Response([v for v in vals if v != ""])
-
+                      #submission_sheet on se, joka määrittelee mikä tulee välitetty eteenpäin!!
         data,fields = submissions_sheet(request, submissions, revealed_ids)
         self.renderer_fields = fields
         response = Response(data)
         if isinstance(getattr(request, 'accepted_renderer'), CSVRenderer):
             response['Content-Disposition'] = 'attachment; filename="submissions.csv"'
-        else:
+        else: #tästä submissiondata/me saa tiedoston ulos
             response['Content-Disposition'] = 'attachment; filename="submissions.json"'
         return response
 

--- a/exercise/api/csv/views.py
+++ b/exercise/api/csv/views.py
@@ -83,7 +83,7 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
             return self.instance.students
         return self.instance.course_staff_and_students
 
-    def get_search_args(self, request): #tämä on suodatus, joka on mainittu ViewSetin lisäselityksessä
+    def get_search_args(self, request):
         return {
             'number': request.GET.get('filter'),
             'category_id': int_or_none(request.GET.get('category_id')),
@@ -131,7 +131,7 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
         ).prefetch_related('exercise', 'notifications', 'files')
         return self.serialize_submissions(request, queryset, revealed_ids)
 
-    def serialize_submissions( #tämä muuntaa palautusten tiedot jsoniksi
+    def serialize_submissions(
             self,
             request: Request,
             queryset: QuerySet[Submission],
@@ -143,22 +143,21 @@ class CourseSubmissionDataViewSet(NestedViewSetMixin,
             submissions = filter_best_submissions(submissions, revealed_ids)
 
         # Pick out a single field.
-        field = request.GET.get('field') #miten tämä valitsee vain tiettyjä parametreja? tai toimiiko se edes näin?
+        field = request.GET.get('field')
         if field:
-            def submitted_field(submission, name): #valitseeko name vain tiettyjä paramentreja kaikista palautuksen tiedoista?
+            def submitted_field(submission, name):
                 for key,val in (submission.submission_data or []):
                     if key == name:
                         return val
                 return ""
             vals = [submitted_field(s, field) for s in submissions]
             return Response([v for v in vals if v != ""])
-                      #submission_sheet on se, joka määrittelee mikä tulee välitetty eteenpäin!!
         data,fields = submissions_sheet(request, submissions, revealed_ids)
         self.renderer_fields = fields
         response = Response(data)
         if isinstance(getattr(request, 'accepted_renderer'), CSVRenderer):
             response['Content-Disposition'] = 'attachment; filename="submissions.csv"'
-        else: #tästä submissiondata/me saa tiedoston ulos
+        else:
             response['Content-Disposition'] = 'attachment; filename="submissions.json"'
         return response
 

--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -58,7 +58,7 @@ def _post_async_submission(request, exercise, submission, errors=None):
         submission.feedback = form.cleaned_data["feedback"]
         submission.grading_data = post_data
 
-        if 'grading_data' in submission.grading_data: #tunnisteille apissa: jos tämä tunniste ei kuulu kurssille, jätä se vain huomiotta
+        if 'grading_data' in submission.grading_data:
             grader_grading_data = json.loads(submission.grading_data['grading_data'])
             if 'submission_tags' in grader_grading_data:
                 for tag_slug in grader_grading_data['submission_tags'].split(','):

--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -58,7 +58,7 @@ def _post_async_submission(request, exercise, submission, errors=None):
         submission.feedback = form.cleaned_data["feedback"]
         submission.grading_data = post_data
 
-        if 'grading_data' in submission.grading_data:
+        if 'grading_data' in submission.grading_data: #tunnisteille apissa: jos tämä tunniste ei kuulu kurssille, jätä se vain huomiotta
             grader_grading_data = json.loads(submission.grading_data['grading_data'])
             if 'submission_tags' in grader_grading_data:
                 for tag_slug in grader_grading_data['submission_tags'].split(','):

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -350,9 +350,9 @@ class SubmissionProto(UrlMixin):
     def get_inspect_url(self):
         return self.get_url("submission-inspect")
 
-
+#TODO: tunnisteet todennäköisesti tänne, jotta submission_sheet voi hakea niitä
 @register_jwt_accessible_class("submission")
-class Submission(SubmissionProto, models.Model):
+class Submission(SubmissionProto, models.Model): #lisätäänkö tunnisteet tänne?
     """
     A submission to some course exercise from one or more submitters.
     """
@@ -447,7 +447,8 @@ class Submission(SubmissionProto, models.Model):
         verbose_name=_('LABEL_SUBMISSION_DATA'),
         blank=True,
     )
-    grading_data = JSONField(
+    #TODO: tunnisteet ovat tässä, joten niitä on pakko jotenkin saada ulos
+    grading_data = JSONField( #tämä on grading-basen asettama rivi
         verbose_name=_('LABEL_GRADING_DATA'),
         blank=True,
     )
@@ -712,7 +713,7 @@ class Submission(SubmissionProto, models.Model):
         except PendingSubmission.DoesNotExist:
             pass
 
-class SubmissionTagging(models.Model):
+class SubmissionTagging(models.Model): #submission tags!
     tag = models.ForeignKey(SubmissionTag,
         verbose_name=_('LABEL_SUBMISSION_TAG'),
         on_delete=models.CASCADE,

--- a/exercise/submission_models.py
+++ b/exercise/submission_models.py
@@ -350,9 +350,9 @@ class SubmissionProto(UrlMixin):
     def get_inspect_url(self):
         return self.get_url("submission-inspect")
 
-#TODO: tunnisteet todennäköisesti tänne, jotta submission_sheet voi hakea niitä
+
 @register_jwt_accessible_class("submission")
-class Submission(SubmissionProto, models.Model): #lisätäänkö tunnisteet tänne?
+class Submission(SubmissionProto, models.Model):
     """
     A submission to some course exercise from one or more submitters.
     """
@@ -447,8 +447,8 @@ class Submission(SubmissionProto, models.Model): #lisätäänkö tunnisteet tän
         verbose_name=_('LABEL_SUBMISSION_DATA'),
         blank=True,
     )
-    #TODO: tunnisteet ovat tässä, joten niitä on pakko jotenkin saada ulos
-    grading_data = JSONField( #tämä on grading-basen asettama rivi
+
+    grading_data = JSONField(
         verbose_name=_('LABEL_GRADING_DATA'),
         blank=True,
     )
@@ -713,7 +713,7 @@ class Submission(SubmissionProto, models.Model): #lisätäänkö tunnisteet tän
         except PendingSubmission.DoesNotExist:
             pass
 
-class SubmissionTagging(models.Model): #submission tags!
+class SubmissionTagging(models.Model):
     tag = models.ForeignKey(SubmissionTag,
         verbose_name=_('LABEL_SUBMISSION_TAG'),
         on_delete=models.CASCADE,


### PR DESCRIPTION
# Description

**What?**

Added submission tags under the Json label 'Tags' to the API endpoint at submissiondata/me.

**Why?**

Submission tags are a relatively new feature that is not yet widely used. This particular issue arose while developing the next iteration of O1 and trying to implement tag functionality. O1 uses A+ plugin in IntelliJ to make turning in submissions and viewing feedback easier, and one of the paths that it uses to update the submission list is submissiondata/me, which is handy to update all the submissions at once, such as when the IDE is opened or the assignment list gets refreshed. Tags were not easily available at the path, which would have made retrieval time-consuming and unnecessarily complicated when updating the assignment tree. Adding tags to a single path makes it easier to fetch all of them at the same time, making it easier for the plugin to do its work.

**How?**

All of the necessary changes were made to `exercise/api/csv/submission_sheet.py` , where I added a new field to the Json that gets sent through the API, along with some logic for processing tags, which mirrors the one implemented in `exercise/async_views.py`. If a tag exists in some course instance, it gets added to a holder array, otherwise it gets quietly discarded without throwing any errors. In the final endpoint tags are separated by | marks to match the format used in other fields.

Fixes #1470 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [+] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

Manually tested submitting assignments for O1 with errors, tags, tags and errors, neither tags nor errors. Tested on a local branch of A+ through O1, where I used it as a docker image in the Docker Hub.

**Did you test the changes in**

The changes were tested in Safari.

- [ ] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
