### PR TITLE
Use django-debug-toolbar 6.1 or later for better support of debugging…

### DIFF
--- a/aplus/settings.py
+++ b/aplus/settings.py
@@ -616,10 +616,8 @@ if ENABLE_DJANGO_DEBUG_TOOLBAR:
             INTERNAL_IPS.append('127.0.0.1')
     except NameError:
         INTERNAL_IPS = ['127.0.0.1']
-    try:
-        # pylint: disable-next=used-before-assignment
-        DEBUG_TOOLBAR_CONFIG.setdefault('SHOW_TOOLBAR_CONFIG', 'lib.helpers.show_debug_toolbar')
-    except NameError:
-        DEBUG_TOOLBAR_CONFIG = {
-            'SHOW_TOOLBAR_CALLBACK': 'lib.helpers.show_debug_toolbar',
-        }
+    # Configure Debug Toolbar to work under Docker by auto-detecting the gateway IP
+    # See: https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#docker
+    DEBUG_TOOLBAR_CONFIG = globals().get('DEBUG_TOOLBAR_CONFIG', {})
+    # Always use the Docker-aware callback so toolbar shows when accessed via localhost
+    DEBUG_TOOLBAR_CONFIG.setdefault('SHOW_TOOLBAR_CALLBACK', 'debug_toolbar.middleware.show_toolbar_with_docker')

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -3,7 +3,7 @@ coverage
 # Required to run browser tests:
 selenium
 pyvirtualdisplay
-django-debug-toolbar >= 3.2.2, < 4
+django-debug-toolbar >= 6.1.0, < 7
 prospector
 pytest-playwright
 pytest-django


### PR DESCRIPTION
… with Docker

# Description

Update Django debug toolbar to version 6+ and use the new show_toolbar_with_docker middleware as the SHOW_TOOLBAR_CALLBACK to show the toolbar consistently on Docker environments without custom workarounds in settings.py.

This only affects the development environment, not production.