### PR TITLE
Only remove notifications if explicitly requested

### DIFF
--- a/exercise/async_views.py
+++ b/exercise/async_views.py
@@ -107,11 +107,11 @@ def _post_async_submission(request, exercise, submission, errors=None): # pylint
             submission.set_ready()
         submission.save()
 
-        if form.cleaned_data["notify"]:
+        if form.cleaned_data["notify"] == "remove":
+            Notification.remove(submission)
+        elif form.cleaned_data["notify"]:
             regrade_when_notification_seen = form.cleaned_data["regrade_when_notification_seen"]
             Notification.send(None, submission, regrade_when_seen=regrade_when_notification_seen)
-        else:
-            Notification.remove(submission)
 
         # If the submission was made through LTI, send results back to the platform.
         if submission.lti_launch_id:


### PR DESCRIPTION
Only remove notifications if explicitly requested by the grading service. This helps in better handling mooc-jutut notifications when feedback is edited.

Related to https://github.com/apluslms/mooc-jutut/pull/136.