### PR TITLE
Add "get_module_of_exercise" url param to deviations page

### DIFF
--- a/deviations/views.py
+++ b/deviations/views.py
@@ -5,6 +5,7 @@ from django.utils.dateparse import parse_datetime
 from django.http import HttpRequest, HttpResponse
 
 from course.models import UserTag, UserTagging
+from exercise.exercise_models import BaseExercise
 from .forms import (
     DeadlineRuleDeviationForm,
     RemoveDeviationForm,
@@ -36,6 +37,13 @@ class AddDeadlinesView(AddDeviationsView):
 
     def get_success_no_override_url(self) -> str:
         return self.instance.get_url('deviations-add-dl')
+
+    def get_initial(self):
+        initial = super().get_initial()
+        if self.request.GET.get('get_module_of_exercise'):
+            exercise = BaseExercise.objects.get(id=self.request.GET.get('get_module_of_exercise'))
+            initial['module'] = [exercise.course_module.id]
+        return initial
 
     def get_initial_get_param_spec(self) -> Dict[str, Optional[Callable[[str], Any]]]:
         spec = super().get_initial_get_param_spec()


### PR DESCRIPTION
# Description

Add handling of "get_module_of_exercise" url param to deviations page

**Why?**

This is required for mooc-jutut's "add deadline deviation" button to work.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.