### PR TITLE
Add template information for when grader feedback has been received

### DIFF
--- a/exercise/templates/exercise/exercise_plain.html
+++ b/exercise/templates/exercise/exercise_plain.html
@@ -203,6 +203,9 @@
 					{% if disable_submit %}
 						data-aplus-disable-submit="true"
 					{% endif %}
+					{% if grader_feedback_just_received %}
+						data-aplus-grader-feedback-just-received="true"
+					{% endif %}
 				>
 					{% include "_messages.html" %}
 					{% include "exercise/_submit_progress.html" %}

--- a/exercise/views.py
+++ b/exercise/views.py
@@ -248,7 +248,11 @@ class ExerciseView(BaseRedirectMixin, ExerciseBaseView, EnrollableViewMixin):
                 return self.redirect(request.GET["__r"], backup=self.exercise);
 
         return self.render_to_response(self.get_context_data(
-            page=page, students=students, submission=new_submission))
+            page=page,
+            students=students,
+            submission=new_submission,
+            grader_feedback_just_received=True,
+        ))
 
     def submission_check(self, request=None):
         if self.exercise.grading_mode == BaseExercise.GRADING_MODE.LAST:


### PR DESCRIPTION
This can be used e.g. to show feedback messages from the grading services that don't want to be permanently shown in the student feedback, like "Feedback received" in mooc-jutut.

**Why?**

Allows grading services to show data *once* when they send grading results to A+.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested together with https://github.com/apluslms/mooc-jutut/pull/138.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.