### PR TITLE
Made DL extensions visible even after the extended DL

### DIFF
--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -22,9 +22,9 @@ def _prepare_topmenu(context):
     return context['topmenu']
 
 
-def _deadline_extended_exercise_open(entry, now):
+def _deadline_extended_exercise_open(entry):
     personal_deadline = entry.personal_deadline
-    return personal_deadline is not None and entry.opening_time <= now <= personal_deadline
+    return personal_deadline is not None
 
 
 @register.inclusion_tag("course/_course_dropdown_menu.html", takes_context=True)
@@ -77,14 +77,14 @@ def exercises_open(entry, now):
 
 
 @register.filter
-def deadline_extended_exercise_open(entry, now):
-    return _deadline_extended_exercise_open(entry, now)
+def deadline_extended_exercise_open(entry):
+    return _deadline_extended_exercise_open(entry)
 
 
 @register.filter
-def deadline_extended_exercises_open(entry, now):
+def deadline_extended_exercises_open(entry):
     return any(
-        _deadline_extended_exercise_open(entry, now)
+        _deadline_extended_exercise_open(entry)
         for entry in entry.flatted
         if isinstance(entry, ExercisePoints)
     )

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -58,7 +58,7 @@
 						{% for requirement in module.requirements %}{{ requirement }}{% endfor %}
 					</span>
 					{% endif %}
-					{% if module|deadline_extended_exercises_open:now %}
+					{% if module|deadline_extended_exercises_open %}
 					<span class="badge text-primary bg-white float-end text-wrap">
 						{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
 					</span>
@@ -151,7 +151,7 @@
 					<td>
 						{% if exercise_accessible and entry.is_revealed or is_course_staff %}
 						<a href="{{ entry.link }}" class="{% if entry.is_in_maintenance %}maintenance{% endif %}">{{ entry.name|parse_localization }}</a>
-						{% if entry|deadline_extended_exercise_open:now %}
+						{% if entry|deadline_extended_exercise_open %}
 							<span
 								data-bs-toggle="tooltip"
 								title="{% translate 'PERSONAL_EXTENDED_DEADLINE' %} {{ entry.personal_deadline }}"

--- a/exercise/templates/exercise/_user_toc.html
+++ b/exercise/templates/exercise/_user_toc.html
@@ -11,7 +11,7 @@
 		{% if accessible %}
 		<h3>
 			<a href="{{ module.link }}" class="{% if module.is_in_maintenance %}maintenance{% endif %}">{{ module.name|parse_localization }}</a>
-			{% if module|deadline_extended_exercises_open:now %}
+			{% if module|deadline_extended_exercises_open %}
 			<span class="badge text-bg-secondary">
 				{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
 			</span>


### PR DESCRIPTION
# Description

**What?**
I made the personal extended deadlines visible for students on the Your Points page even after the extended deadline has passed, as requested in issue #1495

**Why?**

To improve the user experience so that the extended DL doesn't have to be looked up separately

**How?**

Removed the filtering by current time logic in the extended deadline lookup function

Fixes #1495 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [x] Django unit tests.
- [ ] Selenium tests.
- [x] Other test. *(Add a description below)*
- [x] Manual testing.
I ran the Playwright e2e test suite in addition to all existing unit tests.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
