### PR TITLE
LTI1.3 tool: Create lineitem if not found while sending grade

### DIFF
--- a/lti_tool/utils.py
+++ b/lti_tool/utils.py
@@ -11,6 +11,7 @@ from pylti1p3.message_launch import TLaunchData
 from pylti1p3.exception import LtiException, LtiServiceException
 
 from course.models import CourseInstance
+from lib.localization_syntax import pick_localized
 
 
 logger = logging.getLogger('aplus.lti_tool')
@@ -116,8 +117,13 @@ def send_lti_points(request, submission):
             .set_activity_progress('Completed')
             .set_grading_progress('FullyGraded')
             .set_user_id(launch.get_launch_data().get('sub')))
+
+        # Check for lineitem existence and remake if not found
+        e = submission.exercise
         line_item = LineItem()
-        line_item.set_tag(str(submission.exercise.id))
+        line_item.set_tag(str(e.id)).set_score_maximum(e.max_points).set_label(pick_localized(str(e), 'en'))
+        ags.find_or_create_lineitem(line_item)
+
         try:
             ags.put_grade(grade, line_item)
         except LtiServiceException as exc:


### PR DESCRIPTION
Fix for the issue where after some moodle operations grades would no longer be sent from A+ to moodle. Now lineitem existence is checked before trying to send the grade, and is recreated if not found.

Fixes #1483

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested manually removing a lineitem created by A+ and trying to submit the associated exercise before and after changes, verifying that the error happened before the change and no longer after the change.

Also tested that no duplicate lineitems were created if one already existed, e.g. tested submitting without manually removing the lineitem beforehand, as well as doing multiple submissions to the exercise.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.