### PR TITLE
Improve clarity of deadlines extension badges

### DIFF
--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -87,6 +87,33 @@ def deadline_extended_exercises_open(entry):
     )
 
 
+# List exercises in a module by deadline extension, to display in tooltip details
+@register.filter
+def deadline_extended_exercises_by_deadline(entry):
+    deadlines_map = {}
+    for e in entry.flatted:
+        if isinstance(e, ExercisePoints) and e.personal_deadline is not None:
+            if e.personal_deadline not in deadlines_map:
+                deadlines_map[e.personal_deadline] = []
+            deadlines_map[e.personal_deadline].append(e)
+    return list(deadlines_map.items())
+
+
+# Get the personal deadline if all exercises in a module have the same personal deadline
+@register.filter
+def deadline_extended_exercises_same_deadline(entry):
+    deadlines = [
+        e.personal_deadline
+        for e in entry.flatted
+        if isinstance(e, ExercisePoints)
+    ]
+    if not deadlines:
+        return None
+    if len(set(deadlines)) == 1:
+        return deadlines[0]
+    return None
+
+
 @register.filter
 def exercises_submittable(entry, now):
     if entry.late_allowed:

--- a/exercise/templates/exercise/_user_results.html
+++ b/exercise/templates/exercise/_user_results.html
@@ -59,9 +59,26 @@
 					</span>
 					{% endif %}
 					{% if module|deadline_extended_exercises_open %}
-					<span class="badge text-primary bg-white float-end text-wrap">
-						{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
-					</span>
+						<!-- If all exercises of a module have the same deadline, display it directly.
+							Otherwise display a generic message that has a tooltip with details -->
+						{% if module|deadline_extended_exercises_same_deadline %}
+						<span class="badge text-primary bg-white float-end text-wrap">
+							{% translate "PERSONAL_EXTENDED_DEADLINE" %} {{ module|deadline_extended_exercises_same_deadline }}
+						</span>
+						{% else %}
+						<span class="badge text-primary bg-white float-end text-wrap" data-bs-toggle="tooltip" data-bs-html="true" title="
+							{% for deadline, exercises in module|deadline_extended_exercises_by_deadline %}
+								{{ deadline }}:<br/>
+								{% for exercise in exercises %}
+									{{ exercise.name|parse_localization }}{% if not forloop.last %}<br/>{% endif %}
+								{% endfor %}
+								{% if not forloop.last %}<hr/>{% endif %}
+							{% endfor %}"
+						>
+							{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
+						</span>
+						{% endif %}
+
 					{% endif %}
 					{% if not accessible %}
 					<span class="badge text-primary bg-white float-end text-wrap">

--- a/exercise/templates/exercise/_user_toc.html
+++ b/exercise/templates/exercise/_user_toc.html
@@ -12,9 +12,25 @@
 		<h3>
 			<a href="{{ module.link }}" class="{% if module.is_in_maintenance %}maintenance{% endif %}">{{ module.name|parse_localization }}</a>
 			{% if module|deadline_extended_exercises_open %}
-			<span class="badge text-bg-secondary">
-				{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
-			</span>
+				<!-- If all exercises of a module have the same deadline, display it directly.
+					Otherwise display a generic message that has a tooltip with details -->
+				{% if module|deadline_extended_exercises_same_deadline %}
+				<span class="badge text-bg-secondary">
+					{% translate "PERSONAL_EXTENDED_DEADLINE" %} {{ module|deadline_extended_exercises_same_deadline }}
+				</span>
+				{% else %}
+				<span class="badge text-bg-secondary" data-bs-toggle="tooltip" data-bs-html="true" title="
+				{% for deadline, exercises in module|deadline_extended_exercises_by_deadline %}
+					{{ deadline }}:<br/>
+					{% for exercise in exercises %}
+						{{ exercise.name|parse_localization }}{% if not forloop.last %}<br/>{% endif %}
+					{% endfor %}
+					{% if not forloop.last %}<hr/>{% endif %}
+				{% endfor %}
+				">
+					{% translate "ASSIGNMENTS_WITH_PERSONAL_DEADLINE_DEVIATION" %}
+				</span>
+				{% endif %}
 			{% endif %}
 		</h3>
 		<h4>


### PR DESCRIPTION
# Description

**What?**

In both "Your points" page and table of contents:
- Show extension details in badge if all exercises in module have the same updated DL
- Otherwise, show a generic message and hide details in a tooltip

**Why?**

Students seem to have had confusion about finding deadline extension details. These should make those easier to notice.

**How?**

Example image showing both a module with all exercises having the same deadline, and another module that has varying deadline extensions:
<img width="1599" height="692" alt="image" src="https://github.com/user-attachments/assets/575b7eb3-41ac-41eb-a6f5-3dd5a7bb705b" />

Fixes #1494 