### PR TITLE
Add tabindex="-1" to base.html modals

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -261,7 +261,7 @@
 		</footer>
 		{% endblock %}
 	</div>
-	<div id="page-modal" class="modal" role="dialog">
+	<div id="page-modal" tabindex="-1" class="modal" role="dialog">
 		<div class="modal-dialog modal-xl">
 			<div class="modal-content">
 				<div class="modal-progress">
@@ -284,7 +284,7 @@
 			</div>
 		</div>
 	</div>
-	<div id="file-modal" class="modal" role="dialog">
+	<div id="file-modal" tabindex="-1" class="modal" role="dialog">
 		<div class="modal-dialog modal-lg">
 			<div class="modal-content">
 				<div class="modal-progress">


### PR DESCRIPTION
This makes the ESC key close `base.html` modals (which is most of the modals created by the site).

Fixes #1013, although the double-modal issue described in a later comment of the issue still remains. It's a very niche situation, though.