### PR TITLE
Limit users api & rework related features

### DIFF
--- a/assets/js/email_user_select.js
+++ b/assets/js/email_user_select.js
@@ -1,0 +1,251 @@
+/**
+ * Email User Select Widget
+ * 
+ * Allows users to add/remove users by email address. Validates emails against the backend
+ * and displays selected users as badges. The hidden field contains the comma-separated
+ * list of UIDs which is the actual form value.
+ */
+
+(function() {
+    // Store all widget instances
+    const widgets = new Map();
+
+    /**
+     * Initialize an email user select widget
+     * @param {string} widgetId - The unique ID for this widget
+     * @param {string} apiUrl - The API endpoint to search users (default: /api/v2/users/)
+     */
+    function initWidget(widgetId, apiUrl) {
+        const widget = {
+            id: widgetId,
+            apiUrl: apiUrl || '/api/v2/users/',
+            input: document.getElementById(`${widgetId}_input`),
+            addBtn: document.getElementById(`${widgetId}_add_btn`),
+            badgeList: document.getElementById(`${widgetId}_badges`),
+            hiddenField: document.getElementById(`${widgetId}_value`),
+            errorDiv: document.getElementById(`${widgetId}_error`)
+        };
+
+        if (!widget.input || !widget.addBtn || !widget.badgeList || !widget.hiddenField) {
+            console.error(`EmailUserSelect: Missing elements for widget ${widgetId}`);
+            return;
+        }
+
+        widgets.set(widgetId, widget);
+
+        // Event listeners
+        widget.addBtn.addEventListener('click', () => addEmail(widgetId));
+        widget.input.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                addEmail(widgetId);
+            }
+        });
+    }
+
+    /**
+     * Add a user to the badge list by email
+     * @param {string} widgetId - The widget ID
+     */
+    async function addEmail(widgetId) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        const email = widget.input.value.trim();
+        if (!email) {
+            showError(widgetId, 'Please enter an email address');
+            return;
+        }
+
+        // Check if user already exists in the list
+        if (userExists(widgetId, email)) {
+            showError(widgetId, `User with email "${email}" is already in the list`);
+            widget.input.value = '';
+            return;
+        }
+
+        try {
+            // Find user by email against backend
+            const users = await findUserByEmail(widgetId, email);
+            
+            if (!users || users.length === 0) {
+                showError(widgetId, `No user found with email "${email}"`);
+                return;
+            }
+            
+            if (users.length === 1) {
+                const user = users[0];
+                addBadge(widgetId, user);
+            } else {
+                // If multiple users found, show error
+                const userList = users.map(u => `${u.full_name || u.username} (${u.email})`).join(', ');
+                showError(widgetId, `Multiple users found for email "${email}": ${userList}`);
+                return;
+            }
+
+            // Clear input and hide error
+            widget.input.value = '';
+            hideError(widgetId);
+            
+        } catch (error) {
+            showError(widgetId, `Error validating email: ${error.message}`);
+        }
+    }
+
+    /**
+     * Validate email against the backend API
+     * Uses the UserViewSet search endpoint with exact email match
+     * @param {string} widgetId - The widget ID
+     * @param {string} email - The email to validate
+     * @returns {boolean} - True if user exists with this email
+     */
+    async function findUserByEmail(widgetId, email) {
+        const widget = widgets.get(widgetId);
+        
+        try {
+            // Use the search parameter - the API now uses =user__email for exact match
+            const response = await fetch(`${widget.apiUrl}?search=${encodeURIComponent(email)}`);
+            
+            if (!response.ok) {
+                console.error('API response error:', response.status);
+                return false;
+            }
+
+            return (await response.json()).results;
+        } catch (error) {
+            console.error('Error validating email:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Check if a user already exists in the badge list
+     * @param {string} widgetId - The widget ID
+     * @param {string} email - The email to check
+     * @returns {boolean} - True if user exists in the list
+     */
+    function userExists(widgetId, email) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return false;
+
+        const badges = widget.badgeList.querySelectorAll('.badge-item');
+        for (const badge of badges) {
+            if (badge.dataset.email === email) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Add a badge to the list
+     * @param {string} widgetId - The widget ID
+     * @param {Object} user - The user object
+     */
+    function addBadge(widgetId, user) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        const displayName = user.full_name || user.username || user.email;
+        
+        const li = document.createElement('li');
+        li.className = 'list-inline-item badge-item';
+        li.dataset.email = user.email;
+        li.dataset.userId = user.id; // Store user ID
+        
+        li.innerHTML = `
+            <button class="aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary" onclick="removeUser('${widgetId}', '${user.id}')">
+                ${displayName}, ${user.student_id}, ${user.email}
+                <span aria-label="Remove">x
+                </span>
+            </button>
+        `;
+
+        widget.badgeList.appendChild(li);
+        updateHiddenField(widgetId);
+    }
+
+    /**
+     * Remove a user from the badge list
+     * @param {string} widgetId - The widget ID
+     * @param {string} id - The user ID to remove
+     */
+    window.removeUser = function(widgetId, id) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        const badge = widget.badgeList.querySelector(`[data-user-id="${id}"]`);
+        if (badge) {
+            badge.remove();
+            updateHiddenField(widgetId);
+        }
+    };
+
+    /**
+     * Update the hidden field with current user IDs
+     * @param {string} widgetId - The widget ID
+     */
+    function updateHiddenField(widgetId) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        const userIds = [];
+        const badges = widget.badgeList.querySelectorAll('.badge-item');
+        
+        badges.forEach(badge => {
+            const userId = badge.dataset.userId;
+            if (userId) {
+                userIds.push(userId);
+            }
+        });
+
+        // Store as comma-separated user IDs
+        widget.hiddenField.value = userIds.join(', ');
+    }
+
+    /**
+     * Show error message
+     * @param {string} widgetId - The widget ID
+     * @param {string} message - Error message to display
+     */
+    function showError(widgetId, message) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        widget.errorDiv.textContent = message;
+        widget.errorDiv.style.display = 'block';
+        
+        // Hide error after 5 seconds
+        setTimeout(() => {
+            hideError(widgetId);
+        }, 5000);
+    }
+
+    /**
+     * Hide error message
+     * @param {string} widgetId - The widget ID
+     */
+    function hideError(widgetId) {
+        const widget = widgets.get(widgetId);
+        if (!widget) return;
+
+        widget.errorDiv.style.display = 'none';
+    }
+
+    // Auto-initialize widgets when DOM is ready
+    document.addEventListener('DOMContentLoaded', () => {
+        // Look for all email user select widgets
+        document.querySelectorAll('[data-email-user-select]').forEach(element => {
+            const widgetId = element.id;
+            const apiUrl = element.dataset.apiUrl || '/api/v2/users/';
+            initWidget(widgetId, apiUrl);
+        });
+    });
+
+    // Expose functions globally for inline event handlers
+    window.EmailUserSelect = {
+        initWidget,
+        addEmail,
+        removeUser
+    };
+})();

--- a/assets/js/email_user_select.js
+++ b/assets/js/email_user_select.js
@@ -147,19 +147,27 @@
         if (!widget) return;
 
         const displayName = user.full_name || user.username || user.email;
-        
+
+        const parts = [displayName, user.student_id, user.email].filter(Boolean);
+        const text = parts.join(', ');
+
         const li = document.createElement('li');
         li.className = 'list-inline-item badge-item';
-        li.dataset.email = user.email;
-        li.dataset.userId = user.id; // Store user ID
+        li.dataset.email = String(user.email || '');
+        li.dataset.userId = String(user.id); // Store user ID
         
-        li.innerHTML = `
-            <button class="aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary" onclick="removeUser('${widgetId}', '${user.id}')">
-                ${displayName}, ${user.student_id}, ${user.email}
-                <span aria-label="Remove">x
-                </span>
-            </button>
-        `;
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary';
+        button.addEventListener('click', () => window.removeUser(widgetId, String(user.id)));
+
+        const removeSpan = document.createElement('span');
+        removeSpan.setAttribute('aria-label', 'Remove');
+        removeSpan.textContent = 'x';
+
+        button.append(document.createTextNode(`${text} `), removeSpan);
+        li.appendChild(button);
+
 
         widget.badgeList.appendChild(li);
         updateHiddenField(widgetId);

--- a/course/forms.py
+++ b/course/forms.py
@@ -150,6 +150,7 @@ class GroupEditForm(forms.ModelForm):
 class EnrollStudentsForm(forms.Form):
 
     user_profiles = forms.CharField(
+        label=_('LABEL_USERS'),
         widget=EmailUserSelect(),
         required=False,
     )
@@ -173,15 +174,18 @@ class EnrollStudentsForm(forms.Form):
 
         # Split by comma and strip whitespace
         user_ids = []
+        seen = set()
         for item in user_ids_text.split(','):
             item = item.strip()
-            if item:
-                try:
-                    user_id = int(item)
-                    user_ids.append(user_id)
-                except ValueError:
-                    # Skip invalid values
-                    continue
+            if not item:
+                continue
+            try:
+                user_id = int(item)
+            except ValueError as exc:
+                raise ValidationError(_('ERROR_INVALID_USER_IDS')) from exc
+            if user_id not in seen:
+                seen.add(user_id)
+                user_ids.append(user_id)
 
         # Look up users by ID
         users = list(UserProfile.objects.filter(user_id__in=user_ids))

--- a/course/forms.py
+++ b/course/forms.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.utils.safestring import mark_safe
 from django.utils.text import format_lazy
@@ -10,6 +11,7 @@ from django.db.models import Count
 from aplus.api import api_reverse
 from exercise.models import SubmissionDraft
 from lib.fields import UsersSearchSelectField
+from lib.widgets import EmailUserSelect
 from .models import Enrollment, StudentGroup
 from userprofile.models import UserProfile
 
@@ -147,18 +149,47 @@ class GroupEditForm(forms.ModelForm):
 
 class EnrollStudentsForm(forms.Form):
 
-    user_profiles = UsersSearchSelectField(queryset=UserProfile.objects.all(),
-        initial_queryset=UserProfile.objects.none(),
-        label=_('LABEL_USERS'),
+    user_profiles = forms.CharField(
+        widget=EmailUserSelect(),
         required=False,
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.instance = kwargs.pop('instance')
         super().__init__(*args, **kwargs)
-        self.fields['user_profiles'].widget.search_api_url = api_reverse("user-list")
         if self.instance.sis_id:
             self.fields['sis'] = forms.BooleanField(
                 required=False,
                 label=_('LABEL_ENROLL_FROM_SIS'),
             )
+
+    def clean_user_profiles(self):
+        """
+        Validate and convert comma-separated user IDs to UserProfile objects.
+        """
+        user_ids_text = self.cleaned_data.get('user_profiles', '')
+        if not user_ids_text:
+            return []
+
+        # Split by comma and strip whitespace
+        user_ids = []
+        for item in user_ids_text.split(','):
+            item = item.strip()
+            if item:
+                try:
+                    user_id = int(item)
+                    user_ids.append(user_id)
+                except ValueError:
+                    # Skip invalid values
+                    continue
+
+        # Look up users by ID
+        users = list(UserProfile.objects.filter(user_id__in=user_ids))
+
+        # Verify all IDs were found
+        if len(users) != len(user_ids):
+            raise ValidationError(
+                _('ERROR_INVALID_USER_IDS')
+            )
+
+        return users

--- a/edit_course/course_forms.py
+++ b/edit_course/course_forms.py
@@ -191,15 +191,18 @@ class CourseInstanceForm(forms.ModelForm):
 
         # Split by comma and strip whitespace
         user_ids = []
+        seen = set()
         for item in user_ids_text.split(','):
             item = item.strip()
-            if item:
-                try:
-                    user_id = int(item)
-                    user_ids.append(user_id)
-                except ValueError:
-                    # Skip invalid values
-                    continue
+            if not item:
+                continue
+            try:
+                user_id = int(item)
+            except ValueError as exc:
+                raise ValidationError(_('COURSE_TEACHERS_INVALID_USER_IDS')) from exc
+            if user_id not in seen:
+                seen.add(user_id)
+                user_ids.append(user_id)
 
         # Look up users by ID
         teachers = list(UserProfile.objects.filter(user_id__in=user_ids))
@@ -222,15 +225,18 @@ class CourseInstanceForm(forms.ModelForm):
 
         # Split by comma and strip whitespace
         user_ids = []
+        seen = set()
         for item in user_ids_text.split(','):
             item = item.strip()
-            if item:
-                try:
-                    user_id = int(item)
-                    user_ids.append(user_id)
-                except ValueError:
-                    # Skip invalid values
-                    continue
+            if not item:
+                continue
+            try:
+                user_id = int(item)
+            except ValueError as exc:
+                raise ValidationError(_('COURSE_ASSISTANTS_INVALID_USER_IDS')) from exc
+            if user_id not in seen:
+                seen.add(user_id)
+                user_ids.append(user_id)
 
         # Look up users by ID
         assistants = list(UserProfile.objects.filter(user_id__in=user_ids))

--- a/edit_course/course_forms.py
+++ b/edit_course/course_forms.py
@@ -17,7 +17,7 @@ from course.sis import get_sis_configuration, StudentInfoSystem
 from exercise.models import CourseChapter
 from lib.validators import generate_url_key_validator
 from lib.fields import UsersSearchSelectField
-from lib.widgets import DateTimeLocalInput
+from lib.widgets import DateTimeLocalInput, EmailUserSelect
 from notification.cache import CachedNotifications
 from userprofile.models import UserProfile
 
@@ -119,16 +119,18 @@ class CourseModuleForm(FieldsetModelForm):
 
 class CourseInstanceForm(forms.ModelForm):
 
-    teachers = UsersSearchSelectField(
+    teachers = forms.CharField(
         label=_('LABEL_TEACHERS'),
-        queryset=UserProfile.objects.all(),
-        initial_queryset=UserProfile.objects.none(),
-        required=False)
-    assistants = UsersSearchSelectField(
+        required=False,
+        help_text=_('COURSE_TEACHERS_EMAIL_HELPTEXT'),
+        widget=EmailUserSelect()
+    )
+    assistants = forms.CharField(
         label=_('LABEL_ASSISTANTS'),
-        queryset=UserProfile.objects.all(),
-        initial_queryset=UserProfile.objects.none(),
-        required=False) # Not required because a course does not have to have any assistants.
+        required=False,
+        help_text=_('COURSE_ASSISTANTS_EMAIL_HELPTEXT'),
+        widget=EmailUserSelect()
+    )
 
     class Meta:
         model = CourseInstance
@@ -165,12 +167,10 @@ class CourseInstanceForm(forms.ModelForm):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.fields['teachers'].initial = self.instance.teachers.all()
-        self.fields['teachers'].initial_queryset = self.instance.teachers.all()
-        self.fields['teachers'].widget.search_api_url = api_reverse("user-list")
-        self.fields['assistants'].initial = self.instance.assistants.all()
-        self.fields['assistants'].initial_queryset = self.instance.assistants.all()
-        self.fields['assistants'].widget.search_api_url = api_reverse("user-list")
+        if self.instance:
+            self.fields['teachers'].initial = self.instance.teachers.all()
+            self.fields['assistants'].initial = self.instance.assistants.all()
+
         if self.instance and self.instance.visible_to_students:
             self.fields["url"].widget.attrs["readonly"] = "true"
             self.fields["url"].help_text = _('COURSE_URL_IDENTIFIER_LOCKED_WHILE_COURSE_VISIBLE')
@@ -180,6 +180,68 @@ class CourseInstanceForm(forms.ModelForm):
         # If course is not connected to SIS system, disable the enroll checkbox
         if not self.instance.sis_id:
             self.fields['sis_enroll'].disabled = True
+
+    def clean_teachers(self):
+        """
+        Validate and convert comma-separated user IDs to UserProfile objects.
+        """
+        user_ids_text = self.cleaned_data.get('teachers', '')
+        if not user_ids_text:
+            return []
+
+        # Split by comma and strip whitespace
+        user_ids = []
+        for item in user_ids_text.split(','):
+            item = item.strip()
+            if item:
+                try:
+                    user_id = int(item)
+                    user_ids.append(user_id)
+                except ValueError:
+                    # Skip invalid values
+                    continue
+
+        # Look up users by ID
+        teachers = list(UserProfile.objects.filter(user_id__in=user_ids))
+
+        # Verify all IDs were found
+        if len(teachers) != len(user_ids):
+            raise ValidationError(
+                _('COURSE_TEACHERS_INVALID_USER_IDS')
+            )
+
+        return teachers
+
+    def clean_assistants(self):
+        """
+        Validate and convert comma-separated user IDs to UserProfile objects.
+        """
+        user_ids_text = self.cleaned_data.get('assistants', '')
+        if not user_ids_text:
+            return []
+
+        # Split by comma and strip whitespace
+        user_ids = []
+        for item in user_ids_text.split(','):
+            item = item.strip()
+            if item:
+                try:
+                    user_id = int(item)
+                    user_ids.append(user_id)
+                except ValueError:
+                    # Skip invalid values
+                    continue
+
+        # Look up users by ID
+        assistants = list(UserProfile.objects.filter(user_id__in=user_ids))
+
+        # Verify all IDs were found
+        if len(assistants) != len(user_ids):
+            raise ValidationError(
+                _('COURSE_ASSISTANTS_INVALID_USER_IDS')
+            )
+
+        return assistants
 
     def clean_url(self):
         if self.instance and self.instance.visible_to_students:

--- a/lib/widgets.py
+++ b/lib/widgets.py
@@ -208,7 +208,11 @@ class EmailUserSelect(forms.TextInput):
 
         context = super().get_context(name, value, attrs)
 
-        context['selected_users'] = value
+        # When bound, the field value is a raw string; don't iterate it as "selected users".
+        if value is None or isinstance(value, str):
+            context['selected_users'] = []
+        else:
+            context['selected_users'] = value
         # Use the input ID, not the wrapper ID
         context['widget_id'] = context['widget']['attrs'].get('id', '')
         return context

--- a/lib/widgets.py
+++ b/lib/widgets.py
@@ -176,3 +176,39 @@ class SearchSelect(forms.SelectMultiple):
         else:
             value = getattr(instance, field, None)
         return str(value) if value is not None else ''
+
+
+class EmailUserSelect(forms.TextInput):
+    """
+    A widget for entering email addresses that displays selected users as badges.
+
+    This widget allows users to type an email and add it to a badge list.
+    The widget validates if the email exists in the database and provides
+    visual feedback. The badge list represents the actual form value.
+
+    Features:
+    - Type an email and press Enter or click Add to add to the list
+    - Validates if user exists before adding
+    - Shows user info in badges
+    - Click badge to remove from list
+    - Hidden field stores comma-separated UIDs
+    """
+    template_name = 'email_user_select.html'
+
+    class Media:
+        js = ('js/email_user_select.js',)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    def get_context(self, name: str, value: Any, attrs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Get data used to render the widget.
+        """
+
+        context = super().get_context(name, value, attrs)
+
+        context['selected_users'] = value
+        # Use the input ID, not the wrapper ID
+        context['widget_id'] = context['widget']['attrs'].get('id', '')
+        return context

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2337,6 +2337,10 @@ msgstr "Enter email address and press Enter/Add"
 msgid "ADD_USER"
 msgstr "Add"
 
+#: course/forms.py
+msgid "ERROR_INVALID_USER_IDS"
+msgstr "One or more user IDs are invalid"
+
 #: edit_course/course_forms.py
 msgid "ERROR_URL_ALREADY_TAKEN"
 msgstr "The URL is already taken."

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2306,6 +2306,38 @@ msgid "COURSE_REMOVES_SUBMISSION_POSSIBILITY_STUDENTS"
 msgstr "Students will not be able to submit answers after this time."
 
 #: edit_course/course_forms.py
+msgid "COURSE_TEACHERS_EMAIL_HELPTEXT"
+msgstr "Enter email address of teacher to add"
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANTS_EMAIL_HELPTEXT"
+msgstr "Enter email address of assistant to add"
+
+#: edit_course/course_forms.py
+msgid "COURSE_TEACHER_EMAIL_NOT_FOUND"
+msgstr "No user found with email address: {email}"
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANT_EMAIL_NOT_FOUND"
+msgstr "No user found with email address: {email}"
+
+#: edit_course/course_forms.py
+msgid "COURSE_TEACHERS_INVALID_USER_IDS"
+msgstr "One or more teacher user IDs are invalid"
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANTS_INVALID_USER_IDS"
+msgstr "One or more assistant user IDs are invalid"
+
+#: templates/email_user_select.html
+msgid "ENTER_EMAIL_TO_ADD"
+msgstr "Enter email address and press Enter/Add"
+
+#: templates/email_user_select.html
+msgid "ADD_USER"
+msgstr "Add"
+
+#: edit_course/course_forms.py
 msgid "ERROR_URL_ALREADY_TAKEN"
 msgstr "The URL is already taken."
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2330,6 +2330,14 @@ msgid "COURSE_ASSISTANTS_INVALID_USER_IDS"
 msgstr "One or more assistant user IDs are invalid"
 
 #: templates/email_user_select.html
+msgid "SELECTED_USERS"
+msgstr "Selected users"
+
+#: templates/email_user_select.html
+msgid "NO_USERS_ADDED_YET"
+msgstr "No users added yet"
+
+#: templates/email_user_select.html
 msgid "ENTER_EMAIL_TO_ADD"
 msgstr "Enter email address and press Enter/Add"
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2319,6 +2319,38 @@ msgid "COURSE_REMOVES_SUBMISSION_POSSIBILITY_STUDENTS"
 msgstr "Arkistoinnin jälkeen tehtävien palauttaminen ei ole enää mahdollista."
 
 #: edit_course/course_forms.py
+msgid "COURSE_TEACHERS_EMAIL_HELPTEXT"
+msgstr "Syötä lisättävän opettajan sähköpostiosoite."
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANTS_EMAIL_HELPTEXT"
+msgstr "Syötä lisättävän assistentin sähköpostiosoite."
+
+#: edit_course/course_forms.py
+msgid "COURSE_TEACHER_EMAIL_NOT_FOUND"
+msgstr "Käyttäjää ei löytynyt sähköpostiosoitteella: {email}"
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANT_EMAIL_NOT_FOUND"
+msgstr "Käyttäjää ei löytynyt sähköpostiosoitteella: {email}"
+
+#: edit_course/course_forms.py
+msgid "COURSE_TEACHERS_INVALID_USER_IDS"
+msgstr "Yksi tai useampi opettajan käyttäjätunnus on virheellinen"
+
+#: edit_course/course_forms.py
+msgid "COURSE_ASSISTANTS_INVALID_USER_IDS"
+msgstr "Yksi tai useampi assistentin käyttäjätunnus on virheellinen"
+
+#: templates/email_user_select.html
+msgid "ENTER_EMAIL_TO_ADD"
+msgstr "Syötä sähköpostiosoite ja paina Enter/Lisää"
+
+#: templates/email_user_select.html
+msgid "ADD_USER"
+msgstr "Lisää"
+
+#: edit_course/course_forms.py
 msgid "ERROR_URL_ALREADY_TAKEN"
 msgstr "URL on jo käytössä."
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2350,6 +2350,10 @@ msgstr "Syötä sähköpostiosoite ja paina Enter/Lisää"
 msgid "ADD_USER"
 msgstr "Lisää"
 
+#: course/forms.py
+msgid "ERROR_INVALID_USER_IDS"
+msgstr "Yksi tai useampi käyttäjätunnus on virheellinen"
+
 #: edit_course/course_forms.py
 msgid "ERROR_URL_ALREADY_TAKEN"
 msgstr "URL on jo käytössä."

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2343,6 +2343,14 @@ msgid "COURSE_ASSISTANTS_INVALID_USER_IDS"
 msgstr "Yksi tai useampi assistentin käyttäjätunnus on virheellinen"
 
 #: templates/email_user_select.html
+msgid "SELECTED_USERS"
+msgstr "Valitut käyttäjät"
+
+#: templates/email_user_select.html
+msgid "NO_USERS_ADDED_YET"
+msgstr "Käyttäjiä ei ole vielä lisätty"
+
+#: templates/email_user_select.html
 msgid "ENTER_EMAIL_TO_ADD"
 msgstr "Syötä sähköpostiosoite ja paina Enter/Lisää"
 

--- a/templates/email_user_select.html
+++ b/templates/email_user_select.html
@@ -11,7 +11,7 @@
         <ul class="list-inline mt-1 badge-list" id="{{ widget_id }}_badges">
             {% for user in selected_users %}
             <li class="list-inline-item badge-item" data-email="{{ user.user.email }}" data-user-id="{{ user.user.id }}">
-                <button class="aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary" onclick="removeUser('{{ widget_id }}', '{{ user.user.id }}')">
+                <button type="button" class="aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary" onclick="removeUser('{{ widget_id }}', '{{ user.user.id }}')">
                     {{ user.user.get_full_name }},
                     {{ user.student_id }},
                     {{ user.user.email }}

--- a/templates/email_user_select.html
+++ b/templates/email_user_select.html
@@ -1,0 +1,57 @@
+{% load i18n %}
+
+<div class="email-user-select-wrapper" 
+     id="{{ widget_id }}"
+     data-email-user-select="true"
+     data-api-url="{% if widget.attrs.search_api_url %}{{ widget.attrs.search_api_url }}{% else %}/api/v2/users/{% endif %}">
+    
+    <!-- Badge list - displays selected users -->
+    <div class="selected-users mb-2">
+        <strong>{% translate "SELECTED_USERS" %}:</strong>
+        <ul class="list-inline mt-1 badge-list" id="{{ widget_id }}_badges">
+            {% for user in selected_users %}
+            <li class="list-inline-item badge-item" data-email="{{ user.user.email }}" data-user-id="{{ user.user.id }}">
+                <button class="aplus-button--secondary aplus-button--sm btn btn-sm btn-secondary" onclick="removeUser('{{ widget_id }}', '{{ user.user.id }}')">
+                    {{ user.user.get_full_name }},
+                    {{ user.student_id }},
+                    {{ user.user.email }}
+                    <span aria-label="{% translate 'REMOVE' %}">x
+                    </span>
+                </button>
+            </li>
+            {% empty %}
+            <li class="text-muted" style="font-style: italic;">{% translate "NO_USERS_ADDED_YET" %}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    
+    <!-- Input field for adding new users -->
+    <div class="input-group">
+        <input 
+            type="text" 
+            id="{{ widget_id }}_input"
+            class="form-control rounded-0"
+            placeholder="{% translate 'ENTER_EMAIL_TO_ADD' %}"
+            aria-label="{% translate 'ENTER_EMAIL_TO_ADD' %}"
+        />
+        <button 
+            class="btn btn-outline-secondary" 
+            type="button"
+            id="{{ widget_id }}_add_btn"
+            aria-label="{% translate 'ADD_USER' %}"
+        >
+            {% translate 'ADD' %}
+        </button>
+    </div>
+    
+    <!-- Hidden field that stores the actual value (user IDs) -->
+    <input 
+        type="hidden" 
+        name="{{ widget.name }}" 
+        id="{{ widget_id }}_value"
+        value="{% for user in selected_users %}{{ user.user.id }}{% if not forloop.last %}, {% endif %}{% endfor %}"
+    />
+    
+    <!-- Error message container -->
+    <div id="{{ widget_id }}_error" class="text-danger mt-1" style="display: none;"></div>
+</div>

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -24,7 +24,7 @@ class UserViewSet(ListSerializerMixin,
 
     `GET /users/?search=email@address.com`:
         returns a list of users matching the exact email address.
-        The search parameter is required and must be a valid email.
+        The search parameter is required.
 
     `GET /users/<user_id>/`:
         returns the details of a specific user.
@@ -49,15 +49,14 @@ class UserViewSet(ListSerializerMixin,
 
     def get_queryset(self):
         """
-        Only return users when searching by exact email address.
+        Only return users in list view when searching by exact email address.
         Prevents listing all users.
         """
-        # If no search parameter, return empty queryset
-        if not self.request.query_params.get('search'):
-            return UserProfile.objects.none()
-
-        # Get the base queryset
         queryset = super().get_queryset()
+
+        # Only restrict the list endpoint
+        if getattr(self, 'action', None) == 'list' and not self.request.query_params.get('search'):
+            return queryset.none()
 
         return queryset
 

--- a/userprofile/api/views.py
+++ b/userprofile/api/views.py
@@ -17,13 +17,14 @@ class UserViewSet(ListSerializerMixin,
                   MeUserMixin,
                   viewsets.ReadOnlyModelViewSet):
     """
-    The `users` endpoint returns information about all users.
+    The `users` endpoint returns information about users.
 
     Operations
     ----------
 
-    `GET /users/`:
-        returns a list of all users.
+    `GET /users/?search=email@address.com`:
+        returns a list of users matching the exact email address.
+        The search parameter is required and must be a valid email.
 
     `GET /users/<user_id>/`:
         returns the details of a specific user.
@@ -37,10 +38,8 @@ class UserViewSet(ListSerializerMixin,
     filter_backends = (
         IsTeacherOrAdminOrSelf,
         filters.SearchFilter,
-        FieldValuesFilter,
     )
-    search_fields = ['user__first_name', 'user__last_name', 'student_id', 'user__email']
-    field_values_map = {'id': 'user_id', 'student_id': 'student_id', 'email': 'user__email'}
+    search_fields = ['=user__email']
     lookup_field = 'user_id' # UserProfile.user.id
     lookup_url_kwarg = 'user_id'
     lookup_value_regex = REGEX_INT_ME
@@ -48,8 +47,19 @@ class UserViewSet(ListSerializerMixin,
     serializer_class = UserSerializer
     queryset = UserProfile.objects.all()
 
-    # if update is required, change to normal modelviewset and
-    # change permissions
+    def get_queryset(self):
+        """
+        Only return users when searching by exact email address.
+        Prevents listing all users.
+        """
+        # If no search parameter, return empty queryset
+        if not self.request.query_params.get('search'):
+            return UserProfile.objects.none()
+
+        # Get the base queryset
+        queryset = super().get_queryset()
+
+        return queryset
 
 
 class MeDetail(APIView):


### PR DESCRIPTION
# Description

Limit visibility of users API as such that all users are no longer listed, and rework related features (adding course teachers / assistants, manually enroll users) to use the reworked API.

**Why?**

The existing users API lists users too widely compared to the use cases it's required in.

**How?**

Make the users API require an exact email address to search with in order to find users - by default, no users are listed now. Create a new widget that utilizes the reworked API, and use the widget in both teacher/assistant addition form and user enrollment form.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Playwright tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested adding and removing users via the Edit Course --> Course form, as well as enrolling students via Participants --> Enrol students.

**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [X] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Further work

The new widget will currently fail when trying to search with email addresses that match multiple accounts (for some reason there are a couple of users with both username and firstname.lastname accounts that have the same emails). It should be augmented so that in the case of multiple email matches, the user could select one of the found accounts to add.